### PR TITLE
feat: define release compatibility manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
           --basetemp "${{ runner.temp }}/pytest"
           -o cache_dir="${{ runner.temp }}/pytest-cache"
 
+      - name: Validate compatibility manifest
+        run: python scripts/validate_compatibility_manifest.py
+
       - name: Lint
         run: python -m ruff check .
 
@@ -124,4 +127,69 @@ jobs:
           if ($residue) {
             $residue
             throw "Validation left tracked or untracked repository residue."
+          }
+
+  release-artifacts:
+    runs-on: ubuntu-latest
+
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Configure release-audit directory
+        shell: pwsh
+        run: |
+          $artifactDirectory = Join-Path $env:RUNNER_TEMP "compatibility-artifacts"
+          New-Item -ItemType Directory -Force -Path $artifactDirectory | Out-Null
+          "PDS_COMPATIBILITY_ARTIFACT_DIR=$artifactDirectory" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Download exact declared release wheels
+        shell: python
+        run: |
+          import json
+          import os
+          from pathlib import Path
+          from urllib.request import urlretrieve
+
+          manifest_path = (
+              Path("paper_data_suite")
+              / "data"
+              / "release_compatibility_v1.json"
+          )
+          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          destination = Path(os.environ["PDS_COMPATIBILITY_ARTIFACT_DIR"])
+
+          for component in manifest["components"]:
+              release = component["release"]
+              url = (
+                  f"https://github.com/{component['repository']}"
+                  f"/releases/download/{release['tag']}/{release['wheel']}"
+              )
+              urlretrieve(url, destination / release["wheel"])
+
+      - name: Authenticate declared release wheels
+        shell: pwsh
+        run: |
+          python scripts/validate_compatibility_manifest.py
+          python scripts/verify_compatibility_artifacts.py `
+            --artifact-dir "$env:PDS_COMPATIBILITY_ARTIFACT_DIR"
+
+      - name: Verify release-audit repository hygiene
+        shell: pwsh
+        run: |
+          git diff --check
+
+          $residue = git status --porcelain --untracked-files=all
+
+          if ($residue) {
+            $residue
+            throw "Release-artifact audit left repository residue."
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,9 @@ jobs:
               )
               urlretrieve(url, destination / release["wheel"])
 
+      - name: Install suite package for audit tooling
+        run: python -m pip install --no-deps -e .
+
       - name: Authenticate declared release wheels
         shell: pwsh
         run: |

--- a/README.md
+++ b/README.md
@@ -17,8 +17,31 @@ v0.1.0 release yet**. The current `pds` command intentionally exposes only
 minimal help and version behavior. Operational suite commands are added by later
 v0.1.0 issues.
 
-The package requires Python 3.11 or newer and a compatible PDS Core 0.6.x
-installation.
+The package metadata requires Python 3.11 or newer and
+`pds-core>=0.6,<0.7`. Those broad package requirements do **not** by themselves
+qualify every matching interpreter or component release for the suite.
+
+The package now carries a versioned machine-readable compatibility declaration.
+For the current development build, suite qualification is explicit and
+fail-closed:
+
+- suite-qualified Python: `>=3.11,<3.15`;
+- tested Python minors: 3.11, 3.12, 3.13, and 3.14;
+- required Core: `pds-core==0.6.0`;
+- optional qualified applications:
+  - `pds-concord==0.2.0`;
+  - `quillan==0.9.0`;
+  - `scoreform==0.10.0`;
+  - `pds-vitrine==0.2.0`.
+
+Each qualified component row binds to one exact official GitHub Release wheel
+and SHA-256 digest. An installed version absent from the active declaration is
+not silently treated as compatible. Meridian is not currently qualified by this
+development manifest because its audited source identity remains a development
+version, and Portia does not yet have an executable application release.
+
+The normative manifest contract is
+[`docs/architecture/release-compatibility-manifest.md`](docs/architecture/release-compatibility-manifest.md).
 
 ## Architecture direction
 
@@ -31,7 +54,7 @@ canonical records, business rules, and teacher workflows. The shell must use
 public Core services and supported component boundaries rather than copying or
 directly mutating owner state.
 
-The normative contract is
+The normative ownership and integration contract is
 [`docs/architecture/suite-shell-boundaries.md`](docs/architecture/suite-shell-boundaries.md).
 
 ## Development setup
@@ -46,9 +69,9 @@ python -m pip install --upgrade pip
 ```
 
 Install a compatible official PDS Core 0.6.x wheel into the environment first.
-The exact suite release matrix and verified bootstrap workflow are defined by
-later v0.1.0 issues; do not infer exact suite qualification from the broad
-package dependency range alone.
+For the current suite development manifest, the exact qualified Core release is
+0.6.0. Do not infer exact suite qualification from the broad package dependency
+range alone.
 
 After Core is installed:
 
@@ -80,21 +103,31 @@ python -m pytest
 python -m ruff check .
 python -m mypy
 python -m pip check
+python .\scripts\validate_compatibility_manifest.py
 
 Remove-Item .\dist -Recurse -Force -ErrorAction SilentlyContinue
 python -m build
 python -m twine check .\dist\*
 ```
 
-Then validate and smoke-test the built wheel using a compatible Core wheel:
+Then validate and smoke-test the built wheel using the exact Core 0.6.0 wheel:
 
 ```powershell
 python .\scripts\check_package.py <suite-wheel>
 python .\scripts\smoke_test_wheel.py <suite-wheel> <core-wheel>
 ```
 
-The wheel smoke test creates an isolated environment and proves that the suite
-foundation works beside Core without requiring sibling PDS applications.
+To authenticate all exact component wheels declared by the manifest:
+
+```powershell
+python .\scripts\verify_compatibility_artifacts.py `
+  --artifact-dir <directory-containing-declared-wheels>
+```
+
+The built-wheel smoke test creates an isolated environment and proves that the
+bundled compatibility resource loads beside Core without requiring or importing
+sibling PDS applications. The artifact verifier inspects release wheels directly;
+it does not install or import them.
 
 Do not place a real classroom PDS workspace inside this repository.
 
@@ -102,6 +135,8 @@ Do not place a real classroom PDS workspace inside this repository.
 
 - [`docs/architecture/suite-shell-boundaries.md`](docs/architecture/suite-shell-boundaries.md)
   — normative suite-shell ownership and integration contract.
+- [`docs/architecture/release-compatibility-manifest.md`](docs/architecture/release-compatibility-manifest.md)
+  — normative machine-readable suite release-qualification contract.
 - [`docs/development-plan.md`](docs/development-plan.md) — suite-wide
   pilot-readiness and development program.
 - [`docs/pds-viz-identity.md`](docs/pds-viz-identity.md) — shared Paper Data

