### PR TITLE
feat: establish installable suite package and pds command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python: ["3.11", "3.12", "3.13", "3.14"]
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Configure runner-local paths
+        shell: pwsh
+        run: |
+          $coreDirectory = Join-Path $env:RUNNER_TEMP "core"
+          $distDirectory = Join-Path $env:RUNNER_TEMP "dist"
+          $ruffCache = Join-Path $env:RUNNER_TEMP "ruff-cache"
+          $mypyCache = Join-Path $env:RUNNER_TEMP "mypy-cache"
+
+          New-Item -ItemType Directory -Force -Path $coreDirectory | Out-Null
+          New-Item -ItemType Directory -Force -Path $distDirectory | Out-Null
+
+          $coreWheel = Join-Path `
+            $coreDirectory `
+            "pds_core-0.6.0-py3-none-any.whl"
+
+          "PDS_CORE_WHEEL=$coreWheel" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "PDS_DIST_DIR=$distDirectory" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "RUFF_CACHE_DIR=$ruffCache" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "MYPY_CACHE_DIR=$mypyCache" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Download official Core 0.6.0 wheel
+        shell: pwsh
+        run: |
+          Invoke-WebRequest `
+            -Uri "https://github.com/Paper-Data-Suite/pds-core/releases/download/v0.6.0/pds_core-0.6.0-py3-none-any.whl" `
+            -OutFile $env:PDS_CORE_WHEEL `
+            -ErrorAction Stop
+
+          if (-not (Test-Path -LiteralPath $env:PDS_CORE_WHEEL -PathType Leaf)) {
+            throw "Core wheel download did not create $env:PDS_CORE_WHEEL."
+          }
+
+      - name: Install Core and development package
+        shell: pwsh
+        run: |
+          python -m pip install "$env:PDS_CORE_WHEEL"
+          python -m pip install -e ".[dev]"
+          python -m pip check
+
+      - name: Test
+        shell: pwsh
+        run: >-
+          python -m pytest
+          --basetemp "${{ runner.temp }}/pytest"
+          -o cache_dir="${{ runner.temp }}/pytest-cache"
+
+      - name: Lint
+        run: python -m ruff check .
+
+      - name: Type-check
+        shell: pwsh
+        run: python -m mypy --cache-dir "$env:MYPY_CACHE_DIR"
+
+      - name: Build distributions
+        shell: pwsh
+        run: python -m build --outdir "$env:PDS_DIST_DIR"
+
+      - name: Validate distributions
+        shell: pwsh
+        run: |
+          python -m twine check "$env:PDS_DIST_DIR/*"
+
+          $wheels = @(
+            Get-ChildItem `
+              -LiteralPath $env:PDS_DIST_DIR `
+              -Filter "*.whl" `
+              -File
+          )
+
+          if ($wheels.Count -ne 1) {
+            throw "Expected exactly one suite wheel; found $($wheels.Count)."
+          }
+
+          $suiteWheel = $wheels[0].FullName
+
+          python scripts/check_package.py "$suiteWheel"
+          python scripts/smoke_test_wheel.py `
+            "$suiteWheel" `
+            "$env:PDS_CORE_WHEEL"
+
+      - name: Verify repository hygiene
+        shell: pwsh
+        run: |
+          git diff --check
+
+          $residue = git status --porcelain --untracked-files=all
+
+          if ($residue) {
+            $residue
+            throw "Validation left tracked or untracked repository residue."
+          }

--- a/README.md
+++ b/README.md
@@ -4,20 +4,21 @@ Paper Data Suite is a local-first collection of interoperable classroom tools
 for paper-compatible evidence capture, review, scoring, grading/reporting,
 collaboration, portfolio curation, and teacher-controlled support workflows.
 
-This repository is the suite-level repository. Its first implementation
-milestone is intended to establish the `paper-data-suite` shell and `pds`
-command as a bounded orchestration layer over PDS Core and installed modules.
+This repository contains the suite-level orchestration package. The installable
+distribution is `paper-data-suite`, the import package is `paper_data_suite`,
+and the primary command is `pds`.
 
 ## Current status
 
-The suite shell is in initial pre-release development.
+The suite shell is in pre-release development at `0.1.0.dev0`.
 