--- a/docs/architecture/release-compatibility-manifest.md
+++ b/docs/architecture/release-compatibility-manifest.md
@@ -1,0 +1,438 @@
+# Release Compatibility Manifest
+
+## 1. Purpose and authority
+
+The Paper Data Suite release compatibility manifest is the suite shell's
+machine-readable declaration of the exact PDS-owned release composition
+qualified by one suite version.
+
+The v1 resource is:
+
+```text
+paper_data_suite/data/release_compatibility_v1.json
+```
+
+The normative ownership contract remains
+[`suite-shell-boundaries.md`](suite-shell-boundaries.md). This document refines
+that contract for release qualification; it does not transfer authority over
+Core or module-owned records, business rules, or workflows.
+
+The central distinction is:
+
+```text
+package metadata compatibility
+!=
+suite-qualified release composition
+```
+
+A dependency such as:
+
+```text
+pds-core>=0.6,<0.7
+```
+
+describes package-level resolver compatibility. It does not prove that every
+Core version in that range has been tested and accepted for a particular suite
+release.
+
+The manifest records the exact composition the suite has qualified.
+
+## 2. Contract identity
+
+The v1 manifest identifies itself with:
+
+```text
+record_type = paper_data_suite_release_compatibility_manifest
+contract_version = 1
+```
+
+The contract version is independent of the suite package version.
+
+Changing the supported component composition does not by itself require a
+manifest contract-version change. A breaking change to the structure or meaning
+of the manifest does.
+
+The active manifest is bundled inside the `paper-data-suite` wheel and loaded
+through installed-package resources. Loading does not depend on the current
+working directory or a source checkout.
+
+## 3. Suite identity
+
+The `suite` object identifies the distribution that owns the declaration:
+
+```text
+distribution
+version
+release_status
+```
+
+For the current development package:
+
+```text
+distribution = paper-data-suite
+version = 0.1.0.dev0
+release_status = development
+```
+
+The manifest version must equal the package's authoritative
+`paper_data_suite.__version__`.
+
+The development manifest must not claim a final `0.1.0` release before the
+release issue actually changes the package version and release status.
+
+## 4. Python qualification
+
+The `python` object records:
+
+```text
+specifier
+tested_minors
+```
+
+The current suite qualification is:
+
+```text
+specifier = >=3.11,<3.15
+tested_minors = 3.11, 3.12, 3.13, 3.14
+```
+
+This is deliberately narrower than unbounded package metadata such as
+`>=3.11`.
+
+A future Python 3.15 interpreter does not become suite-qualified merely because
+the package installer accepts it. Qualification must be updated explicitly and
+backed by the applicable suite validation.
+
+## 5. Component rows
+
+Every supported component row is an exact qualification record with these
+semantic fields:
+
+```text
+component_id
+display_name
+repository
+distribution
+import_name
+required
+compatibility_status
+version
+requires_python
+release
+capabilities
+entry_points
+external_prerequisites
+```
+
+The active v1 manifest permits at most one supported version for a given
+component ID and one row for a distribution.
+
+A supported row means:
+
+> this exact published component release is qualified by this exact suite
+> manifest.
+
+It does not mean that the component is installed on the current machine.
+
+## 6. Required, optional, and runtime state
+
+These dimensions are distinct:
+
+```text
+suite support
+required/optional composition
+runtime installation state
+```
+
+Core is required by the v0.1.0 suite shell.
+
+Qualified sibling applications are optional. Their absence is therefore a valid
+partial-installation state.
+
+For example:
+
+```text
+ScoreForm 0.10.0
+supported by the active suite
+optional to install
+currently absent
+```
+
+is valid.
+
+Conversely:
+
+```text
+ScoreForm 0.11.0
+installed
+absent from the active manifest
+```
+
+must not be treated as supported merely because pip accepts its dependencies.
+
+Runtime states such as `installed`, `missing`, `broken`, `shadowed`, or
+`incompatible` are not static manifest statuses. Later bootstrap, doctor,
+discovery, and acceptance issues compare the environment to this declaration.
+
+## 7. Exact release artifacts
+
+Every supported component row binds to one official published wheel through:
+
+```text
+repository
+release tag
+wheel filename
+SHA-256 digest
+```
+
+The digest is lowercase hexadecimal and covers the exact release-asset bytes.
+
+Release qualification must not be derived from:
+
+- a locally rebuilt wheel;
+- an editable checkout;
+- a mutable branch;
+- a source archive rebuilt locally;
+- an unknown package cache;
+- or a different artifact that happens to report the same version.
+
+The current development manifest qualifies these exact component versions:
+
+| Component | Distribution | Version | Required |
+|---|---|---:|---|
+| Core | `pds-core` | `0.6.0` | yes |
+| Concord | `pds-concord` | `0.2.0` | no |
+| Quillan | `quillan` | `0.9.0` | no |
+| ScoreForm | `scoreform` | `0.10.0` | no |
+| Vitrine | `pds-vitrine` | `0.2.0` | no |
+
+The JSON manifest is the machine-readable source of truth for the exact wheel
+filenames and SHA-256 digests. This document deliberately does not duplicate
+those digests.
+
+## 8. Published-release-only rule
+
+A supported component must correspond to an immutable published GitHub Release
+asset in the `Paper-Data-Suite` organization.
+
+Mutable development state is not a supported release.
+
+Accordingly:
+
+- Meridian development source is not presently a supported manifest row;
+- Portia has no executable application release and is not fabricated as one.
+
+A future release can be added only by an explicit manifest change and renewed
+artifact qualification.
+
+No `latest` lookup, nearest-version selection, wildcard support, or semver-family
+inference is permitted.
+
+## 9. Entry points and capabilities
+
+The suite architecture distinguishes application launching, Core routing, and
+publication capabilities.
+
+The manifest therefore represents these public entry-point groups separately:
+
+```text
+console_scripts
+paper_data_suite.modules
+paper_data_suite.publication_producers
+```
+
+A component may expose any valid subset.
+
+This prevents false implications such as:
+
+```text
+routing module
+=
+launchable application
+=
+publication producer
+```
+
+Those identities are not equivalent in Paper Data Suite.
+
+The bounded capability vocabulary describes only integration-relevant suite
+facts, such as:
+
+```text
+shared_core
+launchable_application
+routing_module
+publication_producer
+publication_consumer
+```
+
+It does not create a domain-feature catalog such as `can_grade`, `can_group`, or
+`can_review_behavior`.
+
+Domain semantics remain owned by the corresponding module.
+
+## 10. External prerequisites
+
+`external_prerequisites` records non-Python software requirements that later
+environment diagnostics may need to probe.
+
+It does not duplicate ordinary wheel `Requires-Dist` metadata.
+
+For example, PDF scan workflows in ScoreForm and Quillan require the external
+`pdftoppm` command supplied by Poppler. The manifest may identify that command
+and its purpose, but it does not contain package-manager recipes, installer
+URLs, registry edits, or machine-mutating commands.
+
+Issue #6 owns actual diagnostic probing. Issue #5 owns bootstrap and remediation
+planning.
+
+## 11. Not a package index or dependency lock
+
+The manifest is not:
+
+- PyPI;
+- an alternate package index;
+- a mirror list;
+- a transitive Python dependency graph;
+- a `requirements.txt`;
+- a package solver;
+- an installer;
+- an update engine;
+- a historical catalog of all PDS releases.
+
+Python dependency metadata remains in the component wheels.
+
+The active suite release records only the exact PDS-owned release identities and
+bounded external prerequisites needed for suite qualification.
+
+Historical suite releases preserve their own historical declarations through
+their own released artifacts and source history.
+
+## 12. Self-hash exclusion
+
+The manifest does not contain the SHA-256 digest of the `paper-data-suite` wheel
+that contains it.
+
+Embedding the containing wheel's own digest would be self-referential:
+
+```text
+manifest gains suite-wheel digest
+-> wheel bytes change
+-> digest changes
+-> manifest must change
+-> wheel bytes change again
+```
+
+The bundled manifest authenticates subordinate PDS component artifacts.
+
+Authentication of the suite wheel itself belongs to external release/bootstrap
+metadata and the final release process.
+
+## 13. Validation and trust model
+
+The repository provides three complementary checks.
+
+### 13.1 Manifest validation
+
+```powershell
+python .\scripts\validate_compatibility_manifest.py
+```
+
+This validates the v1 structure and suite invariants without inspecting the
+current workspace or installed sibling applications.
+
+### 13.2 Published artifact verification
+
+```powershell
+python .\scripts\verify_compatibility_artifacts.py `
+  --artifact-dir <directory-containing-declared-wheels>
+```
+
+This verifies the declared wheels directly by exact:
+
+- filename;
+- SHA-256;
+- distribution metadata;
+- version metadata;
+- `Requires-Python`;
+- public entry-point groups, names, and targets.
+
+The verifier does not install or import candidate component wheels.
+
+### 13.3 Built-suite validation
+
+```powershell
+python .\scripts\check_package.py <suite-wheel>
+python .\scripts\smoke_test_wheel.py <suite-wheel> <core-wheel>
+```
+
+The package checker proves that the compatibility resource is inside the built
+suite wheel and agrees with the suite wheel's identity.
+
+The clean installed-wheel smoke test proves that the manifest can be loaded
+outside the source checkout, creates no working-directory artifacts, attempts no
+network access, and does not import sibling PDS applications.
+
+CI performs the same checks and separately authenticates the declared official
+release assets.
+
+## 14. Side-effect and privacy boundary
+
+Loading the compatibility manifest must not:
+
+- inspect a PDS workspace;
+- read student or class data;
+- enumerate installed sibling applications;
+- import sibling application packages;
+- make network requests;
+- install software;
+- write files;
+- modify environment variables.
+
+The manifest contains software release metadata only.
+
+It contains no:
+
+- workspace path;
+- class ID;
+- student ID;
+- roster;
+- school-year record;
+- credential;
+- token;
+- machine identifier;
+- domain record.
+
+## 15. Updating qualification
+
+A supported component version changes only through explicit suite work.
+
+Updating a row requires:
+
+1. selecting a specific published release;
+2. authenticating the exact official wheel bytes;
+3. recording the exact wheel filename and SHA-256;
+4. validating wheel `Name`, `Version`, and `Requires-Python`;
+5. validating expected public entry points;
+6. running relevant suite integration qualification;
+7. running repository tests, lint, typing, package checks, and CI;
+8. reviewing the manifest diff.
+
+The shell must never update the declaration merely because a newer component
+release exists.
+
+## 16. Relationship to later v0.1.0 work
+
+This issue establishes compatibility data and verification only.
+
+Later issues consume it:
+
+- #5 — verified Windows bootstrap and update planning;
+- #6 — `pds doctor`;
+- #7 — installed-module discovery and launching;
+- #13 — combined installed-suite acceptance;
+- #14 — final security, privacy, usability, and release audit.
+
+Those issues may classify an actual environment, propose explicit remediation,
+or launch supported components. They must not weaken the fail-closed release
+qualification established here.

--- a/paper_data_suite/compatibility.py
+++ b/paper_data_suite/compatibility.py
@@ -1,0 +1,785 @@
+"""Typed, side-effect-free access to the bundled suite compatibility manifest."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from importlib import resources
+from typing import Final, cast
+
+from paper_data_suite._version import __version__
+
+_RECORD_TYPE: Final = "paper_data_suite_release_compatibility_manifest"
+_CONTRACT_VERSION: Final = "1"
+_SUITE_DISTRIBUTION: Final = "paper-data-suite"
+_RESOURCE_PARTS: Final = ("data", "release_compatibility_v1.json")
+
+_ALLOWED_RELEASE_STATUS: Final = frozenset({"development", "release"})
+_ALLOWED_COMPATIBILITY_STATUS: Final = frozenset({"supported"})
+_ALLOWED_COMPONENT_IDS: Final = frozenset(
+    {"core", "scoreform", "quillan", "concord", "meridian", "vitrine", "portia"}
+)
+_ALLOWED_CAPABILITIES: Final = frozenset(
+    {
+        "shared_core",
+        "launchable_application",
+        "routing_module",
+        "publication_producer",
+        "publication_consumer",
+    }
+)
+_ALLOWED_ENTRY_POINT_GROUPS: Final = (
+    "console_scripts",
+    "paper_data_suite.modules",
+    "paper_data_suite.publication_producers",
+)
+_ALLOWED_PREREQUISITE_KINDS: Final = frozenset({"command"})
+_ALLOWED_PLATFORMS: Final = frozenset({"windows", "linux", "macos"})
+_COMPONENT_ID_RE: Final = re.compile(r"^[a-z][a-z0-9_]*$")
+_PREREQUISITE_ID_RE: Final = re.compile(r"^[a-z][a-z0-9_-]*$")
+_DISTRIBUTION_RE: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_IMPORT_NAME_RE: Final = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*$")
+_REPOSITORY_RE: Final = re.compile(
+    r"^Paper-Data-Suite/[A-Za-z0-9][A-Za-z0-9._-]*$"
+)
+_VERSION_RE: Final = re.compile(r"^[0-9]+(?:\.[0-9A-Za-z]+)*(?:[.-][0-9A-Za-z]+)*$")
+_SHA256_RE: Final = re.compile(r"^[0-9a-f]{64}$")
+_WHEEL_RE: Final = re.compile(r"^[A-Za-z0-9_.+-]+\.whl$")
+_ENTRY_POINT_NAME_RE: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_ENTRY_POINT_TARGET_RE: Final = re.compile(
+    r"^[A-Za-z_][A-Za-z0-9_.]*:[A-Za-z_][A-Za-z0-9_.]*$"
+)
+_MINOR_RE: Final = re.compile(r"^([0-9]+)\.([0-9]+)$")
+_SPECIFIER_TOKEN_RE: Final = re.compile(
+    r"^(>=|<=|==|!=|>|<)([0-9]+)\.([0-9]+)$"
+)
+
+
+class CompatibilityManifestError(ValueError):
+    """Raised when compatibility data violates the v1 contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class SuiteCompatibility:
+    """Identity of the suite release that owns the manifest."""
+
+    distribution: str
+    version: str
+    release_status: str
+
+
+@dataclass(frozen=True, slots=True)
+class PythonCompatibility:
+    """Suite-qualified Python interpreter range."""
+
+    specifier: str
+    tested_minors: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseArtifact:
+    """Exact published wheel identity authenticated by the suite."""
+
+    tag: str
+    wheel: str
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class EntryPointExpectation:
+    """One exact public entry point expected in a released wheel."""
+
+    group: str
+    name: str
+    target: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalPrerequisite:
+    """One non-Python prerequisite for later environment diagnostics."""
+
+    prerequisite_id: str
+    kind: str
+    required: bool
+    commands: tuple[str, ...]
+    platforms: tuple[str, ...]
+    purpose: str
+
+
+@dataclass(frozen=True, slots=True)
+class ComponentCompatibility:
+    """Exact suite qualification row for one PDS-owned component."""
+
+    component_id: str
+    display_name: str
+    repository: str
+    distribution: str
+    import_name: str
+    required: bool
+    compatibility_status: str
+    version: str
+    requires_python: str
+    release: ReleaseArtifact
+    capabilities: tuple[str, ...]
+    entry_points: tuple[EntryPointExpectation, ...]
+    external_prerequisites: tuple[ExternalPrerequisite, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseCompatibilityManifest:
+    """Immutable typed representation of release compatibility v1."""
+
+    record_type: str
+    contract_version: str
+    suite: SuiteCompatibility
+    python: PythonCompatibility
+    components: tuple[ComponentCompatibility, ...]
+
+
+def _duplicate_rejecting_object(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CompatibilityManifestError(
+                f"duplicate JSON object key: {key!r}"
+            )
+        result[key] = value
+    return result
+
+
+def _expect_object(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise CompatibilityManifestError(f"{label} must be an object")
+    return cast(dict[str, object], value)
+
+
+def _expect_keys(
+    value: Mapping[str, object],
+    *,
+    required: frozenset[str],
+    label: str,
+) -> None:
+    keys = frozenset(value)
+    missing = sorted(required - keys)
+    unknown = sorted(keys - required)
+    if missing:
+        raise CompatibilityManifestError(
+            f"{label} is missing fields: {', '.join(missing)}"
+        )
+    if unknown:
+        raise CompatibilityManifestError(
+            f"{label} has unknown fields: {', '.join(unknown)}"
+        )
+
+
+def _expect_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise CompatibilityManifestError(
+            f"{label} must be a non-empty string"
+        )
+    return value
+
+
+def _expect_bool(value: object, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise CompatibilityManifestError(f"{label} must be a boolean")
+    return value
+
+
+def _expect_array(value: object, label: str) -> list[object]:
+    if not isinstance(value, list):
+        raise CompatibilityManifestError(f"{label} must be an array")
+    return cast(list[object], value)
+
+
+def _parse_minor(value: str, label: str) -> tuple[int, int]:
+    match = _MINOR_RE.fullmatch(value)
+    if match is None:
+        raise CompatibilityManifestError(
+            f"{label} must use MAJOR.MINOR form"
+        )
+    return int(match.group(1)), int(match.group(2))
+
+
+def _parse_specifier(
+    value: str, label: str
+) -> tuple[tuple[str, tuple[int, int]], ...]:
+    tokens: list[tuple[str, tuple[int, int]]] = []
+    for raw_token in value.split(","):
+        token = raw_token.strip()
+        match = _SPECIFIER_TOKEN_RE.fullmatch(token)
+        if match is None:
+            raise CompatibilityManifestError(
+                f"{label} has unsupported Python specifier token: {token!r}"
+            )
+        tokens.append(
+            (
+                match.group(1),
+                (int(match.group(2)), int(match.group(3))),
+            )
+        )
+    if not tokens:
+        raise CompatibilityManifestError(f"{label} cannot be empty")
+    return tuple(tokens)
+
+
+def _version_satisfies(
+    version: tuple[int, int],
+    specifiers: Sequence[tuple[str, tuple[int, int]]],
+) -> bool:
+    for operator, expected in specifiers:
+        if operator == ">=" and not version >= expected:
+            return False
+        if operator == ">" and not version > expected:
+            return False
+        if operator == "<=" and not version <= expected:
+            return False
+        if operator == "<" and not version < expected:
+            return False
+        if operator == "==" and not version == expected:
+            return False
+        if operator == "!=" and not version != expected:
+            return False
+    return True
+
+
+def _parse_suite(value: object) -> SuiteCompatibility:
+    data = _expect_object(value, "suite")
+    required = frozenset({"distribution", "version", "release_status"})
+    _expect_keys(data, required=required, label="suite")
+
+    distribution = _expect_string(data["distribution"], "suite.distribution")
+    version = _expect_string(data["version"], "suite.version")
+    release_status = _expect_string(
+        data["release_status"], "suite.release_status"
+    )
+
+    if distribution != _SUITE_DISTRIBUTION:
+        raise CompatibilityManifestError(
+            f"suite.distribution must be {_SUITE_DISTRIBUTION!r}"
+        )
+    if version != __version__:
+        raise CompatibilityManifestError(
+            "manifest suite.version disagrees with package __version__"
+        )
+    if release_status not in _ALLOWED_RELEASE_STATUS:
+        raise CompatibilityManifestError(
+            f"unsupported suite.release_status: {release_status!r}"
+        )
+    if ".dev" in version and release_status != "development":
+        raise CompatibilityManifestError(
+            "development suite version must use release_status='development'"
+        )
+
+    return SuiteCompatibility(distribution, version, release_status)
+
+
+def _parse_python(value: object) -> PythonCompatibility:
+    data = _expect_object(value, "python")
+    required = frozenset({"specifier", "tested_minors"})
+    _expect_keys(data, required=required, label="python")
+
+    specifier = _expect_string(data["specifier"], "python.specifier")
+    parsed_specifier = _parse_specifier(specifier, "python.specifier")
+    raw_minors = _expect_array(data["tested_minors"], "python.tested_minors")
+    tested = tuple(
+        _expect_string(item, f"python.tested_minors[{index}]")
+        for index, item in enumerate(raw_minors)
+    )
+    if not tested:
+        raise CompatibilityManifestError(
+            "python.tested_minors cannot be empty"
+        )
+    if len(tested) != len(set(tested)):
+        raise CompatibilityManifestError(
+            "python.tested_minors contains duplicates"
+        )
+
+    parsed_minors = tuple(
+        _parse_minor(item, f"python.tested_minors[{index}]")
+        for index, item in enumerate(tested)
+    )
+    if parsed_minors != tuple(sorted(parsed_minors)):
+        raise CompatibilityManifestError(
+            "python.tested_minors must be in ascending order"
+        )
+    outside = [
+        value
+        for value, parsed in zip(tested, parsed_minors, strict=True)
+        if not _version_satisfies(parsed, parsed_specifier)
+    ]
+    if outside:
+        raise CompatibilityManifestError(
+            "tested Python minors outside suite specifier: "
+            + ", ".join(outside)
+        )
+
+    return PythonCompatibility(specifier, tested)
+
+
+def _parse_release(
+    value: object,
+    *,
+    distribution: str,
+    version: str,
+) -> ReleaseArtifact:
+    data = _expect_object(value, f"component {distribution!r} release")
+    required = frozenset({"tag", "wheel", "sha256"})
+    _expect_keys(
+        data,
+        required=required,
+        label=f"component {distribution!r} release",
+    )
+
+    tag = _expect_string(data["tag"], "release.tag")
+    wheel = _expect_string(data["wheel"], "release.wheel")
+    sha256 = _expect_string(data["sha256"], "release.sha256")
+
+    if tag != f"v{version}":
+        raise CompatibilityManifestError(
+            f"release.tag {tag!r} must equal version-qualified tag v{version}"
+        )
+    if _WHEEL_RE.fullmatch(wheel) is None:
+        raise CompatibilityManifestError("release.wheel is not a safe wheel filename")
+    normalized_distribution = distribution.replace("-", "_").replace(".", "_")
+    if not wheel.startswith(f"{normalized_distribution}-{version}-"):
+        raise CompatibilityManifestError(
+            "release.wheel does not match distribution/version identity"
+        )
+    if _SHA256_RE.fullmatch(sha256) is None:
+        raise CompatibilityManifestError(
+            "release.sha256 must be 64 lowercase hexadecimal characters"
+        )
+
+    return ReleaseArtifact(tag, wheel, sha256)
+
+
+def _parse_entry_points(
+    value: object,
+    component_id: str,
+) -> tuple[EntryPointExpectation, ...]:
+    data = _expect_object(value, f"component {component_id!r} entry_points")
+    _expect_keys(
+        data,
+        required=frozenset(_ALLOWED_ENTRY_POINT_GROUPS),
+        label=f"component {component_id!r} entry_points",
+    )
+
+    expectations: list[EntryPointExpectation] = []
+    for group in _ALLOWED_ENTRY_POINT_GROUPS:
+        group_data = _expect_object(
+            data[group], f"component {component_id!r} entry_points.{group}"
+        )
+        for name in sorted(group_data):
+            target = group_data[name]
+            if _ENTRY_POINT_NAME_RE.fullmatch(name) is None:
+                raise CompatibilityManifestError(
+                    f"invalid entry-point name {name!r} in group {group!r}"
+                )
+            parsed_target = _expect_string(
+                target,
+                f"component {component_id!r} entry point {group}:{name}",
+            )
+            if _ENTRY_POINT_TARGET_RE.fullmatch(parsed_target) is None:
+                raise CompatibilityManifestError(
+                    f"invalid entry-point target: {parsed_target!r}"
+                )
+            expectations.append(
+                EntryPointExpectation(group, name, parsed_target)
+            )
+
+    return tuple(expectations)
+
+
+def _parse_prerequisites(
+    value: object, component_id: str
+) -> tuple[ExternalPrerequisite, ...]:
+    raw_items = _expect_array(
+        value, f"component {component_id!r} external_prerequisites"
+    )
+    result: list[ExternalPrerequisite] = []
+    seen_ids: set[str] = set()
+
+    required_fields = frozenset(
+        {"id", "kind", "required", "commands", "platforms", "purpose"}
+    )
+    for index, item in enumerate(raw_items):
+        data = _expect_object(
+            item,
+            f"component {component_id!r} external_prerequisites[{index}]",
+        )
+        _expect_keys(
+            data,
+            required=required_fields,
+            label=(
+                f"component {component_id!r} "
+                f"external_prerequisites[{index}]"
+            ),
+        )
+
+        prerequisite_id = _expect_string(data["id"], "prerequisite.id")
+        if not _PREREQUISITE_ID_RE.fullmatch(prerequisite_id):
+            raise CompatibilityManifestError(
+                f"invalid prerequisite id: {prerequisite_id!r}"
+            )
+        if prerequisite_id in seen_ids:
+            raise CompatibilityManifestError(
+                f"duplicate prerequisite id in {component_id}: {prerequisite_id}"
+            )
+        seen_ids.add(prerequisite_id)
+
+        kind = _expect_string(data["kind"], "prerequisite.kind")
+        if kind not in _ALLOWED_PREREQUISITE_KINDS:
+            raise CompatibilityManifestError(
+                f"unsupported prerequisite kind: {kind!r}"
+            )
+        required = _expect_bool(data["required"], "prerequisite.required")
+
+        raw_commands = _expect_array(data["commands"], "prerequisite.commands")
+        commands = tuple(
+            _expect_string(command, "prerequisite command")
+            for command in raw_commands
+        )
+        if not commands or len(commands) != len(set(commands)):
+            raise CompatibilityManifestError(
+                "prerequisite commands must be unique and non-empty"
+            )
+        if tuple(sorted(commands)) != commands:
+            raise CompatibilityManifestError(
+                "prerequisite commands must be sorted"
+            )
+        if any(
+            "/" in command
+            or "\\" in command
+            or "://" in command
+            or any(character.isspace() for character in command)
+            for command in commands
+        ):
+            raise CompatibilityManifestError(
+                "prerequisite commands must be bare executable names"
+            )
+
+        raw_platforms = _expect_array(
+            data["platforms"], "prerequisite.platforms"
+        )
+        platforms = tuple(
+            _expect_string(platform, "prerequisite platform")
+            for platform in raw_platforms
+        )
+        if not platforms or len(platforms) != len(set(platforms)):
+            raise CompatibilityManifestError(
+                "prerequisite platforms must be unique and non-empty"
+            )
+        if tuple(sorted(platforms)) != platforms:
+            raise CompatibilityManifestError(
+                "prerequisite platforms must be sorted"
+            )
+        unknown_platforms = sorted(set(platforms) - _ALLOWED_PLATFORMS)
+        if unknown_platforms:
+            raise CompatibilityManifestError(
+                "unsupported prerequisite platforms: "
+                + ", ".join(unknown_platforms)
+            )
+
+        purpose = _expect_string(data["purpose"], "prerequisite.purpose")
+        if "://" in purpose:
+            raise CompatibilityManifestError(
+                "prerequisite purpose must not contain a URL"
+            )
+
+        result.append(
+            ExternalPrerequisite(
+                prerequisite_id,
+                kind,
+                required,
+                commands,
+                platforms,
+                purpose,
+            )
+        )
+
+    prerequisite_ids = tuple(item.prerequisite_id for item in result)
+    if prerequisite_ids != tuple(sorted(prerequisite_ids)):
+        raise CompatibilityManifestError(
+            f"component {component_id!r} prerequisites must be sorted by id"
+        )
+
+    return tuple(result)
+
+
+def _parse_component(
+    value: object,
+    suite_python: PythonCompatibility,
+) -> ComponentCompatibility:
+    data = _expect_object(value, "component")
+    required_fields = frozenset(
+        {
+            "component_id",
+            "display_name",
+            "repository",
+            "distribution",
+            "import_name",
+            "required",
+            "compatibility_status",
+            "version",
+            "requires_python",
+            "release",
+            "capabilities",
+            "entry_points",
+            "external_prerequisites",
+        }
+    )
+    _expect_keys(data, required=required_fields, label="component")
+
+    component_id = _expect_string(data["component_id"], "component.component_id")
+    if _COMPONENT_ID_RE.fullmatch(component_id) is None:
+        raise CompatibilityManifestError(
+            f"invalid component_id: {component_id!r}"
+        )
+    if component_id not in _ALLOWED_COMPONENT_IDS:
+        raise CompatibilityManifestError(
+            f"unsupported PDS component_id: {component_id!r}"
+        )
+
+    display_name = _expect_string(data["display_name"], "component.display_name")
+    repository = _expect_string(data["repository"], "component.repository")
+    if _REPOSITORY_RE.fullmatch(repository) is None:
+        raise CompatibilityManifestError(
+            "component repository must be an official Paper-Data-Suite repo: "
+            f"{repository!r}"
+        )
+
+    distribution = _expect_string(data["distribution"], "component.distribution")
+    if _DISTRIBUTION_RE.fullmatch(distribution) is None:
+        raise CompatibilityManifestError(
+            f"invalid distribution name: {distribution!r}"
+        )
+    if distribution == _SUITE_DISTRIBUTION:
+        raise CompatibilityManifestError(
+            "suite wheel must not appear as a subordinate component row"
+        )
+
+    import_name = _expect_string(data["import_name"], "component.import_name")
+    if _IMPORT_NAME_RE.fullmatch(import_name) is None:
+        raise CompatibilityManifestError(
+            f"invalid import_name: {import_name!r}"
+        )
+
+    required = _expect_bool(data["required"], "component.required")
+    compatibility_status = _expect_string(
+        data["compatibility_status"], "component.compatibility_status"
+    )
+    if compatibility_status not in _ALLOWED_COMPATIBILITY_STATUS:
+        raise CompatibilityManifestError(
+            f"unsupported compatibility_status: {compatibility_status!r}"
+        )
+
+    version = _expect_string(data["version"], "component.version")
+    if _VERSION_RE.fullmatch(version) is None:
+        raise CompatibilityManifestError(
+            f"invalid component version: {version!r}"
+        )
+    if ".dev" in version:
+        raise CompatibilityManifestError(
+            f"supported component cannot use development version: {version!r}"
+        )
+
+    requires_python = _expect_string(
+        data["requires_python"], "component.requires_python"
+    )
+    component_python = _parse_specifier(
+        requires_python, "component.requires_python"
+    )
+    unsupported_suite_minors = [
+        minor
+        for minor in suite_python.tested_minors
+        if not _version_satisfies(
+            _parse_minor(minor, "suite tested minor"), component_python
+        )
+    ]
+    if unsupported_suite_minors:
+        raise CompatibilityManifestError(
+            f"component {component_id} excludes suite-tested Python minors: "
+            + ", ".join(unsupported_suite_minors)
+        )
+
+    release = _parse_release(
+        data["release"], distribution=distribution, version=version
+    )
+
+    raw_capabilities = _expect_array(
+        data["capabilities"], f"component {component_id!r} capabilities"
+    )
+    capabilities = tuple(
+        _expect_string(item, f"component {component_id!r} capability")
+        for item in raw_capabilities
+    )
+    if len(capabilities) != len(set(capabilities)):
+        raise CompatibilityManifestError(
+            f"component {component_id!r} capabilities contain duplicates"
+        )
+    if tuple(sorted(capabilities)) != capabilities:
+        raise CompatibilityManifestError(
+            f"component {component_id!r} capabilities must be sorted"
+        )
+    unknown_capabilities = sorted(set(capabilities) - _ALLOWED_CAPABILITIES)
+    if unknown_capabilities:
+        raise CompatibilityManifestError(
+            "unsupported capabilities: " + ", ".join(unknown_capabilities)
+        )
+
+    entry_points = _parse_entry_points(data["entry_points"], component_id)
+    external_prerequisites = _parse_prerequisites(
+        data["external_prerequisites"], component_id
+    )
+
+    routing_entries = tuple(
+        item for item in entry_points if item.group == "paper_data_suite.modules"
+    )
+    producer_entries = tuple(
+        item
+        for item in entry_points
+        if item.group == "paper_data_suite.publication_producers"
+    )
+    console_entries = tuple(
+        item for item in entry_points if item.group == "console_scripts"
+    )
+
+    if ("routing_module" in capabilities) != bool(routing_entries):
+        raise CompatibilityManifestError(
+            f"component {component_id!r} routing capability/entry points disagree"
+        )
+    if ("publication_producer" in capabilities) != bool(producer_entries):
+        raise CompatibilityManifestError(
+            f"component {component_id!r} producer capability/entry points disagree"
+        )
+    if "launchable_application" in capabilities and not console_entries:
+        raise CompatibilityManifestError(
+            f"launchable component {component_id!r} must expose a console script"
+        )
+    if component_id == "core":
+        if "shared_core" not in capabilities:
+            raise CompatibilityManifestError("Core must declare shared_core")
+        if distribution != "pds-core":
+            raise CompatibilityManifestError("Core distribution must be pds-core")
+        if not required:
+            raise CompatibilityManifestError("Core must be required")
+    else:
+        if "shared_core" in capabilities:
+            raise CompatibilityManifestError(
+                f"sibling component {component_id!r} cannot declare shared_core"
+            )
+        if required:
+            raise CompatibilityManifestError(
+                f"sibling component {component_id!r} cannot be required"
+            )
+
+    return ComponentCompatibility(
+        component_id,
+        display_name,
+        repository,
+        distribution,
+        import_name,
+        required,
+        compatibility_status,
+        version,
+        requires_python,
+        release,
+        capabilities,
+        entry_points,
+        external_prerequisites,
+    )
+
+
+def parse_release_compatibility_manifest(
+    text: str,
+) -> ReleaseCompatibilityManifest:
+    """Parse manifest JSON into immutable v1 models and enforce all invariants."""
+    try:
+        raw = json.loads(text, object_pairs_hook=_duplicate_rejecting_object)
+    except CompatibilityManifestError:
+        raise
+    except json.JSONDecodeError as error:
+        raise CompatibilityManifestError(
+            f"invalid compatibility manifest JSON: {error.msg}"
+        ) from error
+
+    data = _expect_object(raw, "manifest")
+    required = frozenset(
+        {"record_type", "contract_version", "suite", "python", "components"}
+    )
+    _expect_keys(data, required=required, label="manifest")
+
+    record_type = _expect_string(data["record_type"], "record_type")
+    if record_type != _RECORD_TYPE:
+        raise CompatibilityManifestError(
+            f"record_type must be {_RECORD_TYPE!r}"
+        )
+
+    contract_version = _expect_string(
+        data["contract_version"], "contract_version"
+    )
+    if contract_version != _CONTRACT_VERSION:
+        raise CompatibilityManifestError(
+            f"unsupported compatibility contract version: {contract_version!r}"
+        )
+
+    suite = _parse_suite(data["suite"])
+    python = _parse_python(data["python"])
+    raw_components = _expect_array(data["components"], "components")
+    if not raw_components:
+        raise CompatibilityManifestError("components cannot be empty")
+    components = tuple(
+        _parse_component(item, python) for item in raw_components
+    )
+
+    component_ids = tuple(item.component_id for item in components)
+    if len(component_ids) != len(set(component_ids)):
+        raise CompatibilityManifestError("duplicate component_id")
+
+    distributions = tuple(item.distribution for item in components)
+    if len(distributions) != len(set(distributions)):
+        raise CompatibilityManifestError("duplicate component distribution")
+
+    if component_ids != tuple(sorted(component_ids)):
+        raise CompatibilityManifestError(
+            "components must be sorted by component_id"
+        )
+
+    core_rows = tuple(item for item in components if item.component_id == "core")
+    if len(core_rows) != 1:
+        raise CompatibilityManifestError(
+            "manifest must contain exactly one Core component row"
+        )
+
+    return ReleaseCompatibilityManifest(
+        record_type,
+        contract_version,
+        suite,
+        python,
+        components,
+    )
+
+
+def load_release_compatibility_manifest() -> ReleaseCompatibilityManifest:
+    """Load the bundled active compatibility manifest without environment probing."""
+    resource = resources.files("paper_data_suite").joinpath(*_RESOURCE_PARTS)
+    return parse_release_compatibility_manifest(resource.read_text(encoding="utf-8"))
+
+
+__all__ = (
+    "CompatibilityManifestError",
+    "ComponentCompatibility",
+    "EntryPointExpectation",
+    "ExternalPrerequisite",
+    "PythonCompatibility",
+    "ReleaseArtifact",
+    "ReleaseCompatibilityManifest",
+    "SuiteCompatibility",
+    "load_release_compatibility_manifest",
+    "parse_release_compatibility_manifest",
+)

--- a/paper_data_suite/data/__init__.py
+++ b/paper_data_suite/data/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled non-domain compatibility data resources."""

--- a/paper_data_suite/data/release_compatibility_v1.json
+++ b/paper_data_suite/data/release_compatibility_v1.json
@@ -1,0 +1,202 @@
+{
+  "components": [
+    {
+      "capabilities": [
+        "launchable_application",
+        "publication_producer",
+        "routing_module"
+      ],
+      "compatibility_status": "supported",
+      "component_id": "concord",
+      "display_name": "Concord",
+      "distribution": "pds-concord",
+      "entry_points": {
+        "console_scripts": {
+          "concord": "concord.cli:main"
+        },
+        "paper_data_suite.modules": {
+          "concord": "concord.pds_module:get_module_profile"
+        },
+        "paper_data_suite.publication_producers": {
+          "concord": "concord.pds_publication:get_publication_producer_profile"
+        }
+      },
+      "external_prerequisites": [],
+      "import_name": "concord",
+      "release": {
+        "sha256": "e7f0171e8fd54eaa6ab0fd71580378bdd5ee8577a686890cd470dac83f7a619e",
+        "tag": "v0.2.0",
+        "wheel": "pds_concord-0.2.0-py3-none-any.whl"
+      },
+      "repository": "Paper-Data-Suite/pds-concord",
+      "required": false,
+      "requires_python": ">=3.11",
+      "version": "0.2.0"
+    },
+    {
+      "capabilities": [
+        "shared_core"
+      ],
+      "compatibility_status": "supported",
+      "component_id": "core",
+      "display_name": "PDS Core",
+      "distribution": "pds-core",
+      "entry_points": {
+        "console_scripts": {
+          "core": "pds_core.core_menu:main",
+          "pds-core": "pds_core.cli:main"
+        },
+        "paper_data_suite.modules": {},
+        "paper_data_suite.publication_producers": {}
+      },
+      "external_prerequisites": [],
+      "import_name": "pds_core",
+      "release": {
+        "sha256": "be28c061b38463ef59ebc328ed1aa443767fe7f2c626babb769c2d8e5932f308",
+        "tag": "v0.6.0",
+        "wheel": "pds_core-0.6.0-py3-none-any.whl"
+      },
+      "repository": "Paper-Data-Suite/pds-core",
+      "required": true,
+      "requires_python": ">=3.11",
+      "version": "0.6.0"
+    },
+    {
+      "capabilities": [
+        "launchable_application",
+        "publication_producer",
+        "routing_module"
+      ],
+      "compatibility_status": "supported",
+      "component_id": "quillan",
+      "display_name": "Quillan",
+      "distribution": "quillan",
+      "entry_points": {
+        "console_scripts": {
+          "quillan": "quillan.cli:main"
+        },
+        "paper_data_suite.modules": {
+          "quillan": "quillan.pds_module:get_module_profile"
+        },
+        "paper_data_suite.publication_producers": {
+          "quillan": "quillan.pds_publication:get_publication_producer_profile"
+        }
+      },
+      "external_prerequisites": [
+        {
+          "commands": [
+            "pdftoppm"
+          ],
+          "id": "poppler_pdftoppm",
+          "kind": "command",
+          "platforms": [
+            "linux",
+            "windows"
+          ],
+          "purpose": "PDF scan rasterization",
+          "required": true
+        }
+      ],
+      "import_name": "quillan",
+      "release": {
+        "sha256": "4e3bf92287d1a140a6edc062abcb759c02eb811c9ba4e2212e9c4878d3a07f1c",
+        "tag": "v0.9.0",
+        "wheel": "quillan-0.9.0-py3-none-any.whl"
+      },
+      "repository": "Paper-Data-Suite/pds-quillan",
+      "required": false,
+      "requires_python": ">=3.11",
+      "version": "0.9.0"
+    },
+    {
+      "capabilities": [
+        "launchable_application",
+        "publication_producer",
+        "routing_module"
+      ],
+      "compatibility_status": "supported",
+      "component_id": "scoreform",
+      "display_name": "ScoreForm",
+      "distribution": "scoreform",
+      "entry_points": {
+        "console_scripts": {
+          "scoreform": "scoreform.cli:main"
+        },
+        "paper_data_suite.modules": {
+          "scoreform": "scoreform.pds_module:get_module_profile"
+        },
+        "paper_data_suite.publication_producers": {
+          "scoreform": "scoreform.pds_publication:get_publication_producer_profile"
+        }
+      },
+      "external_prerequisites": [
+        {
+          "commands": [
+            "pdftoppm"
+          ],
+          "id": "poppler_pdftoppm",
+          "kind": "command",
+          "platforms": [
+            "linux",
+            "windows"
+          ],
+          "purpose": "PDF scan rasterization",
+          "required": true
+        }
+      ],
+      "import_name": "scoreform",
+      "release": {
+        "sha256": "04c79c9b884040e3fc32b2551a4ad4fa6c63d4d04f1094b648e223bbb3c076d0",
+        "tag": "v0.10.0",
+        "wheel": "scoreform-0.10.0-py3-none-any.whl"
+      },
+      "repository": "Paper-Data-Suite/pds-scoreform",
+      "required": false,
+      "requires_python": ">=3.11",
+      "version": "0.10.0"
+    },
+    {
+      "capabilities": [
+        "launchable_application"
+      ],
+      "compatibility_status": "supported",
+      "component_id": "vitrine",
+      "display_name": "Vitrine",
+      "distribution": "pds-vitrine",
+      "entry_points": {
+        "console_scripts": {
+          "vitrine": "vitrine.cli:main"
+        },
+        "paper_data_suite.modules": {},
+        "paper_data_suite.publication_producers": {}
+      },
+      "external_prerequisites": [],
+      "import_name": "vitrine",
+      "release": {
+        "sha256": "a2c50b997abab7e4b32c2a8bc434990ef3b8229288db94b1c2677d1ee964a61b",
+        "tag": "v0.2.0",
+        "wheel": "pds_vitrine-0.2.0-py3-none-any.whl"
+      },
+      "repository": "Paper-Data-Suite/pds-vitrine",
+      "required": false,
+      "requires_python": ">=3.11",
+      "version": "0.2.0"
+    }
+  ],
+  "contract_version": "1",
+  "python": {
+    "specifier": ">=3.11,<3.15",
+    "tested_minors": [
+      "3.11",
+      "3.12",
+      "3.13",
+      "3.14"
+    ]
+  },
+  "record_type": "paper_data_suite_release_compatibility_manifest",
+  "suite": {
+    "distribution": "paper-data-suite",
+    "release_status": "development",
+    "version": "0.1.0.dev0"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,12 @@ Repository = "https://github.com/Paper-Data-Suite/pds-paper-data-suite"
 version = { attr = "paper_data_suite._version.__version__" }
 
 [tool.setuptools.packages.find]
-include = ["paper_data_suite"]
+include = ["paper_data_suite", "paper_data_suite.*"]
 namespaces = false
 
 [tool.setuptools.package-data]
 paper_data_suite = ["py.typed"]
+"paper_data_suite.data" = ["*.json"]
 
 [tool.pytest.ini_options]
 addopts = "-ra"

--- a/scripts/check_package.py
+++ b/scripts/check_package.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import configparser
+import json
 import zipfile
 from collections.abc import Sequence
 from pathlib import Path
@@ -25,6 +26,9 @@ REQUIRED_PACKAGE_FILES = frozenset(
         "paper_data_suite/__main__.py",
         "paper_data_suite/_version.py",
         "paper_data_suite/cli.py",
+        "paper_data_suite/compatibility.py",
+        "paper_data_suite/data/__init__.py",
+        "paper_data_suite/data/release_compatibility_v1.json",
         "paper_data_suite/py.typed",
     }
 )
@@ -186,6 +190,66 @@ def validate_wheel(path: Path) -> None:
         _validate_entry_points(
             wheel.read(entry_points_member).decode("utf-8")
         )
+
+        manifest_member = (
+            "paper_data_suite/data/release_compatibility_v1.json"
+        )
+        try:
+            manifest = json.loads(
+                wheel.read(manifest_member).decode("utf-8")
+            )
+        except (KeyError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise PackageValidationError(
+                "Wheel compatibility manifest is missing or invalid."
+            ) from error
+
+        if not isinstance(manifest, dict):
+            raise PackageValidationError(
+                "Wheel compatibility manifest must be a JSON object."
+            )
+        if manifest.get("record_type") != (
+            "paper_data_suite_release_compatibility_manifest"
+        ):
+            raise PackageValidationError(
+                "Unexpected wheel compatibility manifest record type."
+            )
+        if manifest.get("contract_version") != "1":
+            raise PackageValidationError(
+                "Unexpected wheel compatibility manifest contract version."
+            )
+        suite = manifest.get("suite")
+        if not isinstance(suite, dict):
+            raise PackageValidationError(
+                "Wheel compatibility manifest has no suite object."
+            )
+        if suite.get("distribution") != EXPECTED_DISTRIBUTION:
+            raise PackageValidationError(
+                "Wheel compatibility manifest distribution disagrees."
+            )
+        if suite.get("version") != EXPECTED_VERSION:
+            raise PackageValidationError(
+                "Wheel compatibility manifest suite version disagrees."
+            )
+        components = manifest.get("components")
+        if not isinstance(components, list):
+            raise PackageValidationError(
+                "Wheel compatibility manifest components must be an array."
+            )
+        component_ids = [
+            item.get("component_id")
+            for item in components
+            if isinstance(item, dict)
+        ]
+        if component_ids != [
+            "concord",
+            "core",
+            "quillan",
+            "scoreform",
+            "vitrine",
+        ]:
+            raise PackageValidationError(
+                "Wheel compatibility manifest component set changed."
+            )
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/inspect_release_wheel.py
+++ b/scripts/inspect_release_wheel.py
@@ -1,0 +1,121 @@
+"""Inspect one candidate PDS release wheel without installing or importing it."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import hashlib
+import json
+import zipfile
+from collections.abc import Sequence
+from email import policy
+from email.parser import BytesParser
+from pathlib import Path
+from typing import cast
+
+
+class _CaseSensitiveConfigParser(configparser.ConfigParser):
+    def optionxform(self, optionstr: str) -> str:
+        return optionstr
+
+
+class WheelInspectionError(RuntimeError):
+    """Raised when a candidate wheel cannot be inspected safely."""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _single_member(names: Sequence[str], suffix: str) -> str:
+    matches = tuple(name for name in names if name.endswith(suffix))
+    if len(matches) != 1:
+        raise WheelInspectionError(
+            f"expected exactly one wheel member ending with {suffix!r}; "
+            f"found {len(matches)}"
+        )
+    return matches[0]
+
+
+def inspect_wheel(path: Path) -> dict[str, object]:
+    """Return deterministic release metadata for one ordinary wheel file."""
+    if not path.is_file() or path.suffix != ".whl":
+        raise WheelInspectionError(f"candidate wheel does not exist: {path}")
+
+    try:
+        with zipfile.ZipFile(path) as archive:
+            corrupt_member = archive.testzip()
+            if corrupt_member is not None:
+                raise WheelInspectionError(
+                    f"wheel contains corrupt member: {corrupt_member}"
+                )
+            names = tuple(archive.namelist())
+            metadata_member = _single_member(names, ".dist-info/METADATA")
+            entry_member_matches = tuple(
+                name
+                for name in names
+                if name.endswith(".dist-info/entry_points.txt")
+            )
+            metadata = BytesParser(policy=policy.default).parsebytes(
+                archive.read(metadata_member)
+            )
+
+            entry_points: dict[str, dict[str, str]] = {}
+            if entry_member_matches:
+                if len(entry_member_matches) != 1:
+                    raise WheelInspectionError(
+                        "wheel contains ambiguous entry_points.txt files"
+                    )
+                parser = _CaseSensitiveConfigParser(
+                    interpolation=None,
+                    strict=True,
+                )
+                parser.read_string(
+                    archive.read(entry_member_matches[0]).decode("utf-8")
+                )
+                entry_points = {
+                    section: dict(sorted(parser.items(section)))
+                    for section in sorted(parser.sections())
+                }
+    except zipfile.BadZipFile as error:
+        raise WheelInspectionError("candidate is not a readable wheel ZIP") from error
+
+    name = metadata.get("Name")
+    version = metadata.get("Version")
+    requires_python = metadata.get("Requires-Python")
+    if not all(isinstance(value, str) and value for value in (name, version)):
+        raise WheelInspectionError("wheel metadata lacks Name or Version")
+
+    return {
+        "filename": path.name,
+        "sha256": _sha256(path),
+        "distribution": name,
+        "version": version,
+        "requires_python": requires_python,
+        "entry_points": entry_points,
+        "requires_dist": sorted(
+            str(item) for item in metadata.get_all("Requires-Dist", [])
+        ),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheels", nargs="+", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    wheels = cast(list[Path], args.wheels)
+    result = [inspect_wheel(path.resolve()) for path in wheels]
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_test_wheel.py
+++ b/scripts/smoke_test_wheel.py
@@ -170,6 +170,75 @@ print(json.dumps({
     _assert_clean_directory(cwd)
 
 
+def _assert_installed_compatibility_manifest(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    expected_version: str,
+) -> None:
+    code = """
+import json
+import socket
+import sys
+import urllib.request
+
+def blocked_network(*args, **kwargs):
+    raise AssertionError("compatibility loading attempted network access")
+
+socket.create_connection = blocked_network
+urllib.request.urlopen = blocked_network
+urllib.request.urlretrieve = blocked_network
+
+from paper_data_suite.compatibility import load_release_compatibility_manifest
+
+manifest = load_release_compatibility_manifest()
+tracked = [
+    "pds_core",
+    "scoreform",
+    "quillan",
+    "concord",
+    "meridian",
+    "vitrine",
+]
+print(json.dumps({
+    "suite_version": manifest.suite.version,
+    "component_ids": [
+        component.component_id for component in manifest.components
+    ],
+    "loaded": {name: name in sys.modules for name in tracked},
+}))
+""".strip()
+    result = _run([str(python), "-c", code], cwd=cwd, env=env)
+    payload = cast(dict[str, object], json.loads(result.stdout))
+
+    if payload.get("suite_version") != expected_version:
+        raise SmokeTestError(
+            "Installed compatibility manifest version does not match wheel."
+        )
+    if payload.get("component_ids") != [
+        "concord",
+        "core",
+        "quillan",
+        "scoreform",
+        "vitrine",
+    ]:
+        raise SmokeTestError(
+            "Installed compatibility manifest component set changed."
+        )
+
+    loaded = cast(dict[str, bool], payload.get("loaded"))
+    unexpectedly_loaded = sorted(
+        name for name, value in loaded.items() if value
+    )
+    if unexpectedly_loaded:
+        raise SmokeTestError(
+            "Compatibility loading imported PDS owner packages: "
+            + ", ".join(unexpectedly_loaded)
+        )
+    _assert_clean_directory(cwd)
+
+
 def smoke_test(suite_wheel: Path, core_wheel: Path) -> None:
     """Install and exercise the suite wheel beside only Core."""
     if not suite_wheel.is_file():
@@ -227,6 +296,12 @@ def smoke_test(suite_wheel: Path, core_wheel: Path) -> None:
             python, cwd=run_directory, env=command_env
         )
         _assert_import_boundary(
+            python,
+            cwd=run_directory,
+            env=command_env,
+            expected_version=expected_version,
+        )
+        _assert_installed_compatibility_manifest(
             python,
             cwd=run_directory,
             env=command_env,

--- a/scripts/validate_compatibility_manifest.py
+++ b/scripts/validate_compatibility_manifest.py
@@ -1,0 +1,104 @@
+"""Validate the bundled release-compatibility manifest against suite metadata."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from paper_data_suite import __version__
+from paper_data_suite.compatibility import (
+    CompatibilityManifestError,
+    load_release_compatibility_manifest,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_PROJECT_NAME = "paper-data-suite"
+EXPECTED_PROJECT_PYTHON = ">=3.11"
+EXPECTED_CORE_REQUIREMENT = "pds-core>=0.6,<0.7"
+EXPECTED_COMPONENT_IDS = (
+    "concord",
+    "core",
+    "quillan",
+    "scoreform",
+    "vitrine",
+)
+
+
+class ManifestValidationError(RuntimeError):
+    """Raised when repository metadata drifts from the manifest contract."""
+
+
+def validate_repository_manifest() -> None:
+    """Validate the active manifest and its repository-level package anchors."""
+    manifest = load_release_compatibility_manifest()
+
+    project_data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    project = project_data.get("project")
+    if not isinstance(project, dict):
+        raise ManifestValidationError("pyproject.toml has no [project] table")
+
+    if project.get("name") != EXPECTED_PROJECT_NAME:
+        raise ManifestValidationError(
+            f"project name must remain {EXPECTED_PROJECT_NAME!r}"
+        )
+    if project.get("requires-python") != EXPECTED_PROJECT_PYTHON:
+        raise ManifestValidationError(
+            f"project Requires-Python must remain {EXPECTED_PROJECT_PYTHON!r}"
+        )
+    if manifest.suite.version != __version__:
+        raise ManifestValidationError(
+            "manifest suite version disagrees with package version"
+        )
+
+    raw_dependencies = project.get("dependencies")
+    if not isinstance(raw_dependencies, list) or not all(
+        isinstance(item, str) for item in raw_dependencies
+    ):
+        raise ManifestValidationError("project dependencies must be a string list")
+    core_requirements = [
+        item.replace(" ", "")
+        for item in raw_dependencies
+        if item.lower().replace("_", "-").startswith("pds-core")
+    ]
+    if core_requirements != [EXPECTED_CORE_REQUIREMENT]:
+        raise ManifestValidationError(
+            "suite package must require exactly pds-core>=0.6,<0.7"
+        )
+
+    component_ids = tuple(item.component_id for item in manifest.components)
+    if component_ids != EXPECTED_COMPONENT_IDS:
+        raise ManifestValidationError(
+            "active development manifest component set changed without audit: "
+            + ", ".join(component_ids)
+        )
+
+    core = next(item for item in manifest.components if item.component_id == "core")
+    if not core.required:
+        raise ManifestValidationError("Core must remain required")
+    if any(
+        item.required for item in manifest.components if item.component_id != "core"
+    ):
+        raise ManifestValidationError("sibling applications must remain optional")
+
+
+def main() -> int:
+    try:
+        validate_repository_manifest()
+    except (
+        OSError,
+        tomllib.TOMLDecodeError,
+        CompatibilityManifestError,
+        ManifestValidationError,
+    ) as error:
+        print(f"Compatibility manifest validation failed: {error}")
+        return 1
+
+    print(
+        "Compatibility manifest passed: contract v1; suite 0.1.0.dev0; "
+        "Python >=3.11,<3.15; five exact published PDS component releases."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_compatibility_artifacts.py
+++ b/scripts/verify_compatibility_artifacts.py
@@ -1,0 +1,197 @@
+"""Authenticate exact published component wheels declared by the suite manifest."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import hashlib
+import zipfile
+from collections.abc import Sequence
+from email import policy
+from email.message import Message
+from email.parser import BytesParser
+from pathlib import Path
+
+from paper_data_suite.compatibility import (
+    CompatibilityManifestError,
+    ComponentCompatibility,
+    EntryPointExpectation,
+    load_release_compatibility_manifest,
+)
+
+_ALLOWED_ENTRY_POINT_GROUPS = (
+    "console_scripts",
+    "paper_data_suite.modules",
+    "paper_data_suite.publication_producers",
+)
+
+
+class ArtifactVerificationError(RuntimeError):
+    """Raised when a release artifact disagrees with the manifest."""
+
+
+class _CaseSensitiveConfigParser(configparser.ConfigParser):
+    def optionxform(self, optionstr: str) -> str:
+        return optionstr
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _single_metadata_value(message: Message, field: str, label: str) -> str:
+    values = message.get_all(field, [])
+    if len(values) != 1:
+        raise ArtifactVerificationError(
+            f"{label} must contain exactly one {field} metadata field"
+        )
+    return str(values[0]).strip()
+
+
+def _expected_entry_points(
+    expectations: Sequence[EntryPointExpectation],
+) -> dict[str, dict[str, str]]:
+    result: dict[str, dict[str, str]] = {
+        group: {} for group in _ALLOWED_ENTRY_POINT_GROUPS
+    }
+    for item in expectations:
+        result[item.group][item.name] = item.target
+    return result
+
+
+def _read_entry_points(
+    archive: zipfile.ZipFile,
+    names: Sequence[str],
+) -> dict[str, dict[str, str]]:
+    members = tuple(
+        name for name in names if name.endswith(".dist-info/entry_points.txt")
+    )
+    if not members:
+        return {group: {} for group in _ALLOWED_ENTRY_POINT_GROUPS}
+    if len(members) != 1:
+        raise ArtifactVerificationError(
+            "wheel must contain at most one top-level entry_points.txt"
+        )
+
+    parser = _CaseSensitiveConfigParser(interpolation=None, strict=True)
+    try:
+        parser.read_string(archive.read(members[0]).decode("utf-8"))
+    except (UnicodeDecodeError, configparser.Error) as error:
+        raise ArtifactVerificationError("wheel entry_points.txt is invalid") from error
+
+    unexpected_groups = sorted(
+        set(parser.sections()) - set(_ALLOWED_ENTRY_POINT_GROUPS)
+    )
+    if unexpected_groups:
+        raise ArtifactVerificationError(
+            "wheel exposes undeclared entry-point groups: "
+            + ", ".join(unexpected_groups)
+        )
+
+    return {
+        group: dict(sorted(parser.items(group))) if parser.has_section(group) else {}
+        for group in _ALLOWED_ENTRY_POINT_GROUPS
+    }
+
+
+def verify_component_wheel(component: ComponentCompatibility, path: Path) -> None:
+    """Verify one exact wheel without installing or importing it."""
+    wheel = path.resolve()
+    label = f"{component.component_id} wheel"
+
+    if wheel.name != component.release.wheel:
+        raise ArtifactVerificationError(
+            f"{label} filename mismatch: expected {component.release.wheel!r}, "
+            f"got {wheel.name!r}"
+        )
+    if not wheel.is_file():
+        raise ArtifactVerificationError(f"{label} is missing: {wheel}")
+
+    actual_digest = _sha256(wheel)
+    if actual_digest != component.release.sha256:
+        raise ArtifactVerificationError(
+            f"{label} SHA-256 mismatch: expected {component.release.sha256}, "
+            f"got {actual_digest}"
+        )
+
+    try:
+        with zipfile.ZipFile(wheel) as archive:
+            corrupt_member = archive.testzip()
+            if corrupt_member is not None:
+                raise ArtifactVerificationError(
+                    f"{label} contains corrupt member: {corrupt_member}"
+                )
+            names = tuple(archive.namelist())
+            metadata_members = tuple(
+                name for name in names if name.endswith(".dist-info/METADATA")
+            )
+            if len(metadata_members) != 1:
+                raise ArtifactVerificationError(
+                    f"{label} must contain exactly one METADATA file"
+                )
+            metadata = BytesParser(policy=policy.default).parsebytes(
+                archive.read(metadata_members[0])
+            )
+            entry_points = _read_entry_points(archive, names)
+    except zipfile.BadZipFile as error:
+        raise ArtifactVerificationError(
+            f"{label} is not a readable wheel ZIP"
+        ) from error
+
+    if _single_metadata_value(metadata, "Name", label) != component.distribution:
+        raise ArtifactVerificationError(f"{label} distribution identity mismatch")
+    if _single_metadata_value(metadata, "Version", label) != component.version:
+        raise ArtifactVerificationError(f"{label} version identity mismatch")
+    if (
+        _single_metadata_value(metadata, "Requires-Python", label)
+        != component.requires_python
+    ):
+        raise ArtifactVerificationError(f"{label} Requires-Python mismatch")
+
+    expected_entry_points = _expected_entry_points(component.entry_points)
+    if entry_points != expected_entry_points:
+        raise ArtifactVerificationError(
+            f"{label} entry-point metadata disagrees with manifest"
+        )
+
+
+def verify_artifact_directory(artifact_dir: Path) -> None:
+    """Verify every supported component wheel in one local directory."""
+    manifest = load_release_compatibility_manifest()
+    directory = artifact_dir.resolve()
+    if not directory.is_dir():
+        raise ArtifactVerificationError(
+            f"artifact directory does not exist: {directory}"
+        )
+
+    for component in manifest.components:
+        verify_component_wheel(component, directory / component.release.wheel)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-dir", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        verify_artifact_directory(args.artifact_dir)
+    except (OSError, CompatibilityManifestError, ArtifactVerificationError) as error:
+        print(f"Compatibility artifact verification failed: {error}")
+        return 1
+
+    print(
+        "Compatibility artifacts passed: exact filenames, SHA-256 digests, "
+        "wheel metadata, Python requirements, and public entry points verified."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from paper_data_suite import __version__
+from paper_data_suite.compatibility import (
+    CompatibilityManifestError,
+    load_release_compatibility_manifest,
+    parse_release_compatibility_manifest,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = (
+    ROOT / "paper_data_suite" / "data" / "release_compatibility_v1.json"
+)
+EXPECTED_COMPONENT_IDS = (
+    "concord",
+    "core",
+    "quillan",
+    "scoreform",
+    "vitrine",
+)
+
+
+def _raw_manifest() -> dict[str, Any]:
+    return cast(
+        dict[str, Any],
+        json.loads(MANIFEST_PATH.read_text(encoding="utf-8")),
+    )
+
+
+def _parse(data: dict[str, Any]) -> object:
+    return parse_release_compatibility_manifest(json.dumps(data))
+
+
+def _component(data: dict[str, Any], component_id: str) -> dict[str, Any]:
+    return next(
+        item for item in data["components"] if item["component_id"] == component_id
+    )
+
+
+def test_bundled_manifest_loads_and_matches_package_version() -> None:
+    manifest = load_release_compatibility_manifest()
+
+    assert manifest.record_type == (
+        "paper_data_suite_release_compatibility_manifest"
+    )
+    assert manifest.contract_version == "1"
+    assert manifest.suite.distribution == "paper-data-suite"
+    assert manifest.suite.version == __version__ == "0.1.0.dev0"
+    assert manifest.suite.release_status == "development"
+    assert manifest.python.specifier == ">=3.11,<3.15"
+    assert manifest.python.tested_minors == (
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+    )
+
+
+def test_manifest_qualifies_exact_audited_published_releases() -> None:
+    manifest = load_release_compatibility_manifest()
+    by_id = {item.component_id: item for item in manifest.components}
+
+    assert tuple(by_id) == EXPECTED_COMPONENT_IDS
+    assert by_id["core"].release.sha256 == (
+        "be28c061b38463ef59ebc328ed1aa443"
+        "767fe7f2c626babb769c2d8e5932f308"
+    )
+    assert by_id["scoreform"].release.sha256 == (
+        "04c79c9b884040e3fc32b2551a4ad4fa"
+        "6c63d4d04f1094b648e223bbb3c076d0"
+    )
+    assert by_id["quillan"].release.sha256 == (
+        "4e3bf92287d1a140a6edc062abcb759c"
+        "02eb811c9ba4e2212e9c4878d3a07f1c"
+    )
+    assert by_id["concord"].release.sha256 == (
+        "e7f0171e8fd54eaa6ab0fd71580378bd"
+        "d5ee8577a686890cd470dac83f7a619e"
+    )
+    assert by_id["vitrine"].release.sha256 == (
+        "a2c50b997abab7e4b32c2a8bc434990e"
+        "f3b8229288db94b1c2677d1ee964a61b"
+    )
+
+
+def test_only_core_is_required() -> None:
+    manifest = load_release_compatibility_manifest()
+
+    required = tuple(
+        item.component_id for item in manifest.components if item.required
+    )
+    assert required == ("core",)
+
+
+def test_public_capabilities_remain_independent() -> None:
+    manifest = load_release_compatibility_manifest()
+    by_id = {item.component_id: item for item in manifest.components}
+
+    producer_routing = (
+        "launchable_application",
+        "publication_producer",
+        "routing_module",
+    )
+    assert by_id["scoreform"].capabilities == producer_routing
+    assert by_id["quillan"].capabilities == producer_routing
+    assert by_id["concord"].capabilities == producer_routing
+    assert by_id["vitrine"].capabilities == ("launchable_application",)
+    assert by_id["core"].capabilities == ("shared_core",)
+
+
+def test_poppler_is_declared_only_for_audited_pdf_scan_components() -> None:
+    manifest = load_release_compatibility_manifest()
+    by_id = {item.component_id: item for item in manifest.components}
+
+    for component_id in ("scoreform", "quillan"):
+        prerequisites = by_id[component_id].external_prerequisites
+        assert len(prerequisites) == 1
+        prerequisite = prerequisites[0]
+        assert prerequisite.prerequisite_id == "poppler_pdftoppm"
+        assert prerequisite.kind == "command"
+        assert prerequisite.required is True
+        assert prerequisite.commands == ("pdftoppm",)
+        assert prerequisite.platforms == ("linux", "windows")
+        assert prerequisite.purpose == "PDF scan rasterization"
+
+    assert by_id["core"].external_prerequisites == ()
+    assert by_id["concord"].external_prerequisites == ()
+    assert by_id["vitrine"].external_prerequisites == ()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("record_type", "wrong"),
+        ("contract_version", "2"),
+    ],
+)
+def test_wrong_top_level_contract_identity_fails(
+    field: str,
+    value: str,
+) -> None:
+    data = _raw_manifest()
+    data[field] = value
+
+    with pytest.raises(CompatibilityManifestError):
+        _parse(data)
+
+
+def test_unknown_top_level_field_fails() -> None:
+    data = _raw_manifest()
+    data["typo"] = "value"
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="unknown fields",
+    ):
+        _parse(data)
+
+
+def test_duplicate_json_object_key_fails() -> None:
+    text = (
+        '{"record_type":"paper_data_suite_release_compatibility_manifest",'
+        '"record_type":"paper_data_suite_release_compatibility_manifest"}'
+    )
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="duplicate JSON object key",
+    ):
+        parse_release_compatibility_manifest(text)
+
+
+def test_suite_version_mismatch_fails() -> None:
+    data = _raw_manifest()
+    data["suite"]["version"] = "0.1.0"
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="suite.version",
+    ):
+        _parse(data)
+
+
+@pytest.mark.parametrize(
+    "tested_minors",
+    [
+        ["3.11", "3.11"],
+        ["3.12", "3.11"],
+        ["3.11", "3.15"],
+    ],
+)
+def test_invalid_tested_python_minor_sets_fail(
+    tested_minors: list[str],
+) -> None:
+    data = _raw_manifest()
+    data["python"]["tested_minors"] = tested_minors
+
+    with pytest.raises(CompatibilityManifestError):
+        _parse(data)
+
+
+def test_malformed_python_specifier_fails() -> None:
+    data = _raw_manifest()
+    data["python"]["specifier"] = "Python >= 3.11"
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="specifier",
+    ):
+        _parse(data)
+
+
+def test_unknown_component_id_fails() -> None:
+    data = _raw_manifest()
+    data["components"][0]["component_id"] = "unknown_component"
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="unsupported PDS component_id",
+    ):
+        _parse(data)
+
+
+def test_duplicate_component_id_fails() -> None:
+    data = _raw_manifest()
+    data["components"].append(copy.deepcopy(data["components"][0]))
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="duplicate component_id",
+    ):
+        _parse(data)
+
+
+def test_duplicate_distribution_fails() -> None:
+    data = _raw_manifest()
+    concord = _component(data, "concord")
+    scoreform = _component(data, "scoreform")
+    scoreform["distribution"] = concord["distribution"]
+    scoreform["release"]["wheel"] = "pds_concord-0.10.0-py3-none-any.whl"
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="duplicate component distribution",
+    ):
+        _parse(data)
+
+
+def test_components_must_be_sorted() -> None:
+    data = _raw_manifest()
+    data["components"][0], data["components"][1] = (
+        data["components"][1],
+        data["components"][0],
+    )
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="sorted by component_id",
+    ):
+        _parse(data)
+
+
+@pytest.mark.parametrize(
+    "digest",
+    [
+        "a" * 63,
+        "A" * 64,
+        "g" * 64,
+    ],
+)
+def test_malformed_digest_fails(digest: str) -> None:
+    data = _raw_manifest()
+    _component(data, "core")["release"]["sha256"] = digest
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="sha256",
+    ):
+        _parse(data)
+
+
+def test_supported_component_cannot_use_dev_version() -> None:
+    data = _raw_manifest()
+    component = _component(data, "core")
+    component["version"] = "0.6.1.dev0"
+    component["release"]["tag"] = "v0.6.1.dev0"
+    component["release"]["wheel"] = "pds_core-0.6.1.dev0-py3-none-any.whl"
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="development version",
+    ):
+        _parse(data)
+
+
+def test_sibling_component_cannot_be_required() -> None:
+    data = _raw_manifest()
+    _component(data, "scoreform")["required"] = True
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="cannot be required",
+    ):
+        _parse(data)
+
+
+def test_suite_distribution_cannot_be_component_row() -> None:
+    data = _raw_manifest()
+    component = _component(data, "scoreform")
+    component["distribution"] = "paper-data-suite"
+    component["release"]["wheel"] = (
+        "paper_data_suite-0.10.0-py3-none-any.whl"
+    )
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="subordinate component row",
+    ):
+        _parse(data)
+
+
+def test_routing_capability_must_match_routing_entry_point() -> None:
+    data = _raw_manifest()
+    component = _component(data, "scoreform")
+    component["entry_points"]["paper_data_suite.modules"] = {}
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="routing capability",
+    ):
+        _parse(data)
+
+
+def test_publication_capability_must_match_producer_entry_point() -> None:
+    data = _raw_manifest()
+    component = _component(data, "quillan")
+    component["entry_points"]["paper_data_suite.publication_producers"] = {}
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="producer capability",
+    ):
+        _parse(data)
+
+
+def test_launchable_application_requires_console_script() -> None:
+    data = _raw_manifest()
+    component = _component(data, "vitrine")
+    component["entry_points"]["console_scripts"] = {}
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="must expose a console script",
+    ):
+        _parse(data)
+
+
+def test_prerequisite_command_must_be_bare_executable_name() -> None:
+    data = _raw_manifest()
+    prerequisite = _component(data, "scoreform")["external_prerequisites"][0]
+    prerequisite["commands"] = ["C:\\Program Files\\poppler\\pdftoppm.exe"]
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="bare executable",
+    ):
+        _parse(data)
+
+
+def test_prerequisite_platforms_must_be_sorted() -> None:
+    data = _raw_manifest()
+    prerequisite = _component(data, "scoreform")["external_prerequisites"][0]
+    prerequisite["platforms"] = ["windows", "linux"]
+
+    with pytest.raises(
+        CompatibilityManifestError,
+        match="platforms must be sorted",
+    ):
+        _parse(data)
+
+
+def test_manifest_models_are_immutable() -> None:
+    manifest = load_release_compatibility_manifest()
+
+    with pytest.raises(AttributeError):
+        manifest.suite.version = "0.1.0"  # type: ignore[misc]

--- a/tests/test_compatibility_artifacts.py
+++ b/tests/test_compatibility_artifacts.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import configparser
+import hashlib
+import zipfile
+from dataclasses import replace
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from paper_data_suite.compatibility import (
+    ComponentCompatibility,
+    EntryPointExpectation,
+    load_release_compatibility_manifest,
+)
+from scripts.verify_compatibility_artifacts import (
+    ArtifactVerificationError,
+    verify_component_wheel,
+)
+
+
+class _CaseSensitiveConfigParser(configparser.ConfigParser):
+    def optionxform(self, optionstr: str) -> str:
+        return optionstr
+
+
+def _component(component_id: str) -> ComponentCompatibility:
+    manifest = load_release_compatibility_manifest()
+    return next(
+        item for item in manifest.components if item.component_id == component_id
+    )
+
+
+def _entry_point_text(expectations: tuple[EntryPointExpectation, ...]) -> str:
+    groups: dict[str, dict[str, str]] = {}
+    for item in expectations:
+        groups.setdefault(item.group, {})[item.name] = item.target
+
+    parser = _CaseSensitiveConfigParser(interpolation=None)
+    for group, values in groups.items():
+        if values:
+            parser[group] = values
+
+    output = StringIO()
+    parser.write(output)
+    return output.getvalue()
+
+
+def _write_wheel(
+    path: Path,
+    component: ComponentCompatibility,
+    *,
+    version: str | None = None,
+    entry_points: tuple[EntryPointExpectation, ...] | None = None,
+) -> str:
+    normalized = component.distribution.replace("-", "_").replace(".", "_")
+    dist_info = f"{normalized}-{component.version}.dist-info"
+    metadata = (
+        "Metadata-Version: 2.4\n"
+        f"Name: {component.distribution}\n"
+        f"Version: {version or component.version}\n"
+        f"Requires-Python: {component.requires_python}\n"
+        "\n"
+    )
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(f"{dist_info}/METADATA", metadata)
+        selected = component.entry_points if entry_points is None else entry_points
+        if selected:
+            archive.writestr(
+                f"{dist_info}/entry_points.txt",
+                _entry_point_text(selected),
+            )
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _with_test_digest(
+    component: ComponentCompatibility,
+    digest: str,
+) -> ComponentCompatibility:
+    release = replace(component.release, sha256=digest)
+    return replace(component, release=release)
+
+
+def test_exact_component_wheel_passes(tmp_path: Path) -> None:
+    component = _component("scoreform")
+    wheel = tmp_path / component.release.wheel
+    digest = _write_wheel(wheel, component)
+
+    verify_component_wheel(_with_test_digest(component, digest), wheel)
+
+
+def test_digest_mismatch_fails_before_metadata_trust(tmp_path: Path) -> None:
+    component = _component("core")
+    wheel = tmp_path / component.release.wheel
+    _write_wheel(wheel, component)
+
+    with pytest.raises(
+        ArtifactVerificationError,
+        match="SHA-256 mismatch",
+    ):
+        verify_component_wheel(component, wheel)
+
+
+def test_version_mismatch_fails(tmp_path: Path) -> None:
+    component = _component("vitrine")
+    wheel = tmp_path / component.release.wheel
+    digest = _write_wheel(wheel, component, version="9.9.9")
+
+    with pytest.raises(
+        ArtifactVerificationError,
+        match="version identity mismatch",
+    ):
+        verify_component_wheel(_with_test_digest(component, digest), wheel)
+
+
+def test_entry_point_target_mismatch_fails(tmp_path: Path) -> None:
+    component = _component("quillan")
+    wheel = tmp_path / component.release.wheel
+    altered = tuple(
+        replace(item, target="quillan.cli:other")
+        if item.group == "console_scripts" and item.name == "quillan"
+        else item
+        for item in component.entry_points
+    )
+    digest = _write_wheel(wheel, component, entry_points=altered)
+
+    with pytest.raises(
+        ArtifactVerificationError,
+        match="entry-point metadata",
+    ):
+        verify_component_wheel(_with_test_digest(component, digest), wheel)
+
+
+def test_filename_mismatch_fails(tmp_path: Path) -> None:
+    component = _component("concord")
+    wheel = tmp_path / "wrong.whl"
+    digest = _write_wheel(wheel, component)
+
+    with pytest.raises(
+        ArtifactVerificationError,
+        match="filename mismatch",
+    ):
+        verify_component_wheel(_with_test_digest(component, digest), wheel)

--- a/tests/test_package_compatibility.py
+++ b/tests/test_package_compatibility.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.check_package import PackageValidationError, validate_wheel
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = (
+    ROOT / "paper_data_suite" / "data" / "release_compatibility_v1.json"
+)
+
+_PACKAGE_FILES = (
+    "paper_data_suite/__init__.py",
+    "paper_data_suite/__main__.py",
+    "paper_data_suite/_version.py",
+    "paper_data_suite/cli.py",
+    "paper_data_suite/compatibility.py",
+    "paper_data_suite/data/__init__.py",
+    "paper_data_suite/py.typed",
+)
+
+
+def _build_wheel(
+    path: Path,
+    *,
+    include_manifest: bool = True,
+    manifest_version: str | None = None,
+) -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    if manifest_version is not None:
+        manifest["suite"]["version"] = manifest_version
+
+    metadata = "\n".join(
+        (
+            "Metadata-Version: 2.4",
+            "Name: paper-data-suite",
+            "Version: 0.1.0.dev0",
+            "Requires-Python: >=3.11",
+            "Requires-Dist: pds-core<0.7,>=0.6",
+            "",
+        )
+    )
+    entry_points = "\n".join(
+        (
+            "[console_scripts]",
+            "pds = paper_data_suite.cli:main",
+            "",
+        )
+    )
+
+    with zipfile.ZipFile(path, "w") as wheel:
+        for member in _PACKAGE_FILES:
+            wheel.writestr(member, "")
+        if include_manifest:
+            wheel.writestr(
+                "paper_data_suite/data/release_compatibility_v1.json",
+                json.dumps(manifest, sort_keys=True),
+            )
+        wheel.writestr(
+            "paper_data_suite-0.1.0.dev0.dist-info/METADATA",
+            metadata,
+        )
+        wheel.writestr(
+            "paper_data_suite-0.1.0.dev0.dist-info/entry_points.txt",
+            entry_points,
+        )
+
+
+def test_package_validator_accepts_manifest_bearing_wheel(
+    tmp_path: Path,
+) -> None:
+    wheel = tmp_path / "paper_data_suite-0.1.0.dev0-py3-none-any.whl"
+    _build_wheel(wheel)
+
+    validate_wheel(wheel)
+
+
+def test_package_validator_rejects_missing_manifest(tmp_path: Path) -> None:
+    wheel = tmp_path / "paper_data_suite-0.1.0.dev0-py3-none-any.whl"
+    _build_wheel(wheel, include_manifest=False)
+
+    with pytest.raises(
+        PackageValidationError,
+        match="missing required package files",
+    ):
+        validate_wheel(wheel)
+
+
+def test_package_validator_rejects_manifest_version_drift(
+    tmp_path: Path,
+) -> None:
+    wheel = tmp_path / "paper_data_suite-0.1.0.dev0-py3-none-any.whl"
+    _build_wheel(wheel, manifest_version="0.1.0")
+
+    with pytest.raises(
+        PackageValidationError,
+        match="manifest suite version",
+    ):
+        validate_wheel(wheel)


### PR DESCRIPTION
## Summary

Completes #4 by defining the first machine-readable Paper Data Suite release compatibility manifest.

This establishes a fail-closed, suite-owned declaration of the exact published PDS component artifacts and public integration surfaces qualified by the current `paper-data-suite` development version.

## What this adds

- bundled `release_compatibility_v1.json` contract data;
- immutable typed compatibility models and installed-package-safe loader;
- explicit suite-qualified Python range `>=3.11,<3.15`;
- exact qualification of:
  - PDS Core 0.6.0;
  - Concord 0.2.0;
  - Quillan 0.9.0;
  - ScoreForm 0.10.0;
  - Vitrine 0.2.0;
- exact official GitHub Release wheel filenames and SHA-256 digests;
- independent console-script, routing-module, and publication-producer expectations;
- Poppler/`pdftoppm` prerequisite declarations where supported by the owning release contracts;
- strict manifest parsing and invariant validation;
- offline published-wheel inspection and authentication tooling;
- built-wheel compatibility-resource validation;
- isolated installed-wheel compatibility loading with network access blocked;
- CI authentication of all declared release artifacts;
- normative compatibility-manifest architecture documentation;
- README reconciliation for exact suite qualification.

Meridian is intentionally not qualified because the audited source identity remains development-versioned. Portia is intentionally absent because it does not yet have an executable application release.

## Trust and architecture boundaries

The manifest distinguishes:

```text
package metadata compatibility
!=
suite-qualified release composition
```

It does not act as:

- a package index;
- a dependency resolver;
- a transitive lock file;
- an installer or update engine;
- a historical release catalog;
- a runtime installed-state report;
- or a replacement for component wheel metadata.

Compatibility is explicit and fail-closed. The implementation does not infer support from semver proximity, newest installed versions, dependency resolution, mutable branches, or plugin presence.

The embedded manifest authenticates subordinate PDS component wheels only. It deliberately does not attempt to self-hash the containing `paper-data-suite` wheel.

## Validation

Local validation completed successfully on Windows / Python 3.11:

```text
54 tests passed
Ruff passed
strict Mypy passed
pip check passed
compatibility manifest validation passed
sdist build passed
wheel build passed
Twine checks passed
built-wheel package validation passed
isolated installed-wheel smoke test passed
five exact published component artifacts authenticated
git diff --check passed
```

The isolated wheel smoke test confirms that the bundled compatibility resource loads outside the repository without requiring or importing sibling PDS applications and without network access.

The release-artifact verifier confirms exact:

- filenames;
- SHA-256 digests;
- distribution names;
- versions;
- Requires-Python metadata;
- public entry-point groups, names, and targets.

## Release impact

The suite remains:

```text
0.1.0.dev0
```

This PR does not create a final suite release, add bootstrap/update behavior, implement `pds doctor`, inspect installed module state, or expand the public `pds` CLI.

Later v0.1.0 issues consume this contract for bootstrap, diagnostics, module discovery, combined acceptance, and final release audit.

Closes #4