-At this point, this repository contains planning and architecture documentation
-only. It is **not yet an installable Python package**, does not yet expose a
-`pds` command, and has no supported release.
+The package foundation is installable, but there is **no supported public
+v0.1.0 release yet**. The current `pds` command intentionally exposes only
+minimal help and version behavior. Operational suite commands are added by later
+v0.1.0 issues.
 
-The active v0.1.0 milestone will build the first runtime implementation within
-the ownership and integration boundaries established for the suite shell.
+The package requires Python 3.11 or newer and a compatible PDS Core 0.6.x
+installation.
 
 ## Architecture direction
 
@@ -33,14 +34,10 @@ directly mutating owner state.
 The normative contract is
 [`docs/architecture/suite-shell-boundaries.md`](docs/architecture/suite-shell-boundaries.md).
 
-## Development bootstrap
+## Development setup
 
-The initial development checkout uses Python 3.11 as the conservative baseline
-shared by the current PDS module releases. The installable package and its
-formal Python compatibility metadata will be established separately by the
-package-foundation issue.
-
-On Windows PowerShell:
+Create and activate a Python 3.11-or-newer virtual environment. On Windows
+PowerShell:
 
 ```powershell
 py -3.11 -m venv .venv
@@ -48,8 +45,56 @@ py -3.11 -m venv .venv
 python -m pip install --upgrade pip
 ```
 
-There is intentionally no `pip install -e .` step yet because this repository
-does not contain package metadata.
+Install a compatible official PDS Core 0.6.x wheel into the environment first.
+The exact suite release matrix and verified bootstrap workflow are defined by
+later v0.1.0 issues; do not infer exact suite qualification from the broad
+package dependency range alone.
+
+After Core is installed:
+
+```powershell
+python -m pip install -e ".[dev]"
+```
+
+The current foundation commands are:
+
+```powershell
+pds
+pds --help
+pds --version
+
+python -m paper_data_suite
+python -m paper_data_suite --help
+python -m paper_data_suite --version
+```
+
+These commands do not create or select a workspace, discover sibling
+applications, or perform classroom-data workflows.
+
+## Development validation
+
+Run:
+
+```powershell
+python -m pytest
+python -m ruff check .
+python -m mypy
+python -m pip check
+
+Remove-Item .\dist -Recurse -Force -ErrorAction SilentlyContinue
+python -m build
+python -m twine check .\dist\*
+```
+
+Then validate and smoke-test the built wheel using a compatible Core wheel:
+
+```powershell
+python .\scripts\check_package.py <suite-wheel>
+python .\scripts\smoke_test_wheel.py <suite-wheel> <core-wheel>
+```
+
+The wheel smoke test creates an isolated environment and proves that the suite
+foundation works beside Core without requiring sibling PDS applications.
 
 Do not place a real classroom PDS workspace inside this repository.
 

--- a/paper_data_suite/__init__.py
+++ b/paper_data_suite/__init__.py
@@ -1,0 +1,5 @@
+"""Public package surface for the Paper Data Suite shell."""
+
+from paper_data_suite._version import __version__
+
+__all__ = ("__version__",)

--- a/paper_data_suite/__main__.py
+++ b/paper_data_suite/__main__.py
@@ -1,0 +1,6 @@
+"""Execute Paper Data Suite with ``python -m paper_data_suite``."""
+
+from paper_data_suite.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/paper_data_suite/_version.py
+++ b/paper_data_suite/_version.py
@@ -1,0 +1,5 @@
+"""Authoritative Paper Data Suite shell version."""
+
+from typing import Final
+
+__version__: Final[str] = "0.1.0.dev0"

--- a/paper_data_suite/cli.py
+++ b/paper_data_suite/cli.py
@@ -1,0 +1,33 @@
+"""Minimal command-line foundation for Paper Data Suite."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+from paper_data_suite._version import __version__
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the package-foundation command-line parser."""
+    parser = argparse.ArgumentParser(
+        prog="pds",
+        description=(
+            "Paper Data Suite suite shell. Operational commands are added by "
+            "later v0.1.0 development issues."
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the minimal Paper Data Suite command-line interface."""
+    parser = build_parser()
+    parser.parse_args(argv)
+    parser.print_help()
+    return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,75 @@
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "paper-data-suite"
+dynamic = ["version"]
+description = "Suite-level orchestration and teacher convenience for Paper Data Suite."
+readme = "README.md"
+requires-python = ">=3.11"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [
+    { name = "Stephen Severino" }
+]
+dependencies = [
+    "pds-core>=0.6,<0.7",
+]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Typing :: Typed",
+]
+
+[project.optional-dependencies]
+dev = [
+    "build",
+    "mypy",
+    "packaging",
+    "pytest",
+    "ruff",
+    "twine",
+]
+
+[project.scripts]
+pds = "paper_data_suite.cli:main"
+
+[project.urls]
+Documentation = "https://github.com/Paper-Data-Suite/pds-paper-data-suite/tree/main/docs"
+Repository = "https://github.com/Paper-Data-Suite/pds-paper-data-suite"
+
+[tool.setuptools.dynamic]
+version = { attr = "paper_data_suite._version.__version__" }
+
+[tool.setuptools.packages.find]
+include = ["paper_data_suite"]
+namespaces = false
+
+[tool.setuptools.package-data]
+paper_data_suite = ["py.typed"]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+explicit_package_bases = true
+files = ["paper_data_suite", "scripts"]
+
+[[tool.mypy.overrides]]
+module = ["pds_core", "pds_core.*"]
+follow_untyped_imports = true

--- a/scripts/check_package.py
+++ b/scripts/check_package.py
@@ -1,0 +1,208 @@
+"""Validate the built Paper Data Suite wheel foundation."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import zipfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import cast
+
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
+
+EXPECTED_DISTRIBUTION = "paper-data-suite"
+EXPECTED_VERSION = "0.1.0.dev0"
+EXPECTED_REQUIRES_PYTHON = ">=3.11"
+EXPECTED_CORE_RANGE = SpecifierSet(">=0.6,<0.7")
+EXPECTED_CONSOLE_TARGET = "paper_data_suite.cli:main"
+
+REQUIRED_PACKAGE_FILES = frozenset(
+    {
+        "paper_data_suite/__init__.py",
+        "paper_data_suite/__main__.py",
+        "paper_data_suite/_version.py",
+        "paper_data_suite/cli.py",
+        "paper_data_suite/py.typed",
+    }
+)
+FORBIDDEN_WHEEL_PREFIXES = (
+    "tests/",
+    "scripts/",
+    "docs/",
+    ".github/",
+)
+FORBIDDEN_PDS_DISTRIBUTIONS = frozenset(
+    {
+        "scoreform",
+        "quillan",
+        "pds-concord",
+        "pds-meridian",
+        "pds-vitrine",
+        "pds-portia",
+    }
+)
+
+
+class PackageValidationError(RuntimeError):
+    """Raised when a built wheel violates the package foundation contract."""
+
+
+def _single_member(names: tuple[str, ...], suffix: str) -> str:
+    matches = tuple(name for name in names if name.endswith(suffix))
+    if len(matches) != 1:
+        raise PackageValidationError(
+            f"Expected exactly one wheel member ending with {suffix!r}; "
+            f"found {len(matches)}."
+        )
+    return matches[0]
+
+
+def _parse_metadata(text: str) -> dict[str, list[str]]:
+    fields: dict[str, list[str]] = {}
+    current_key: str | None = None
+
+    for raw_line in text.splitlines():
+        if raw_line.startswith((" ", "\t")) and current_key is not None:
+            fields[current_key][-1] += raw_line.strip()
+            continue
+        if ":" not in raw_line:
+            current_key = None
+            continue
+
+        key, value = raw_line.split(":", 1)
+        current_key = key
+        fields.setdefault(key, []).append(value.strip())
+
+    return fields
+
+
+def _one_field(fields: dict[str, list[str]], key: str) -> str:
+    values = fields.get(key, [])
+    if len(values) != 1:
+        raise PackageValidationError(
+            f"Expected exactly one {key!r} metadata field; found {len(values)}."
+        )
+    return values[0]
+
+
+def _validate_runtime_requirements(fields: dict[str, list[str]]) -> None:
+    requirements = tuple(
+        Requirement(value) for value in fields.get("Requires-Dist", [])
+    )
+
+    core_requirements = tuple(
+        requirement
+        for requirement in requirements
+        if canonicalize_name(requirement.name) == "pds-core"
+        and requirement.marker is None
+    )
+    if len(core_requirements) != 1:
+        raise PackageValidationError(
+            "Expected exactly one unconditional pds-core runtime requirement."
+        )
+
+    core_requirement = core_requirements[0]
+    if core_requirement.specifier != EXPECTED_CORE_RANGE:
+        raise PackageValidationError(
+            "Unexpected Core runtime range: "
+            f"{core_requirement.specifier!s}; expected {EXPECTED_CORE_RANGE!s}."
+        )
+
+    forbidden = sorted(
+        requirement.name
+        for requirement in requirements
+        if canonicalize_name(requirement.name) in FORBIDDEN_PDS_DISTRIBUTIONS
+    )
+    if forbidden:
+        raise PackageValidationError(
+            "Sibling PDS distributions must not be dependencies: "
+            + ", ".join(forbidden)
+        )
+
+
+def _validate_entry_points(text: str) -> None:
+    parser = configparser.ConfigParser()
+    parser.read_string(text)
+
+    if not parser.has_section("console_scripts"):
+        raise PackageValidationError("Wheel has no console_scripts entry points.")
+
+    scripts = dict(parser.items("console_scripts"))
+    if scripts != {"pds": EXPECTED_CONSOLE_TARGET}:
+        raise PackageValidationError(
+            f"Unexpected console scripts: {scripts!r}."
+        )
+
+
+def validate_wheel(path: Path) -> None:
+    """Validate one built wheel."""
+    if not path.is_file() or path.suffix != ".whl":
+        raise PackageValidationError(f"Wheel does not exist: {path}")
+
+    with zipfile.ZipFile(path) as wheel:
+        names = tuple(wheel.namelist())
+        name_set = frozenset(names)
+
+        missing = sorted(REQUIRED_PACKAGE_FILES - name_set)
+        if missing:
+            raise PackageValidationError(
+                "Wheel is missing required package files: " + ", ".join(missing)
+            )
+
+        forbidden = sorted(
+            name
+            for name in names
+            if name.startswith(FORBIDDEN_WHEEL_PREFIXES)
+            or "__pycache__/" in name
+            or name.endswith((".pyc", ".pyo"))
+            or ".egg-info/" in name
+        )
+        if forbidden:
+            raise PackageValidationError(
+                "Repository-only artifacts leaked into wheel: "
+                + ", ".join(forbidden)
+            )
+
+        metadata_member = _single_member(names, ".dist-info/METADATA")
+        fields = _parse_metadata(
+            wheel.read(metadata_member).decode("utf-8")
+        )
+
+        if canonicalize_name(_one_field(fields, "Name")) != EXPECTED_DISTRIBUTION:
+            raise PackageValidationError("Unexpected distribution name.")
+        if _one_field(fields, "Version") != EXPECTED_VERSION:
+            raise PackageValidationError("Unexpected distribution version.")
+        if _one_field(fields, "Requires-Python") != EXPECTED_REQUIRES_PYTHON:
+            raise PackageValidationError("Unexpected Requires-Python value.")
+
+        _validate_runtime_requirements(fields)
+
+        entry_points_member = _single_member(
+            names, ".dist-info/entry_points.txt"
+        )
+        _validate_entry_points(
+            wheel.read(entry_points_member).decode("utf-8")
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the wheel-validation parser."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("wheel")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Validate the requested wheel and return a process status."""
+    args = build_parser().parse_args(argv)
+    wheel = Path(cast(str, args.wheel)).resolve()
+    validate_wheel(wheel)
+    print(f"Validated package wheel: {wheel}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_test_wheel.py
+++ b/scripts/smoke_test_wheel.py
@@ -1,0 +1,315 @@
+"""Smoke-test the built Paper Data Suite wheel in a clean virtual environment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+import venv
+import zipfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import cast
+
+from packaging.utils import canonicalize_name
+
+FORBIDDEN_SIBLING_DISTRIBUTIONS = frozenset(
+    {
+        "scoreform",
+        "quillan",
+        "pds-concord",
+        "pds-meridian",
+        "pds-vitrine",
+        "pds-portia",
+    }
+)
+
+
+class SmokeTestError(RuntimeError):
+    """Raised when the clean-wheel smoke test fails."""
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=dict(env),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SmokeTestError(
+            "Command failed "
+            f"({result.returncode}): {' '.join(command)}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _wheel_version(path: Path) -> str:
+    with zipfile.ZipFile(path) as wheel:
+        metadata_members = tuple(
+            name
+            for name in wheel.namelist()
+            if name.endswith(".dist-info/METADATA")
+        )
+        if len(metadata_members) != 1:
+            raise SmokeTestError("Suite wheel has ambiguous METADATA.")
+        text = wheel.read(metadata_members[0]).decode("utf-8")
+
+    for line in text.splitlines():
+        if line.startswith("Version: "):
+            return line.removeprefix("Version: ").strip()
+    raise SmokeTestError("Suite wheel METADATA has no Version field.")
+
+
+def _venv_python(environment: Path) -> Path:
+    if os.name == "nt":
+        return environment / "Scripts" / "python.exe"
+    return environment / "bin" / "python"
+
+
+def _scripts_directory(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> Path:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            "import sysconfig; print(sysconfig.get_path('scripts'))",
+        ],
+        cwd=cwd,
+        env=env,
+    )
+    return Path(result.stdout.strip())
+
+
+def _assert_clean_directory(path: Path) -> None:
+    contents = tuple(path.iterdir())
+    if contents:
+        names = ", ".join(item.name for item in contents)
+        raise SmokeTestError(
+            f"Foundation command created working-directory artifacts: {names}"
+        )
+
+
+def _assert_no_sibling_distributions(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> None:
+    code = (
+        "import importlib.metadata as m, json; "
+        "print(json.dumps(sorted("
+        "d.metadata['Name'] for d in m.distributions() "
+        "if d.metadata.get('Name'))))"
+    )
+    result = _run([str(python), "-c", code], cwd=cwd, env=env)
+    installed = {
+        canonicalize_name(name)
+        for name in cast(list[str], json.loads(result.stdout))
+    }
+    forbidden = sorted(installed & FORBIDDEN_SIBLING_DISTRIBUTIONS)
+    if forbidden:
+        raise SmokeTestError(
+            "Clean smoke environment contains sibling PDS distributions: "
+            + ", ".join(forbidden)
+        )
+
+
+def _assert_import_boundary(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    expected_version: str,
+) -> None:
+    code = """
+import json
+import sys
+import paper_data_suite
+
+tracked = [
+    "pds_core",
+    "scoreform",
+    "quillan",
+    "concord",
+    "meridian",
+    "vitrine",
+]
+print(json.dumps({
+    "version": paper_data_suite.__version__,
+    "loaded": {name: name in sys.modules for name in tracked},
+}))
+""".strip()
+    result = _run([str(python), "-c", code], cwd=cwd, env=env)
+    payload = cast(dict[str, object], json.loads(result.stdout))
+    if payload.get("version") != expected_version:
+        raise SmokeTestError("Installed package version does not match wheel.")
+
+    loaded = cast(dict[str, bool], payload.get("loaded"))
+    unexpectedly_loaded = sorted(name for name, value in loaded.items() if value)
+    if unexpectedly_loaded:
+        raise SmokeTestError(
+            "Package import crossed owner boundaries: "
+            + ", ".join(unexpectedly_loaded)
+        )
+    _assert_clean_directory(cwd)
+
+
+def smoke_test(suite_wheel: Path, core_wheel: Path) -> None:
+    """Install and exercise the suite wheel beside only Core."""
+    if not suite_wheel.is_file():
+        raise SmokeTestError(f"Suite wheel does not exist: {suite_wheel}")
+    if not core_wheel.is_file():
+        raise SmokeTestError(f"Core wheel does not exist: {core_wheel}")
+
+    expected_version = _wheel_version(suite_wheel)
+
+    with tempfile.TemporaryDirectory(prefix="pds-suite-smoke-") as temporary:
+        temp_root = Path(temporary)
+        environment = temp_root / "venv"
+        run_directory = temp_root / "run"
+        run_directory.mkdir()
+
+        venv.EnvBuilder(with_pip=True).create(environment)
+        python = _venv_python(environment)
+
+        command_env = dict(os.environ)
+        command_env["PYTHONDONTWRITEBYTECODE"] = "1"
+        command_env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+        command_env.pop("PYTHONPATH", None)
+
+        _run(
+            [
+                str(python),
+                "-m",
+                "pip",
+                "install",
+                "--no-deps",
+                str(core_wheel),
+            ],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _run(
+            [
+                str(python),
+                "-m",
+                "pip",
+                "install",
+                "--no-deps",
+                str(suite_wheel),
+            ],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _run(
+            [str(python), "-m", "pip", "check"],
+            cwd=run_directory,
+            env=command_env,
+        )
+
+        _assert_no_sibling_distributions(
+            python, cwd=run_directory, env=command_env
+        )
+        _assert_import_boundary(
+            python,
+            cwd=run_directory,
+            env=command_env,
+            expected_version=expected_version,
+        )
+
+        module_version = _run(
+            [
+                str(python),
+                "-m",
+                "paper_data_suite",
+                "--version",
+            ],
+            cwd=run_directory,
+            env=command_env,
+        )
+        if module_version.stdout.strip() != f"pds {expected_version}":
+            raise SmokeTestError("Unexpected module --version output.")
+        _assert_clean_directory(run_directory)
+
+        module_help = _run(
+            [str(python), "-m", "paper_data_suite", "--help"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        if "usage: pds" not in module_help.stdout:
+            raise SmokeTestError("Module help does not identify pds.")
+        _assert_clean_directory(run_directory)
+
+        scripts = _scripts_directory(
+            python, cwd=run_directory, env=command_env
+        )
+        launcher = scripts / ("pds.exe" if os.name == "nt" else "pds")
+        if not launcher.is_file():
+            raise SmokeTestError(
+                f"Installed pds launcher does not exist: {launcher}"
+            )
+
+        console_version = _run(
+            [str(launcher), "--version"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        if console_version.stdout.strip() != f"pds {expected_version}":
+            raise SmokeTestError("Unexpected installed pds --version output.")
+        _assert_clean_directory(run_directory)
+
+        console_help = _run(
+            [str(launcher), "--help"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        if "usage: pds" not in console_help.stdout:
+            raise SmokeTestError("Installed pds help does not identify pds.")
+        _assert_clean_directory(run_directory)
+
+        console_bare = _run(
+            [str(launcher)],
+            cwd=run_directory,
+            env=command_env,
+        )
+        if "usage: pds" not in console_bare.stdout:
+            raise SmokeTestError("Bare installed pds did not print help.")
+        _assert_clean_directory(run_directory)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the smoke-test parser."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("suite_wheel")
+    parser.add_argument("core_wheel")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the clean-wheel smoke test."""
+    args = build_parser().parse_args(argv)
+    suite_wheel = Path(cast(str, args.suite_wheel)).resolve()
+    core_wheel = Path(cast(str, args.core_wheel)).resolve()
+    smoke_test(suite_wheel, core_wheel)
+    print(f"Smoke-tested suite wheel: {suite_wheel}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+
+import pytest
+
+from paper_data_suite import __version__
+from paper_data_suite.cli import main
+
+
+def _console_script_path() -> Path:
+    script_name = "pds.exe" if os.name == "nt" else "pds"
+    return Path(sysconfig.get_path("scripts")) / script_name
+
+
+def test_main_without_arguments_prints_help(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(()) == 0
+    output = capsys.readouterr().out
+    assert "usage: pds" in output
+    assert "Paper Data Suite" in output
+    assert "Operational commands" in output
+
+
+def test_main_help_returns_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as raised:
+        main(("--help",))
+    assert raised.value.code == 0
+    assert "usage: pds" in capsys.readouterr().out
+
+
+def test_main_version_returns_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as raised:
+        main(("--version",))
+    assert raised.value.code == 0
+    assert capsys.readouterr().out.strip() == f"pds {__version__}"
+
+
+def test_invalid_argument_returns_usage_failure() -> None:
+    with pytest.raises(SystemExit) as raised:
+        main(("--unknown",))
+    assert raised.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [(), ("--help",), ("--version",)],
+)
+def test_python_module_cli_is_read_only(
+    tmp_path: Path,
+    arguments: tuple[str, ...],
+) -> None:
+    before = tuple(tmp_path.iterdir())
+    result = subprocess.run(
+        [sys.executable, "-m", "paper_data_suite", *arguments],
+        cwd=tmp_path,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert tuple(tmp_path.iterdir()) == before
+    assert "usage: pds" in result.stdout or result.stdout.strip() == (
+        f"pds {__version__}"
+    )
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [(), ("--help",), ("--version",)],
+)
+def test_installed_console_script_is_read_only(
+    tmp_path: Path,
+    arguments: tuple[str, ...],
+) -> None:
+    executable = _console_script_path()
+    assert executable.is_file()
+    before = tuple(tmp_path.iterdir())
+    result = subprocess.run(
+        [str(executable), *arguments],
+        cwd=tmp_path,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert tuple(tmp_path.iterdir()) == before
+    assert "usage: pds" in result.stdout or result.stdout.strip() == (
+        f"pds {__version__}"
+    )

--- a/tests/test_import_safety.py
+++ b/tests/test_import_safety.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+TRACKED_MODULES = (
+    "pds_core",
+    "scoreform",
+    "quillan",
+    "concord",
+    "meridian",
+    "vitrine",
+)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["paper_data_suite", "paper_data_suite.cli"],
+)
+def test_import_is_side_effect_free(
+    tmp_path: Path,
+    module_name: str,
+) -> None:
+    code = f"""
+import importlib
+import json
+import sys
+
+importlib.import_module({module_name!r})
+tracked = {TRACKED_MODULES!r}
+print(json.dumps({{name: name in sys.modules for name in tracked}}))
+""".strip()
+
+    before = tuple(tmp_path.iterdir())
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=tmp_path,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    assert tuple(tmp_path.iterdir()) == before
+
+    loaded = cast(dict[str, bool], json.loads(result.stdout))
+    assert loaded == {name: False for name in TRACKED_MODULES}

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib.metadata
+import re
+from pathlib import Path
+
+from paper_data_suite import __version__
+
+EXPECTED_VERSION = "0.1.0.dev0"
+
+
+def _repository_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def test_public_version_is_development_version() -> None:
+    assert __version__ == EXPECTED_VERSION
+
+
+def test_installed_distribution_version_matches_package() -> None:
+    assert importlib.metadata.version("paper-data-suite") == __version__
+
+
+def test_pyproject_uses_package_version_as_dynamic_source() -> None:
+    pyproject = (_repository_root() / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    assert 'dynamic = ["version"]' in pyproject
+    assert (
+        'version = { attr = "paper_data_suite._version.__version__" }'
+        in pyproject
+    )
+
+
+def test_production_version_literal_has_one_authoritative_source() -> None:
+    package_root = _repository_root() / "paper_data_suite"
+    matches: list[Path] = []
+
+    for path in package_root.glob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        if re.search(r'["\']0\.1\.0\.dev0["\']', text):
+            matches.append(path)
+
+    assert matches == [package_root / "_version.py"]


### PR DESCRIPTION
## Summary

Establish the first installable Paper Data Suite shell foundation.

This PR creates the `paper-data-suite` Python distribution, the `paper_data_suite` import package, and the `pds` console command while preserving the suite-shell ownership boundaries established in #2.

The implementation is intentionally minimal: it provides package identity, versioning, strict typing, help/version CLI behavior, package/import safety, built-artifact validation, isolated wheel smoke testing, and CI. It does not implement workspace, module discovery, doctor, compatibility-manifest, backup, or other later v0.1.0 workflows.

Closes #3.

## Package identity

This PR establishes:

```text
Repository:          pds-paper-data-suite
Distribution:        paper-data-suite
Import package:      paper_data_suite
Console command:     pds
Development version: 0.1.0.dev0
Python requirement:  >=3.11
```

The base runtime dependency is:

```text
pds-core>=0.6,<0.7
```

ScoreForm, Quillan, Concord, Meridian, Vitrine, and Portia remain separately installed components and are not hard dependencies of the suite shell.

## Changes

### Package foundation

Add:

```text
pyproject.toml
paper_data_suite/__init__.py
paper_data_suite/__main__.py
paper_data_suite/_version.py
paper_data_suite/cli.py
paper_data_suite/py.typed
```

The package:

- uses setuptools;
- declares Python `>=3.11`;
- is marked as typed;
- uses strict Mypy;
- uses Ruff and pytest;
- exposes `pds` through `[project.scripts]`;
- keeps `_version.py` as the authoritative version source;
- exposes `paper_data_suite.__version__`;
- remains side-effect free at import time.

### Minimal CLI

The current foundation supports:

```text
pds
pds --help
pds --version

python -m paper_data_suite
python -m paper_data_suite --help
python -m paper_data_suite --version
```

Bare invocation prints help and exits successfully.

`--version` reports:

```text
pds 0.1.0.dev0
```

Unknown arguments use normal CLI usage-error behavior.

The CLI does not:

- resolve or create a workspace;
- read classroom records;
- discover sibling applications;
- import sibling application packages;
- write configuration;
- create files;
- launch Core or another module menu.

### Import-safety and CLI tests

Add focused tests covering:

- package version identity;
- installed distribution metadata;
- authoritative version-source consistency;
- bare CLI behavior;
- `--help`;
- `--version`;
- unknown arguments;
- `python -m paper_data_suite`;
- installed `pds` launcher behavior;
- read-only invocation from unrelated temporary directories;
- package and CLI import side effects;
- absence of implicit Core/sibling imports.

### Built-artifact validation

Add:

```text
scripts/check_package.py
scripts/smoke_test_wheel.py
```

`check_package.py` validates the built wheel rather than trusting the editable checkout.

It verifies:

- distribution name;
- version;
- `Requires-Python`;
- Core dependency range;
- absence of sibling PDS dependencies;
- `pds` console entry point;
- required package files;
- `py.typed`;
- absence of repository-only residue.

`smoke_test_wheel.py` creates a clean virtual environment, installs only:

```text
pds-core
paper-data-suite
```

and then validates the installed package from outside the source checkout.

The smoke test verifies:

```text
pip check
import paper_data_suite
python -m paper_data_suite --version
python -m paper_data_suite --help
pds
pds --help
pds --version
```

It also verifies that ScoreForm, Quillan, Concord, Meridian, Vitrine, and Portia are not present as hidden dependencies.

### CI

Add `.github/workflows/ci.yml`.

The workflow runs on:

```text
pull requests
pushes to main
```

with read-only repository permissions.

The matrix covers:

```text
Windows
Linux

Python 3.11
Python 3.12
Python 3.13
Python 3.14
```

Each job validates:

- official Core 0.6.0 wheel installation;
- development installation;
- `pip check`;
- pytest;
- Ruff;
- strict Mypy;
- sdist/wheel build;
- Twine validation;
- built-wheel package inspection;
- isolated installed-wheel smoke testing;
- repository hygiene.

### README

Update the README to reflect that the repository is now an installable development package.

It documents:

- package/distribution/command identity;
- development version;
- Python requirement;
- Core dependency;
- development setup;
- current minimal CLI behavior;
- validation commands;
- the lack of a supported v0.1.0 release;
- the existing architecture and student-data safety boundaries.

## Architecture preserved

This PR does not register the suite shell under:

```text
paper_data_suite.modules
paper_data_suite.publication_producers
```

The shell remains neither a PDS2 routing module nor a publication producer.

It does not introduce a generic application-provider contract.

It does not add sibling-module imports or dependencies.

It does not duplicate Core workspace or canonical-record behavior.

Importing:

```python
import paper_data_suite
```

remains inert apart from exposing package identity/version.

## Local validation

Validated on Windows with Python 3.11 and the official Core 0.6.0 wheel.

Source validation:

```text
16 passed
Ruff: pass
Mypy strict: pass
pip check: pass
git diff --check: pass
```

Built-artifact validation:

```text
python -m build: pass
twine check wheel: pass
twine check sdist: pass
check_package.py: pass
smoke_test_wheel.py: pass
```

Built artifacts:

```text
paper_data_suite-0.1.0.dev0.tar.gz
paper_data_suite-0.1.0.dev0-py3-none-any.whl
```

Manual CLI verification:

```text
pds
pds --help
pds --version
python -m paper_data_suite
python -m paper_data_suite --help
python -m paper_data_suite --version
```

All produced the expected minimal foundation behavior.

## Explicit non-goals

This PR does not implement:

- compatibility-manifest semantics;
- exact supported component combinations;
- verified bootstrap/update planning;
- `pds doctor`;
- sibling-component discovery;
- application launching;
- workspace selection or creation;
- class/roster/standards/Academic Period setup;
- backup or restore;
- suite settings;
- installed-suite acceptance;
- mixed-module intake;
- grouping workflows;
- GUI/web UI;
- telemetry;
- cloud sync;
- release publication;
- final version `0.1.0`.

Those remain assigned to later v0.1.0 issues.

## Result

This PR establishes the package and CLI substrate required by the rest of the v0.1.0 suite-shell milestone.

Later issues can now add real `pds` functionality without revisiting package identity, versioning, typing, CLI entry points, baseline tests, built-wheel validation, or CI structure.