### PR TITLE
feat: add read-only pds doctor diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ and the primary command is `pds`.
 
 The suite shell is in pre-release development at `0.1.0.dev0`.
 
-The package foundation is installable, but there is **no supported public
-v0.1.0 release yet**. The current `pds` command intentionally exposes only
-minimal help and version behavior. Operational suite commands are added by later
-v0.1.0 issues.
+There is **no supported public v0.1.0 release yet**. The package foundation is
+installable and the first operational shell command, `pds doctor`, provides
+read-only environment diagnostics. Additional teacher-facing workflows are added
+by later v0.1.0 issues.
 
 The package metadata requires Python 3.11 or newer and
 `pds-core>=0.6,<0.7`. Those broad package requirements do **not** by themselves
@@ -79,6 +79,35 @@ The normative operational contract, trust hierarchy, apply behavior, failure
 semantics, and recovery boundaries are documented in
 [`docs/operations/windows-bootstrap.md`](docs/operations/windows-bootstrap.md).
 
+## Environment diagnostics
+
+Run the read-only suite health check with:
+
+```powershell
+pds doctor
+```
+
+To inspect one workspace without saving or initializing it:
+
+```powershell
+pds doctor --workspace "D:\School\Paper Data Suite"
+```
+
+`doctor` compares the running Python and installed suite/component metadata with
+the exact bundled compatibility manifest, checks declared public entry points,
+Python dependency consistency, applicable external command prerequisites, and
+uses public Core services for workspace, active-school-year, and registry health.
+It does not install, update, create, repair, or modify those resources.
+
+The current qualified Core contract does not expose failure-isolated provider
+execution diagnostics or shared module-reported readiness, so those deeper
+capabilities are reported honestly as `SKIP` rather than being reimplemented in
+the suite.
+
+The operational contract, status/exit semantics, privacy boundary, and
+installed-wheel acceptance requirements are documented in
+[`docs/operations/pds-doctor.md`](docs/operations/pds-doctor.md).
+
 ## Architecture direction
 
 The suite shell is an orchestration and teacher-convenience layer, not a second
@@ -115,20 +144,24 @@ After Core is installed:
 python -m pip install -e ".[dev]"
 ```
 
-The current foundation commands are:
+The current shell commands are:
 
 ```powershell
 pds
 pds --help
 pds --version
+pds doctor
+pds doctor --workspace <path>
 
 python -m paper_data_suite
 python -m paper_data_suite --help
 python -m paper_data_suite --version
+python -m paper_data_suite doctor
 ```
 
-These commands do not create or select a workspace, discover sibling
-applications, or perform classroom-data workflows.
+The help/version commands and `doctor` do not create or select a workspace or
+perform classroom-data mutation. `doctor --workspace` is an invocation-scoped
+inspection override only.
 
 ## Development validation
 
@@ -160,10 +193,12 @@ python .\scripts\verify_compatibility_artifacts.py `
   --artifact-dir <directory-containing-declared-wheels>
 ```
 
-The built-wheel smoke test creates an isolated environment and proves that the
-bundled compatibility resource loads beside Core without requiring or importing
-sibling PDS applications. The artifact verifier inspects release wheels directly;
-it does not install or import them.
+The built-wheel smoke test creates an isolated environment, removes source-tree
+shadowing inputs, proves that the bundled compatibility resource loads beside
+Core without requiring sibling PDS applications, and exercises installed
+`python -m paper_data_suite doctor` and `pds doctor` against a synthetic absent
+workspace path. The artifact verifier inspects release wheels directly; it does
+not install or import them.
 
 Do not place a real classroom PDS workspace inside this repository.
 
@@ -175,6 +210,8 @@ Do not place a real classroom PDS workspace inside this repository.
   — normative machine-readable suite release-qualification contract.
 - [`docs/operations/windows-bootstrap.md`](docs/operations/windows-bootstrap.md)
   — normative verified Windows bootstrap and exact update-planning workflow.
+- [`docs/operations/pds-doctor.md`](docs/operations/pds-doctor.md)
+  — read-only suite environment diagnostics, statuses, privacy, and acceptance.
 - [`docs/development-plan.md`](docs/development-plan.md) — suite-wide
   pilot-readiness and development program.
 - [`docs/pds-viz-identity.md`](docs/pds-viz-identity.md) — shared Paper Data

--- a/docs/operations/pds-doctor.md
+++ b/docs/operations/pds-doctor.md
@@ -1,0 +1,207 @@
+# `pds doctor` environment diagnostics
+
+`pds doctor` is the read-only health check for an installed Paper Data Suite
+environment. It compares the running environment with the release-compatibility
+manifest bundled in the installed `paper-data-suite` package and delegates shared
+workspace health to public PDS Core services.
+
+The command is diagnostic only. It does not install or update packages, install
+system software, create or select a workspace, change user configuration, repair
+Core state, clear locks, or modify module-owned records.
+
+## Commands
+
+Run the normal resolved-workspace check with:
+
+```powershell
+pds doctor
+```
+
+Inspect one workspace for this invocation only with:
+
+```powershell
+pds doctor --workspace "D:\School\Paper Data Suite"
+```
+
+The `--workspace` value is passed to Core's public workspace inspection service.
+It is not saved and the directory is not initialized or created.
+
+The equivalent module invocation is:
+
+```powershell
+python -m paper_data_suite doctor
+python -m paper_data_suite doctor --workspace "D:\School\Paper Data Suite"
+```
+
+## Status and exit semantics
+
+Each check has one of four statuses:
+
+- `PASS` — the check completed and the required condition is satisfied;
+- `WARN` — a non-blocking condition needs attention or stronger verification;
+- `FAIL` — a required condition is missing, incompatible, corrupt, or unusable;
+- `SKIP` — the check is not applicable or cannot run safely with the currently
+  available contract/prerequisites.
+
+A completed report exits with:
+
+- `0` when there are no `FAIL` results, including warning-only reports;
+- `1` when one or more `FAIL` results exist;
+- argparse's normal `2` for invalid command-line syntax.
+
+A failure in one independent area does not normally abort later diagnostics.
+Workspace-dependent checks become `SKIP` if Core cannot provide an accessible
+workspace rather than producing secondary failures.
+
+## Release authority
+
+The bundled release-compatibility manifest is the authority for:
+
+- qualified Python minors;
+- exact suite and component versions;
+- required versus optional components;
+- declared public entry-point metadata;
+- component capabilities;
+- manifest-declared external command prerequisites.
+
+`doctor` does not infer compatibility from repository `main`, package-manager
+"latest" results, or the fact that a newer package happens to install.
+
+A broad package dependency such as `pds-core>=0.6,<0.7` is not equivalent to the
+exact Core release qualified by the active suite manifest.
+
+## Diagnostic coverage
+
+The current command checks, in stable sections:
+
+### Runtime
+
+The running Python `major.minor` must be one of the tested minors in the bundled
+manifest. The report also identifies the running interpreter path.
+
+### Suite identity
+
+The installed `paper-data-suite` distribution must match the bundled suite
+manifest version.
+
+When the managed-environment marker `.pds-suite-environment.json` is present,
+`doctor` validates its suite version and compatibility-manifest SHA-256 using the
+suite's existing marker parser. A missing marker is a warning so development or
+manual installations remain diagnosable; an invalid or contradictory marker is a
+failure. `doctor` never creates or repairs the marker.
+
+### Packages
+
+Every component row in the active manifest is compared with installed distribution
+metadata without importing optional applications. Required components must be
+present at the exact qualified version. Optional components may be absent, but an
+installed optional component at another version is a failure.
+
+### Python dependencies
+
+`doctor` runs the read-only equivalent of:
+
+```text
+<running Python> -m pip check
+```
+
+with captured output and a bounded timeout. It does not run any pip installation
+or upgrade command.
+
+### Public entry points
+
+For exactly qualified installed components, `doctor` compares installed metadata
+with the manifest's expected entry-point group, name, target, and owning
+distribution. It detects missing, mismatched, duplicate, and foreign/conflicting
+metadata without loading optional provider code.
+
+### Core public contracts
+
+The suite verifies that the public Core services it requires for this command are
+available. Workspace, school-year, and registry state are consumed through public
+Core APIs rather than by duplicating Core storage formats or private validators.
+
+### External prerequisites
+
+External commands are checked generically from the manifest and only when an exact
+qualified installed component actually requires them on the current platform.
+
+For the current manifest this includes `pdftoppm` for the qualified ScoreForm and
+Quillan PDF-rasterization workflows on supported platforms. If those applications
+are absent, their external prerequisite is not treated as a suite blocker.
+
+Python imaging packages are not duplicated in a suite-owned dependency table;
+ordinary declared dependency integrity remains the responsibility of package
+metadata plus `pip check`, while functional imaging smoke tests remain module-owned.
+
+### Workspace and active school year
+
+Core resolves the workspace using its normal precedence unless `--workspace` is
+supplied. The suite reports Core's bounded path/source/existence/directory/writable
+status without claiming stronger workspace authenticity than Core's public
+inspection contract proves.
+
+For an accessible workspace, the active school year is read through Core. No year
+is a warning; malformed/unreadable school-year state is a failure.
+
+### Core registry
+
+For an accessible workspace, `doctor` uses Core's bounded non-mutating registry
+status with deep publication-manifest verification disabled by default. It reports
+canonical validity, contract compatibility when available, catalog state/currency,
+coordination state, and bounded warning/error finding codes/counts.
+
+The suite does not rebuild the catalog, remove locks, repair records, or read raw
+student evidence merely to prove environment health.
+
+## Reduced provider fidelity in the current qualified Core contract
+
+The current suite-qualified Core contract does not expose a failure-isolated
+health inventory for routing/publication provider execution, nor a shared
+module-operations readiness contract.
+
+`doctor` therefore reports those capabilities as `SKIP` with reduced diagnostic
+fidelity. It does **not** call Core's strict runtime discovery and does not import
+module-private internals to simulate the missing contracts.
+
+When a future suite composition qualifies Core contracts that expose these neutral
+surfaces, the suite can consume them without changing ownership: Core validates
+Core-defined provider contracts, modules own readiness facts, and the suite owns
+aggregation and teacher-facing `PASS`/`WARN`/`FAIL`/`SKIP` presentation.
+
+## Privacy and bounded output
+
+Normal doctor output must not expose student names, answers, scores, writing,
+behavior narratives, scans, portfolio artifacts, raw module records, credentials,
+or arbitrary environment dumps.
+
+Core registry findings are summarized with bounded codes/counts rather than raw
+record payloads. Exception tracebacks are not part of the user-facing diagnostic
+contract.
+
+## Installed-wheel acceptance
+
+Release validation must exercise `doctor` from the built wheel, not only from the
+repository source tree.
+
+`scripts/smoke_test_wheel.py` creates an isolated virtual environment, installs the
+built suite wheel beside the exact Core wheel supplied to the script, removes
+`PYTHONPATH`, runs from a separate empty directory, and exercises both:
+
+```text
+python -m paper_data_suite doctor
+pds doctor
+```
+
+The smoke environment points workspace resolution at a deliberately absent
+synthetic path so the diagnostic run cannot read a developer's real classroom
+workspace. The command must leave that path and the working directory unchanged.
+
+Run the existing package validation flow with:
+
+```powershell
+python .\scripts\check_package.py <suite-wheel>
+python .\scripts\smoke_test_wheel.py <suite-wheel> <core-wheel>
+```
+
+The smoke script exits nonzero if its acceptance assertions fail.

--- a/paper_data_suite/cli.py
+++ b/paper_data_suite/cli.py
@@ -1,20 +1,22 @@
-"""Minimal command-line foundation for Paper Data Suite."""
+"""Command-line interface for the Paper Data Suite shell."""
 
 from __future__ import annotations
 
 import argparse
 from collections.abc import Sequence
+from pathlib import Path
 
 from paper_data_suite._version import __version__
+from paper_data_suite.doctor import collect_doctor_diagnostics, render_doctor_report
 
 
 def build_parser() -> argparse.ArgumentParser:
-    """Build the package-foundation command-line parser."""
+    """Build the Paper Data Suite command-line parser."""
     parser = argparse.ArgumentParser(
         prog="pds",
         description=(
-            "Paper Data Suite suite shell. Operational commands are added by "
-            "later v0.1.0 development issues."
+            "Paper Data Suite suite shell. Operational commands provide bounded, "
+            "teacher-facing suite workflows."
         ),
     )
     parser.add_argument(
@@ -22,12 +24,33 @@ def build_parser() -> argparse.ArgumentParser:
         action="version",
         version=f"%(prog)s {__version__}",
     )
+    subparsers = parser.add_subparsers(dest="command")
+    doctor = subparsers.add_parser(
+        "doctor",
+        help="diagnose the installed suite environment without modifying it",
+        description=(
+            "Diagnose Paper Data Suite runtime, packages, dependencies, public "
+            "integration contracts, workspace access, and Core registry health."
+        ),
+    )
+    doctor.add_argument(
+        "--workspace",
+        type=Path,
+        help=(
+            "inspect this workspace for this invocation only; do not save or "
+            "initialize it"
+        ),
+    )
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Run the minimal Paper Data Suite command-line interface."""
+    """Run the Paper Data Suite command-line interface."""
     parser = build_parser()
-    parser.parse_args(argv)
+    arguments = parser.parse_args(argv)
+    if arguments.command == "doctor":
+        report = collect_doctor_diagnostics(workspace=arguments.workspace)
+        print(render_doctor_report(report), end="")
+        return report.exit_code
     parser.print_help()
     return 0

--- a/paper_data_suite/doctor.py
+++ b/paper_data_suite/doctor.py
@@ -1,0 +1,1846 @@
+"""Typed, read-only diagnostic primitives for the Paper Data Suite shell."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from importlib import import_module, metadata
+from pathlib import Path
+from typing import Protocol, cast
+
+from paper_data_suite.bootstrap import (
+    BootstrapPlanningError,
+    normalize_distribution_name,
+)
+from paper_data_suite.compatibility import (
+    ComponentCompatibility,
+    ExternalPrerequisite,
+    ReleaseCompatibilityManifest,
+    load_release_compatibility_manifest,
+    release_compatibility_manifest_sha256,
+)
+from paper_data_suite.environment_inspection import (
+    ENVIRONMENT_MARKER_FILENAME,
+    EnvironmentInspectionError,
+    parse_environment_marker,
+)
+
+DistributionVersionLookup = Callable[[str], str]
+CommandLookup = Callable[[str], str | None]
+ManifestDigestLookup = Callable[[], str]
+ModuleImporter = Callable[[str], object]
+
+
+@dataclass(frozen=True, slots=True)
+class EntryPointObservation:
+    """Metadata-only observation of one installed public entry point."""
+
+    group: str
+    name: str
+    target: str
+    distribution: str
+    distribution_version: str
+
+
+EntryPointInventoryLookup = Callable[[], Sequence[EntryPointObservation]]
+
+
+class CommandRunner(Protocol):
+    """Bounded command-execution shape used by read-only diagnostics."""
+
+    def __call__(
+        self,
+        args: Sequence[str],
+        *,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]: ...
+
+
+class DiagnosticStatus(str, Enum):
+    """Bounded outcome for one doctor diagnostic check."""
+
+    PASS = "PASS"
+    WARN = "WARN"
+    FAIL = "FAIL"
+    SKIP = "SKIP"
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticCheck:
+    """One deterministic, privacy-bounded diagnostic result."""
+
+    section: str
+    code: str
+    status: DiagnosticStatus
+    summary: str
+    component_id: str | None = None
+    detail: str | None = None
+    remediation: str | None = None
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("section", self.section),
+            ("code", self.code),
+            ("summary", self.summary),
+        ):
+            if not value or not value.strip():
+                raise ValueError(f"diagnostic {label} must be a non-empty string")
+        if self.component_id is not None and not self.component_id.strip():
+            raise ValueError("diagnostic component_id cannot be blank")
+        if self.detail is not None and not self.detail.strip():
+            raise ValueError("diagnostic detail cannot be blank")
+        if self.remediation is not None and not self.remediation.strip():
+            raise ValueError("diagnostic remediation cannot be blank")
+
+
+@dataclass(frozen=True, slots=True)
+class DoctorReport:
+    """Immutable ordered collection of doctor diagnostic checks."""
+
+    checks: tuple[DiagnosticCheck, ...]
+
+    @property
+    def failure_count(self) -> int:
+        """Return the number of blocking diagnostic failures."""
+        return sum(check.status is DiagnosticStatus.FAIL for check in self.checks)
+
+    @property
+    def warning_count(self) -> int:
+        """Return the number of non-blocking diagnostic warnings."""
+        return sum(check.status is DiagnosticStatus.WARN for check in self.checks)
+
+    @property
+    def exit_code(self) -> int:
+        """Return the CLI exit status implied by this completed report."""
+        return 1 if self.failure_count else 0
+
+    def for_section(self, section: str) -> tuple[DiagnosticCheck, ...]:
+        """Return checks in their original order for one section."""
+        return tuple(check for check in self.checks if check.section == section)
+
+
+def combine_reports(*reports: DoctorReport) -> DoctorReport:
+    """Combine already ordered diagnostic reports without changing their checks."""
+    return DoctorReport(tuple(check for report in reports for check in report.checks))
+
+
+def _lookup_distribution_version(
+    distribution: str,
+    version_lookup: DistributionVersionLookup,
+) -> str | None:
+    try:
+        return version_lookup(distribution)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _python_check(
+    manifest: ReleaseCompatibilityManifest,
+    *,
+    python_version: tuple[int, int, int],
+    python_executable: str,
+) -> DiagnosticCheck:
+    major, minor, micro = python_version
+    observed_minor = f"{major}.{minor}"
+    observed_version = f"{major}.{minor}.{micro}"
+    qualified = observed_minor in manifest.python.tested_minors
+    if qualified:
+        return DiagnosticCheck(
+            section="Runtime",
+            code="python.qualified",
+            status=DiagnosticStatus.PASS,
+            summary=f"Python {observed_version} is suite-qualified.",
+            detail=f"Interpreter: {python_executable}",
+        )
+
+    qualified_text = ", ".join(manifest.python.tested_minors)
+    return DiagnosticCheck(
+        section="Runtime",
+        code="python.unsupported",
+        status=DiagnosticStatus.FAIL,
+        summary=f"Python {observed_version} is not suite-qualified.",
+        detail=(
+            f"Interpreter: {python_executable}; qualified minors: {qualified_text}."
+        ),
+        remediation=(
+            "Run this Paper Data Suite release with a qualified Python minor "
+            f"({qualified_text}), then rerun `pds doctor`."
+        ),
+    )
+
+
+def _suite_package_check(
+    manifest: ReleaseCompatibilityManifest,
+    *,
+    version_lookup: DistributionVersionLookup,
+) -> DiagnosticCheck:
+    distribution = manifest.suite.distribution
+    expected = manifest.suite.version
+    observed = _lookup_distribution_version(distribution, version_lookup)
+    if observed is None:
+        return DiagnosticCheck(
+            section="Suite",
+            code="suite.distribution_missing",
+            status=DiagnosticStatus.FAIL,
+            summary=f"{distribution} distribution metadata is unavailable.",
+            detail=f"Expected suite version: {expected}.",
+            remediation=(
+                "Reinstall this Paper Data Suite release through the verified suite "
+                "bootstrap/update workflow, then rerun `pds doctor`."
+            ),
+        )
+    if observed != expected:
+        return DiagnosticCheck(
+            section="Suite",
+            code="suite.version_mismatch",
+            status=DiagnosticStatus.FAIL,
+            summary=(
+                f"{distribution} {observed} does not match the bundled suite "
+                f"manifest version {expected}."
+            ),
+            remediation=(
+                f"Install the suite-qualified {distribution} {expected} release, "
+                "then rerun `pds doctor`."
+            ),
+        )
+    return DiagnosticCheck(
+        section="Suite",
+        code="suite.version_match",
+        status=DiagnosticStatus.PASS,
+        summary=f"{distribution} {observed} matches the bundled suite manifest.",
+    )
+
+
+def _component_package_check(
+    component: ComponentCompatibility,
+    *,
+    version_lookup: DistributionVersionLookup,
+) -> DiagnosticCheck:
+    observed = _lookup_distribution_version(component.distribution, version_lookup)
+    if observed is None:
+        if component.required:
+            return DiagnosticCheck(
+                section="Packages",
+                code="package.required_missing",
+                status=DiagnosticStatus.FAIL,
+                component_id=component.component_id,
+                summary=(
+                    f"{component.display_name} is required but "
+                    f"{component.distribution} is not installed."
+                ),
+                detail=f"Required version: {component.version}.",
+                remediation=(
+                    f"Install the suite-qualified {component.distribution} "
+                    f"{component.version} release, then rerun `pds doctor`."
+                ),
+            )
+        return DiagnosticCheck(
+            section="Packages",
+            code="package.optional_absent",
+            status=DiagnosticStatus.SKIP,
+            component_id=component.component_id,
+            summary=f"{component.display_name} is optional and is not installed.",
+            detail=f"Suite-qualified version when installed: {component.version}.",
+        )
+
+    if observed != component.version:
+        return DiagnosticCheck(
+            section="Packages",
+            code="package.version_mismatch",
+            status=DiagnosticStatus.FAIL,
+            component_id=component.component_id,
+            summary=(
+                f"{component.display_name} has {component.distribution} {observed}; "
+                f"the suite qualifies exactly {component.version}."
+            ),
+            remediation=(
+                f"Install the suite-qualified {component.distribution} "
+                f"{component.version} release, then rerun `pds doctor`."
+            ),
+        )
+
+    return DiagnosticCheck(
+        section="Packages",
+        code="package.version_match",
+        status=DiagnosticStatus.PASS,
+        component_id=component.component_id,
+        summary=(
+            f"{component.display_name} {component.distribution} {observed} "
+            "matches the suite manifest."
+        ),
+    )
+
+
+def collect_runtime_package_diagnostics(
+    manifest: ReleaseCompatibilityManifest | None = None,
+    *,
+    python_version: tuple[int, int, int] | None = None,
+    python_executable: str | None = None,
+    version_lookup: DistributionVersionLookup = metadata.version,
+) -> DoctorReport:
+    """Collect deterministic runtime and package diagnostics.
+
+    The check uses only the running interpreter and installed distribution metadata.
+    """
+    active_manifest = manifest or load_release_compatibility_manifest()
+    observed_python = python_version or (
+        sys.version_info.major,
+        sys.version_info.minor,
+        sys.version_info.micro,
+    )
+    observed_executable = python_executable or sys.executable
+
+    checks: list[DiagnosticCheck] = [
+        _python_check(
+            active_manifest,
+            python_version=observed_python,
+            python_executable=observed_executable,
+        ),
+        _suite_package_check(active_manifest, version_lookup=version_lookup),
+    ]
+    checks.extend(
+        _component_package_check(component, version_lookup=version_lookup)
+        for component in active_manifest.components
+    )
+    return DoctorReport(tuple(checks))
+
+
+def _environment_marker_check(
+    manifest: ReleaseCompatibilityManifest,
+    *,
+    environment_root: Path,
+    manifest_digest_lookup: ManifestDigestLookup,
+) -> DiagnosticCheck:
+    marker_path = environment_root / ENVIRONMENT_MARKER_FILENAME
+    if not marker_path.exists():
+        return DiagnosticCheck(
+            section="Suite",
+            code="suite.marker_missing",
+            status=DiagnosticStatus.WARN,
+            summary="Suite environment ownership marker is not present.",
+            detail=f"Expected marker: {marker_path}",
+            remediation=(
+                "For a managed installation, use the verified suite bootstrap/update "
+                "workflow. Development and manual environments may continue without "
+                "a marker."
+            ),
+        )
+    if not marker_path.is_file():
+        return DiagnosticCheck(
+            section="Suite",
+            code="suite.marker_unreadable",
+            status=DiagnosticStatus.FAIL,
+            summary="Suite environment ownership marker is not a regular file.",
+            detail=f"Marker path: {marker_path}",
+            remediation=(
+                "Restore this environment through the verified suite bootstrap/update "
+                "workflow, then rerun `pds doctor`."
+            ),
+        )
+
+    try:
+        marker = parse_environment_marker(marker_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, EnvironmentInspectionError) as error:
+        return DiagnosticCheck(
+            section="Suite",
+            code="suite.marker_invalid",
+            status=DiagnosticStatus.FAIL,
+            summary="Suite environment ownership marker is invalid.",
+            detail=str(error),
+            remediation=(
+                "Restore this environment through the verified suite bootstrap/update "
+                "workflow; do not hand-edit the marker. Then rerun `pds doctor`."
+            ),
+        )
+
+    expected_digest = manifest_digest_lookup()
+    mismatches: list[str] = []
+    if marker.suite_version != manifest.suite.version:
+        mismatches.append(
+            f"suite version {marker.suite_version!r} != {manifest.suite.version!r}"
+        )
+    if marker.compatibility_manifest_sha256 != expected_digest:
+        mismatches.append("compatibility manifest digest does not match this suite")
+    if mismatches:
+        return DiagnosticCheck(
+            section="Suite",
+            code="suite.marker_mismatch",
+            status=DiagnosticStatus.FAIL,
+            summary=(
+                "Suite environment ownership marker belongs to another composition."
+            ),
+            detail="; ".join(mismatches) + ".",
+            remediation=(
+                "Use the verified suite update workflow to reconcile the environment "
+                "with this release, then rerun `pds doctor`."
+            ),
+        )
+
+    return DiagnosticCheck(
+        section="Suite",
+        code="suite.marker_match",
+        status=DiagnosticStatus.PASS,
+        summary="Suite environment ownership marker matches this release.",
+        detail=f"Marker: {marker_path}",
+    )
+
+
+def _bounded_command_output(result: subprocess.CompletedProcess[str]) -> str | None:
+    lines = [
+        line.strip()
+        for text in (result.stdout, result.stderr)
+        for line in text.splitlines()
+        if line.strip()
+    ]
+    if not lines:
+        return None
+    bounded = " | ".join(lines[:4])
+    if len(bounded) > 500:
+        return bounded[:497] + "..."
+    return bounded
+
+
+def _default_command_runner(
+    args: Sequence[str],
+    *,
+    capture_output: bool,
+    text: bool,
+    check: bool,
+    timeout: float,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        capture_output=capture_output,
+        text=text,
+        check=check,
+        timeout=timeout,
+    )
+
+
+def _python_dependency_check(
+    *,
+    python_executable: str,
+    command_runner: CommandRunner,
+    timeout_seconds: float,
+) -> DiagnosticCheck:
+    command = (python_executable, "-m", "pip", "check")
+    try:
+        result = command_runner(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        return DiagnosticCheck(
+            section="Dependencies",
+            code="dependencies.pip_check_timeout",
+            status=DiagnosticStatus.FAIL,
+            summary="Python dependency consistency check timed out.",
+            detail=f"Timeout: {timeout_seconds:g} seconds.",
+            remediation=(
+                "Verify that pip is healthy in this environment, then rerun "
+                "`pds doctor`."
+            ),
+        )
+    except OSError as error:
+        return DiagnosticCheck(
+            section="Dependencies",
+            code="dependencies.pip_check_unavailable",
+            status=DiagnosticStatus.FAIL,
+            summary="Python dependency consistency check could not be started.",
+            detail=str(error),
+            remediation=(
+                "Verify the current Python environment and its pip installation, then "
+                "rerun `pds doctor`."
+            ),
+        )
+
+    detail = _bounded_command_output(result)
+    if result.returncode == 0:
+        return DiagnosticCheck(
+            section="Dependencies",
+            code="dependencies.consistent",
+            status=DiagnosticStatus.PASS,
+            summary="Installed Python package dependencies are consistent.",
+            detail=detail,
+        )
+    return DiagnosticCheck(
+        section="Dependencies",
+        code="dependencies.inconsistent",
+        status=DiagnosticStatus.FAIL,
+        summary="Installed Python package dependencies are inconsistent.",
+        detail=detail or f"pip check exited with status {result.returncode}.",
+        remediation=(
+            "Repair the installed suite environment through the verified bootstrap/"
+            "update workflow, then rerun `pds doctor`."
+        ),
+    )
+
+
+def _platform_name(platform: str) -> str:
+    normalized = platform.lower()
+    if normalized.startswith(("win32", "cygwin", "msys")):
+        return "windows"
+    if normalized.startswith("linux"):
+        return "linux"
+    if normalized == "darwin":
+        return "macos"
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class _PrerequisiteUse:
+    prerequisite: ExternalPrerequisite
+    consumers: tuple[ComponentCompatibility, ...]
+
+
+def _applicable_prerequisites(
+    manifest: ReleaseCompatibilityManifest,
+    *,
+    platform: str,
+) -> tuple[_PrerequisiteUse, ...]:
+    by_id: dict[str, tuple[ExternalPrerequisite, list[ComponentCompatibility]]] = {}
+    for component in manifest.components:
+        for prerequisite in component.external_prerequisites:
+            if platform not in prerequisite.platforms:
+                continue
+            existing = by_id.get(prerequisite.prerequisite_id)
+            if existing is None:
+                by_id[prerequisite.prerequisite_id] = (prerequisite, [component])
+                continue
+            canonical, consumers = existing
+            if prerequisite != canonical:
+                # Keep both definitions visible to the caller through duplicate uses.
+                conflict_id = f"{prerequisite.prerequisite_id}:{component.component_id}"
+                by_id[conflict_id] = (prerequisite, [component])
+                continue
+            consumers.append(component)
+
+    return tuple(
+        _PrerequisiteUse(prerequisite, tuple(consumers))
+        for _, (prerequisite, consumers) in sorted(by_id.items())
+    )
+
+
+def _qualified_installed_consumers(
+    use: _PrerequisiteUse,
+    *,
+    version_lookup: DistributionVersionLookup,
+) -> tuple[ComponentCompatibility, ...]:
+    return tuple(
+        component
+        for component in use.consumers
+        if _lookup_distribution_version(component.distribution, version_lookup)
+        == component.version
+    )
+
+
+def _external_prerequisite_check(
+    use: _PrerequisiteUse,
+    *,
+    version_lookup: DistributionVersionLookup,
+    command_lookup: CommandLookup,
+) -> DiagnosticCheck:
+    prerequisite = use.prerequisite
+    active_consumers = _qualified_installed_consumers(
+        use,
+        version_lookup=version_lookup,
+    )
+    consumer_names = ", ".join(
+        component.display_name for component in active_consumers
+    )
+    commands = ", ".join(prerequisite.commands)
+
+    if not active_consumers:
+        return DiagnosticCheck(
+            section="External prerequisites",
+            code="external.not_required",
+            status=DiagnosticStatus.SKIP,
+            summary=(
+                f"{prerequisite.prerequisite_id} is not required by an installed "
+                "suite-qualified component."
+            ),
+            detail=f"Accepted command names: {commands}.",
+        )
+
+    found: tuple[tuple[str, str], ...] = tuple(
+        (command, path)
+        for command in prerequisite.commands
+        if (path := command_lookup(command)) is not None
+    )
+    if found:
+        command, path = found[0]
+        return DiagnosticCheck(
+            section="External prerequisites",
+            code="external.command_available",
+            status=DiagnosticStatus.PASS,
+            summary=f"{command} is available for {consumer_names}.",
+            detail=f"{prerequisite.purpose}; resolved command: {path}",
+        )
+
+    status = DiagnosticStatus.FAIL if prerequisite.required else DiagnosticStatus.WARN
+    return DiagnosticCheck(
+        section="External prerequisites",
+        code="external.command_missing",
+        status=status,
+        summary=(
+            f"Required command for {consumer_names} was not found."
+            if prerequisite.required
+            else f"Optional command for {consumer_names} was not found."
+        ),
+        detail=f"{prerequisite.purpose}; accepted command names: {commands}.",
+        remediation=(
+            f"Install or expose {commands} on PATH for this environment, then rerun "
+            "`pds doctor`."
+        ),
+    )
+
+
+def collect_environment_dependency_diagnostics(
+    manifest: ReleaseCompatibilityManifest | None = None,
+    *,
+    environment_root: Path | None = None,
+    python_executable: str | None = None,
+    platform: str | None = None,
+    version_lookup: DistributionVersionLookup = metadata.version,
+    manifest_digest_lookup: ManifestDigestLookup = (
+        release_compatibility_manifest_sha256
+    ),
+    command_lookup: CommandLookup = shutil.which,
+    command_runner: CommandRunner = _default_command_runner,
+    pip_check_timeout_seconds: float = 20.0,
+) -> DoctorReport:
+    """Check environment ownership, Python dependencies, and external commands.
+
+    All checks are read-only. External prerequisites are activated only by components
+    installed at the exact version qualified by the bundled suite manifest.
+    """
+    active_manifest = manifest or load_release_compatibility_manifest()
+    root = (environment_root or Path(sys.prefix)).expanduser().resolve()
+    executable = python_executable or sys.executable
+    active_platform = _platform_name(platform or sys.platform)
+
+    checks: list[DiagnosticCheck] = [
+        _environment_marker_check(
+            active_manifest,
+            environment_root=root,
+            manifest_digest_lookup=manifest_digest_lookup,
+        ),
+        _python_dependency_check(
+            python_executable=executable,
+            command_runner=command_runner,
+            timeout_seconds=pip_check_timeout_seconds,
+        ),
+    ]
+    checks.extend(
+        _external_prerequisite_check(
+            use,
+            version_lookup=version_lookup,
+            command_lookup=command_lookup,
+        )
+        for use in _applicable_prerequisites(
+            active_manifest,
+            platform=active_platform,
+        )
+    )
+    return DoctorReport(tuple(checks))
+
+
+_CORE_PUBLIC_CONTRACTS: tuple[tuple[str, str, str], ...] = (
+    ("pds_core.workspace", "inspect_workspace_root", "workspace inspection"),
+    ("pds_core.school_years", "get_active_school_year", "active school year"),
+    (
+        "pds_core.registry_audit",
+        "get_academic_registry_status",
+        "academic registry status",
+    ),
+)
+
+
+def _installed_entry_point_inventory() -> tuple[EntryPointObservation, ...]:
+    """Read installed entry-point metadata without loading entry-point targets."""
+    observations: list[EntryPointObservation] = []
+    for distribution in metadata.distributions():
+        try:
+            owner = distribution.metadata["Name"]
+            version = distribution.version
+            entry_points = tuple(distribution.entry_points)
+        except (KeyError, OSError, TypeError, ValueError):
+            continue
+        if not owner or not version:
+            continue
+        for entry_point in entry_points:
+            observations.append(
+                EntryPointObservation(
+                    group=entry_point.group,
+                    name=entry_point.name,
+                    target=entry_point.value,
+                    distribution=str(owner),
+                    distribution_version=str(version),
+                )
+            )
+    return tuple(
+        sorted(
+            observations,
+            key=lambda item: (
+                item.group,
+                item.name,
+                normalize_distribution_name(item.distribution),
+                item.distribution_version,
+                item.target,
+            ),
+        )
+    )
+
+
+def _qualified_component(
+    component: ComponentCompatibility,
+    *,
+    version_lookup: DistributionVersionLookup,
+) -> bool:
+    return (
+        _lookup_distribution_version(component.distribution, version_lookup)
+        == component.version
+    )
+
+
+def _entry_point_component_skip(
+    component: ComponentCompatibility,
+) -> DiagnosticCheck:
+    return DiagnosticCheck(
+        section="Entry points",
+        code="entry_point.component_unqualified",
+        status=DiagnosticStatus.SKIP,
+        component_id=component.component_id,
+        summary=(
+            f"{component.display_name} entry points were not checked because the "
+            "suite-qualified package version is not installed."
+        ),
+    )
+
+
+def _normalized_owner(value: str) -> str | None:
+    try:
+        return normalize_distribution_name(value)
+    except BootstrapPlanningError:
+        return None
+
+
+def _entry_point_check(
+    component: ComponentCompatibility,
+    expectation_group: str,
+    expectation_name: str,
+    expectation_target: str,
+    *,
+    inventory: Sequence[EntryPointObservation],
+) -> DiagnosticCheck:
+    expected_owner = normalize_distribution_name(component.distribution)
+    same_identity = tuple(
+        item
+        for item in inventory
+        if item.group == expectation_group and item.name == expectation_name
+    )
+    owned = tuple(
+        item
+        for item in same_identity
+        if _normalized_owner(item.distribution) == expected_owner
+    )
+    foreign = tuple(
+        item
+        for item in same_identity
+        if _normalized_owner(item.distribution) != expected_owner
+    )
+    identity = f"{expectation_group}:{expectation_name}"
+
+    if not owned:
+        if foreign:
+            owners = ", ".join(
+                sorted({item.distribution for item in foreign}, key=str.lower)
+            )
+            return DiagnosticCheck(
+                section="Entry points",
+                code="entry_point.owner_mismatch",
+                status=DiagnosticStatus.FAIL,
+                component_id=component.component_id,
+                summary=(
+                    f"{identity} is not owned by the suite-qualified "
+                    f"{component.distribution} distribution."
+                ),
+                detail=f"Observed owner(s): {owners}.",
+                remediation=(
+                    f"Reinstall {component.distribution} {component.version} through "
+                    "the verified suite workflow, then rerun `pds doctor`."
+                ),
+            )
+        return DiagnosticCheck(
+            section="Entry points",
+            code="entry_point.missing",
+            status=DiagnosticStatus.FAIL,
+            component_id=component.component_id,
+            summary=f"Expected public entry point {identity} is missing.",
+            detail=(
+                f"Expected owner: {component.distribution}; target: "
+                f"{expectation_target}."
+            ),
+            remediation=(
+                f"Reinstall {component.distribution} {component.version} through the "
+                "verified suite workflow, then rerun `pds doctor`."
+            ),
+        )
+
+    if len(owned) != 1:
+        targets = ", ".join(sorted(item.target for item in owned))
+        return DiagnosticCheck(
+            section="Entry points",
+            code="entry_point.duplicate",
+            status=DiagnosticStatus.FAIL,
+            component_id=component.component_id,
+            summary=(
+                f"{identity} has duplicate definitions in "
+                f"{component.distribution}."
+            ),
+            detail=f"Observed targets: {targets}.",
+            remediation=(
+                f"Reinstall {component.distribution} {component.version} into a clean "
+                "suite environment, then rerun `pds doctor`."
+            ),
+        )
+
+    observed = owned[0]
+    if observed.target != expectation_target:
+        return DiagnosticCheck(
+            section="Entry points",
+            code="entry_point.target_mismatch",
+            status=DiagnosticStatus.FAIL,
+            component_id=component.component_id,
+            summary=f"{identity} has an unexpected target.",
+            detail=(
+                f"Expected {expectation_target}; observed {observed.target}; owner "
+                f"{observed.distribution} {observed.distribution_version}."
+            ),
+            remediation=(
+                f"Reinstall {component.distribution} {component.version} through the "
+                "verified suite workflow, then rerun `pds doctor`."
+            ),
+        )
+
+    if foreign:
+        conflicts = ", ".join(
+            sorted(
+                {
+                    f"{item.distribution} {item.distribution_version} -> {item.target}"
+                    for item in foreign
+                },
+                key=str.lower,
+            )
+        )
+        return DiagnosticCheck(
+            section="Entry points",
+            code="entry_point.conflict",
+            status=DiagnosticStatus.FAIL,
+            component_id=component.component_id,
+            summary=(
+                f"{identity} has a conflicting definition from another package."
+            ),
+            detail=f"Conflicting definition(s): {conflicts}.",
+            remediation=(
+                "Remove or reconcile the conflicting Python package through the "
+                "managed suite environment workflow, then rerun `pds doctor`."
+            ),
+        )
+
+    return DiagnosticCheck(
+        section="Entry points",
+        code="entry_point.match",
+        status=DiagnosticStatus.PASS,
+        component_id=component.component_id,
+        summary=(
+            f"{identity} matches {component.distribution} {component.version}."
+        ),
+        detail=f"Target: {expectation_target}.",
+    )
+
+
+def _core_component(
+    manifest: ReleaseCompatibilityManifest,
+) -> ComponentCompatibility | None:
+    candidates = tuple(
+        component
+        for component in manifest.components
+        if "shared_core" in component.capabilities
+    )
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _core_contract_diagnostics(
+    manifest: ReleaseCompatibilityManifest,
+    *,
+    version_lookup: DistributionVersionLookup,
+    module_importer: ModuleImporter,
+) -> tuple[DiagnosticCheck, ...]:
+    component = _core_component(manifest)
+    if component is None:
+        return (
+            DiagnosticCheck(
+                section="Core",
+                code="core.manifest_contract_missing",
+                status=DiagnosticStatus.FAIL,
+                summary=(
+                    "The suite manifest does not identify exactly one shared Core "
+                    "component."
+                ),
+                remediation=(
+                    "Restore the authenticated compatibility manifest for this suite "
+                    "release, then rerun `pds doctor`."
+                ),
+            ),
+        )
+
+    if not _qualified_component(component, version_lookup=version_lookup):
+        return (
+            DiagnosticCheck(
+                section="Core",
+                code="core.contracts_skipped",
+                status=DiagnosticStatus.SKIP,
+                component_id=component.component_id,
+                summary=(
+                    "Core public contracts were not imported because the exact "
+                    "suite-qualified Core package is not installed."
+                ),
+            ),
+        )
+
+    checks: list[DiagnosticCheck] = []
+    for module_name, attribute_name, purpose in _CORE_PUBLIC_CONTRACTS:
+        try:
+            module = module_importer(module_name)
+        except (ImportError, OSError, RuntimeError) as error:
+            checks.append(
+                DiagnosticCheck(
+                    section="Core",
+                    code="core.contract_import_failed",
+                    status=DiagnosticStatus.FAIL,
+                    component_id=component.component_id,
+                    summary=f"Core {purpose} contract could not be imported.",
+                    detail=str(error)[:500] or "Import failed without a message.",
+                    remediation=(
+                        f"Reinstall {component.distribution} {component.version} "
+                        "through the verified suite workflow, then rerun `pds doctor`."
+                    ),
+                )
+            )
+            continue
+
+        contract = getattr(module, attribute_name, None)
+        if not callable(contract):
+            checks.append(
+                DiagnosticCheck(
+                    section="Core",
+                    code="core.contract_missing",
+                    status=DiagnosticStatus.FAIL,
+                    component_id=component.component_id,
+                    summary=f"Core {purpose} public contract is unavailable.",
+                    detail=f"Expected callable: {module_name}.{attribute_name}.",
+                    remediation=(
+                        f"Reinstall {component.distribution} {component.version} "
+                        "through the verified suite workflow, then rerun `pds doctor`."
+                    ),
+                )
+            )
+            continue
+
+        checks.append(
+            DiagnosticCheck(
+                section="Core",
+                code="core.contract_available",
+                status=DiagnosticStatus.PASS,
+                component_id=component.component_id,
+                summary=f"Core {purpose} public contract is available.",
+                detail=f"Callable: {module_name}.{attribute_name}.",
+            )
+        )
+    return tuple(checks)
+
+
+def collect_entry_point_core_diagnostics(
+    manifest: ReleaseCompatibilityManifest | None = None,
+    *,
+    version_lookup: DistributionVersionLookup = metadata.version,
+    entry_point_inventory_lookup: EntryPointInventoryLookup = (
+        _installed_entry_point_inventory
+    ),
+    module_importer: ModuleImporter = import_module,
+) -> DoctorReport:
+    """Check exact public entry-point metadata and existing Core contracts.
+
+    Entry-point targets are never loaded. Provider-profile discovery is intentionally
+    not performed here: failure-isolated provider inventory remains Core-owned.
+    """
+    active_manifest = manifest or load_release_compatibility_manifest()
+    checks: list[DiagnosticCheck] = []
+
+    try:
+        inventory = tuple(entry_point_inventory_lookup())
+    except (OSError, RuntimeError, TypeError, ValueError) as error:
+        inventory = ()
+        checks.append(
+            DiagnosticCheck(
+                section="Entry points",
+                code="entry_point.inventory_unavailable",
+                status=DiagnosticStatus.FAIL,
+                summary="Installed entry-point metadata could not be inventoried.",
+                detail=(
+                    str(error)[:500] or "Metadata inventory failed without a message."
+                ),
+                remediation=(
+                    "Repair the installed Python environment through the verified "
+                    "suite workflow, then rerun `pds doctor`."
+                ),
+            )
+        )
+
+    if not checks:
+        for component in active_manifest.components:
+            if not component.entry_points:
+                continue
+            if not _qualified_component(component, version_lookup=version_lookup):
+                checks.append(_entry_point_component_skip(component))
+                continue
+            for expectation in component.entry_points:
+                checks.append(
+                    _entry_point_check(
+                        component,
+                        expectation.group,
+                        expectation.name,
+                        expectation.target,
+                        inventory=inventory,
+                    )
+                )
+
+    checks.extend(
+        _core_contract_diagnostics(
+            active_manifest,
+            version_lookup=version_lookup,
+            module_importer=module_importer,
+        )
+    )
+    return DoctorReport(tuple(checks))
+
+
+class WorkspaceStatusLike(Protocol):
+    """Public Core workspace status fields consumed by suite diagnostics."""
+
+    root: Path
+    source: str
+    exists: bool
+    is_dir: bool
+    is_writable: bool
+
+
+class WorkspaceInspector(Protocol):
+    """Public Core workspace-inspection callable shape."""
+
+    def __call__(
+        self,
+        explicit_root: str | Path | None = None,
+    ) -> WorkspaceStatusLike: ...
+
+
+class SchoolYearLookup(Protocol):
+    """Public Core active-school-year callable shape."""
+
+    def __call__(self, workspace_root: str | Path) -> str | None: ...
+
+
+class RegistryFindingLike(Protocol):
+    """Privacy-bounded Core registry finding fields used for summaries."""
+
+    severity: str
+    code: str
+
+
+class RegistryStatusLike(Protocol):
+    """Public Core registry-status fields consumed by suite diagnostics."""
+
+    canonical_valid: bool
+    contracts_compatible: bool | None
+    catalog_state: str
+    catalog_sources_current: bool | None
+    lock_count: int
+    temporary_artifact_count: int
+    findings: Sequence[RegistryFindingLike]
+
+
+class RegistryStatusLookup(Protocol):
+    """Public Core registry-status callable shape."""
+
+    def __call__(
+        self,
+        workspace_root: str | Path,
+        *,
+        verify_manifests: bool = False,
+    ) -> RegistryStatusLike: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _CoreWorkspaceServices:
+    inspect_workspace_root: WorkspaceInspector
+    get_active_school_year: SchoolYearLookup
+    get_academic_registry_status: RegistryStatusLookup
+
+
+class _CoreWorkspaceServiceError(RuntimeError):
+    """Raised when a required public Core workspace service cannot be loaded."""
+
+
+def _load_core_workspace_services(
+    module_importer: ModuleImporter,
+) -> _CoreWorkspaceServices:
+    loaded: dict[tuple[str, str], object] = {}
+    for module_name, attribute_name, _purpose in _CORE_PUBLIC_CONTRACTS:
+        try:
+            module = module_importer(module_name)
+        except Exception as error:
+            raise _CoreWorkspaceServiceError(
+                f"could not import {module_name}: {error}"
+            ) from error
+        value = getattr(module, attribute_name, None)
+        if not callable(value):
+            raise _CoreWorkspaceServiceError(
+                f"public Core callable is unavailable: {module_name}.{attribute_name}"
+            )
+        loaded[(module_name, attribute_name)] = value
+
+    return _CoreWorkspaceServices(
+        inspect_workspace_root=cast(
+            WorkspaceInspector,
+            loaded[("pds_core.workspace", "inspect_workspace_root")],
+        ),
+        get_active_school_year=cast(
+            SchoolYearLookup,
+            loaded[("pds_core.school_years", "get_active_school_year")],
+        ),
+        get_academic_registry_status=cast(
+            RegistryStatusLookup,
+            loaded[("pds_core.registry_audit", "get_academic_registry_status")],
+        ),
+    )
+
+
+def _dependent_workspace_skip(section: str, code: str, summary: str) -> DiagnosticCheck:
+    return DiagnosticCheck(
+        section=section,
+        code=code,
+        status=DiagnosticStatus.SKIP,
+        summary=summary,
+    )
+
+
+def _workspace_status_check(
+    status: WorkspaceStatusLike,
+) -> tuple[DiagnosticCheck, Path | None]:
+    try:
+        root = Path(status.root)
+        source = status.source
+        exists = status.exists
+        is_dir = status.is_dir
+        is_writable = status.is_writable
+    except (AttributeError, TypeError, ValueError) as error:
+        return (
+            DiagnosticCheck(
+                section="Workspace",
+                code="workspace.status_invalid",
+                status=DiagnosticStatus.FAIL,
+                summary="Core returned an invalid workspace status result.",
+                detail=str(error)[:500] or "Workspace status shape is invalid.",
+                remediation=(
+                    "Repair the suite-qualified Core installation, then rerun "
+                    "`pds doctor`."
+                ),
+            ),
+            None,
+        )
+
+    if not isinstance(source, str) or not source.strip():
+        return (
+            DiagnosticCheck(
+                section="Workspace",
+                code="workspace.status_invalid",
+                status=DiagnosticStatus.FAIL,
+                summary="Core returned an invalid workspace selection source.",
+                remediation=(
+                    "Repair the suite-qualified Core installation, then rerun "
+                    "`pds doctor`."
+                ),
+            ),
+            None,
+        )
+    if not all(isinstance(value, bool) for value in (exists, is_dir, is_writable)):
+        return (
+            DiagnosticCheck(
+                section="Workspace",
+                code="workspace.status_invalid",
+                status=DiagnosticStatus.FAIL,
+                summary="Core returned invalid workspace access flags.",
+                remediation=(
+                    "Repair the suite-qualified Core installation, then rerun "
+                    "`pds doctor`."
+                ),
+            ),
+            None,
+        )
+
+    detail = f"Path: {root}; selection source: {source}."
+    if not exists:
+        return (
+            DiagnosticCheck(
+                section="Workspace",
+                code="workspace.not_configured",
+                status=DiagnosticStatus.WARN,
+                summary=(
+                    "No accessible workspace currently exists at the resolved path."
+                ),
+                detail=detail,
+                remediation=(
+                    "Complete Paper Data Suite workspace setup, then rerun "
+                    "`pds doctor`."
+                ),
+            ),
+            None,
+        )
+    if not is_dir:
+        return (
+            DiagnosticCheck(
+                section="Workspace",
+                code="workspace.not_directory",
+                status=DiagnosticStatus.FAIL,
+                summary="The resolved workspace path is not a directory.",
+                detail=detail,
+                remediation=(
+                    "Select or restore a valid Paper Data Suite workspace directory, "
+                    "then rerun `pds doctor`."
+                ),
+            ),
+            None,
+        )
+    if not is_writable:
+        return (
+            DiagnosticCheck(
+                section="Workspace",
+                code="workspace.not_writable",
+                status=DiagnosticStatus.FAIL,
+                summary="The resolved workspace is not writable according to Core.",
+                detail=detail,
+                remediation=(
+                    "Restore write access to the workspace or select an accessible "
+                    "workspace, then rerun `pds doctor`."
+                ),
+            ),
+            None,
+        )
+
+    return (
+        DiagnosticCheck(
+            section="Workspace",
+            code="workspace.accessible",
+            status=DiagnosticStatus.PASS,
+            summary="The resolved workspace exists and is writable.",
+            detail=detail,
+        ),
+        root,
+    )
+
+
+def _school_year_check(
+    root: Path,
+    lookup: SchoolYearLookup,
+) -> DiagnosticCheck:
+    try:
+        school_year = lookup(root)
+    except Exception as error:
+        return DiagnosticCheck(
+            section="Workspace",
+            code="school_year.state_invalid",
+            status=DiagnosticStatus.FAIL,
+            summary="Core could not read the active school-year state.",
+            detail=str(error)[:500] or "School-year lookup failed without a message.",
+            remediation=(
+                "Review the Core school-year state through its supported workflow, "
+                "then rerun `pds doctor`."
+            ),
+        )
+
+    if school_year is None:
+        return DiagnosticCheck(
+            section="Workspace",
+            code="school_year.not_active",
+            status=DiagnosticStatus.WARN,
+            summary="No active school year is configured for this workspace.",
+            remediation=(
+                "Complete the Paper Data Suite school-year setup workflow, then "
+                "rerun `pds doctor`."
+            ),
+        )
+    if not isinstance(school_year, str) or not school_year.strip():
+        return DiagnosticCheck(
+            section="Workspace",
+            code="school_year.state_invalid",
+            status=DiagnosticStatus.FAIL,
+            summary="Core returned an invalid active school-year value.",
+            remediation=(
+                "Review the Core school-year state through its supported workflow, "
+                "then rerun `pds doctor`."
+            ),
+        )
+    return DiagnosticCheck(
+        section="Workspace",
+        code="school_year.active",
+        status=DiagnosticStatus.PASS,
+        summary=f"Active school year: {school_year}.",
+    )
+
+
+def _finding_summary(findings: Sequence[RegistryFindingLike]) -> tuple[int, int, str]:
+    errors = 0
+    warnings = 0
+    codes: list[str] = []
+    for finding in findings:
+        severity = getattr(finding, "severity", None)
+        code = getattr(finding, "code", None)
+        if severity == "error":
+            errors += 1
+        elif severity == "warning":
+            warnings += 1
+        if isinstance(code, str) and code and code not in codes:
+            codes.append(code)
+    bounded_codes = ", ".join(codes[:5])
+    if len(codes) > 5:
+        bounded_codes += f", +{len(codes) - 5} more"
+    return errors, warnings, bounded_codes
+
+
+def _registry_status_checks(status: RegistryStatusLike) -> tuple[DiagnosticCheck, ...]:
+    try:
+        canonical_valid = status.canonical_valid
+        contracts_compatible = status.contracts_compatible
+        catalog_state = status.catalog_state
+        catalog_sources_current = status.catalog_sources_current
+        lock_count = status.lock_count
+        temporary_artifact_count = status.temporary_artifact_count
+        findings = tuple(status.findings)
+    except (AttributeError, TypeError, ValueError) as error:
+        return (
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.status_invalid",
+                status=DiagnosticStatus.FAIL,
+                summary="Core returned an invalid academic-registry status result.",
+                detail=str(error)[:500] or "Registry status shape is invalid.",
+                remediation=(
+                    "Repair the suite-qualified Core installation, then rerun "
+                    "`pds doctor`."
+                ),
+            ),
+        )
+
+    checks: list[DiagnosticCheck] = []
+    if canonical_valid is True:
+        checks.append(
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.canonical_valid",
+                status=DiagnosticStatus.PASS,
+                summary="Core reports canonical academic-registry state as valid.",
+            )
+        )
+    else:
+        checks.append(
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.canonical_invalid",
+                status=DiagnosticStatus.FAIL,
+                summary="Core reports invalid canonical academic-registry state.",
+                remediation=(
+                    "Review the reported Core registry condition using Core's "
+                    "supported audit/maintenance workflow."
+                ),
+            )
+        )
+
+    if contracts_compatible is None:
+        checks.append(
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.contracts_not_reported",
+                status=DiagnosticStatus.SKIP,
+                summary="Core did not report registry contract compatibility.",
+            )
+        )
+    elif contracts_compatible is True:
+        checks.append(
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.contracts_compatible",
+                status=DiagnosticStatus.PASS,
+                summary="Core reports registry contracts as compatible.",
+            )
+        )
+    else:
+        checks.append(
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.contracts_incompatible",
+                status=DiagnosticStatus.FAIL,
+                summary="Core reports incompatible registry contracts.",
+                remediation=(
+                    "Review the reported Core registry condition using Core's "
+                    "supported audit/maintenance workflow."
+                ),
+            )
+        )
+
+    if catalog_state == "ready" and catalog_sources_current is True:
+        checks.append(
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.catalog_ready",
+                status=DiagnosticStatus.PASS,
+                summary="Core reports the academic catalog as ready and current.",
+            )
+        )
+    elif catalog_state in {"missing", "absent", "not_built"}:
+        checks.append(
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.catalog_missing",
+                status=DiagnosticStatus.WARN,
+                summary="Core reports that the academic catalog is not built.",
+                remediation=(
+                    "Use Core's supported catalog workflow when catalog-backed "
+                    "features are needed; `pds doctor` will not build it."
+                ),
+            )
+        )
+    else:
+        currency = (
+            "unknown"
+            if catalog_sources_current is None
+            else ("current" if catalog_sources_current else "stale")
+        )
+        checks.append(
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.catalog_unhealthy",
+                status=DiagnosticStatus.FAIL,
+                summary="Core reports an unhealthy or stale academic catalog.",
+                detail=f"Catalog state: {catalog_state}; source currency: {currency}.",
+                remediation=(
+                    "Review the Core registry/catalog condition using Core's "
+                    "supported audit/maintenance workflow."
+                ),
+            )
+        )
+
+    if isinstance(lock_count, int) and isinstance(temporary_artifact_count, int):
+        if lock_count == 0 and temporary_artifact_count == 0:
+            checks.append(
+                DiagnosticCheck(
+                    section="Core registry",
+                    code="registry.coordination_clear",
+                    status=DiagnosticStatus.PASS,
+                    summary=(
+                        "Core reports no coordination locks or temporary artifacts."
+                    ),
+                )
+            )
+        else:
+            checks.append(
+                DiagnosticCheck(
+                    section="Core registry",
+                    code="registry.coordination_present",
+                    status=DiagnosticStatus.WARN,
+                    summary="Core reports coordination state that requires attention.",
+                    detail=(
+                        f"Locks: {lock_count}; temporary artifacts: "
+                        f"{temporary_artifact_count}."
+                    ),
+                    remediation=(
+                        "Review this state with Core's supported audit/maintenance "
+                        "workflow; `pds doctor` will not clear locks or artifacts."
+                    ),
+                )
+            )
+    else:
+        checks.append(
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.status_invalid",
+                status=DiagnosticStatus.FAIL,
+                summary="Core returned invalid registry coordination counts.",
+                remediation=(
+                    "Repair the suite-qualified Core installation, then rerun "
+                    "`pds doctor`."
+                ),
+            )
+        )
+
+    errors, warnings, codes = _finding_summary(findings)
+    if errors:
+        checks.append(
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.findings_error",
+                status=DiagnosticStatus.FAIL,
+                summary=f"Core reports {errors} registry error finding(s).",
+                detail=(
+                    f"Warning findings: {warnings}; finding codes: {codes or 'none'}."
+                ),
+                remediation=(
+                    "Review the reported Core registry findings using Core's "
+                    "supported audit/maintenance workflow."
+                ),
+            )
+        )
+    elif warnings:
+        checks.append(
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.findings_warning",
+                status=DiagnosticStatus.WARN,
+                summary=f"Core reports {warnings} registry warning finding(s).",
+                detail=f"Finding codes: {codes or 'none'}.",
+                remediation=(
+                    "Review the reported Core registry findings before relying on "
+                    "affected workflows."
+                ),
+            )
+        )
+    else:
+        checks.append(
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.findings_clear",
+                status=DiagnosticStatus.PASS,
+                summary="Core reports no blocking or warning registry findings.",
+            )
+        )
+
+    return tuple(checks)
+
+
+def _registry_check(
+    root: Path,
+    lookup: RegistryStatusLookup,
+) -> tuple[DiagnosticCheck, ...]:
+    try:
+        status = lookup(root, verify_manifests=False)
+    except Exception as error:
+        return (
+            DiagnosticCheck(
+                section="Core registry",
+                code="registry.inspection_failed",
+                status=DiagnosticStatus.FAIL,
+                summary="Core academic-registry health inspection failed.",
+                detail=(
+                    str(error)[:500]
+                    or "Registry inspection failed without a message."
+                ),
+                remediation=(
+                    "Review the workspace with Core's supported registry audit "
+                    "workflow, then rerun `pds doctor`."
+                ),
+            ),
+        )
+    return _registry_status_checks(status)
+
+
+def collect_workspace_registry_diagnostics(
+    manifest: ReleaseCompatibilityManifest | None = None,
+    *,
+    workspace: str | Path | None = None,
+    version_lookup: DistributionVersionLookup = metadata.version,
+    module_importer: ModuleImporter = import_module,
+    services: _CoreWorkspaceServices | None = None,
+) -> DoctorReport:
+    """Collect read-only Core workspace, school-year, and registry diagnostics.
+
+    The optional workspace path is invocation-scoped input only. This function never
+    saves, creates, initializes, repairs, or otherwise mutates a Core workspace.
+    """
+    active_manifest = manifest or load_release_compatibility_manifest()
+    core = _core_component(active_manifest)
+    if core is None:
+        return DoctorReport(
+            (
+                DiagnosticCheck(
+                    section="Workspace",
+                    code="workspace.core_manifest_invalid",
+                    status=DiagnosticStatus.FAIL,
+                    summary=(
+                        "Workspace diagnostics cannot identify exactly one shared "
+                        "Core component in the suite manifest."
+                    ),
+                ),
+                _dependent_workspace_skip(
+                    "Workspace",
+                    "school_year.skipped",
+                    (
+                        "Active school-year diagnostics require an accessible Core "
+                        "workspace."
+                    ),
+                ),
+                _dependent_workspace_skip(
+                    "Core registry",
+                    "registry.skipped",
+                    "Registry diagnostics require an accessible Core workspace.",
+                ),
+            )
+        )
+    if not _qualified_component(core, version_lookup=version_lookup):
+        return DoctorReport(
+            (
+                _dependent_workspace_skip(
+                    "Workspace",
+                    "workspace.core_unqualified",
+                    (
+                        "Workspace diagnostics require the exact suite-qualified "
+                        "Core package."
+                    ),
+                ),
+                _dependent_workspace_skip(
+                    "Workspace",
+                    "school_year.core_unqualified",
+                    (
+                        "School-year diagnostics require the exact suite-qualified "
+                        "Core package."
+                    ),
+                ),
+                _dependent_workspace_skip(
+                    "Core registry",
+                    "registry.core_unqualified",
+                    (
+                        "Registry diagnostics require the exact suite-qualified "
+                        "Core package."
+                    ),
+                ),
+            )
+        )
+
+    try:
+        active_services = services or _load_core_workspace_services(module_importer)
+    except _CoreWorkspaceServiceError as error:
+        return DoctorReport(
+            (
+                DiagnosticCheck(
+                    section="Workspace",
+                    code="workspace.core_service_unavailable",
+                    status=DiagnosticStatus.FAIL,
+                    component_id=core.component_id,
+                    summary="Required public Core workspace services are unavailable.",
+                    detail=str(error)[:500],
+                    remediation=(
+                        f"Reinstall {core.distribution} {core.version} through the "
+                        "verified suite workflow, then rerun `pds doctor`."
+                    ),
+                ),
+                _dependent_workspace_skip(
+                    "Workspace",
+                    "school_year.skipped",
+                    "Active school-year diagnostics require Core workspace services.",
+                ),
+                _dependent_workspace_skip(
+                    "Core registry",
+                    "registry.skipped",
+                    "Registry diagnostics require Core workspace services.",
+                ),
+            )
+        )
+
+    try:
+        workspace_status = active_services.inspect_workspace_root(workspace)
+    except Exception as error:
+        return DoctorReport(
+            (
+                DiagnosticCheck(
+                    section="Workspace",
+                    code="workspace.inspection_failed",
+                    status=DiagnosticStatus.FAIL,
+                    component_id=core.component_id,
+                    summary="Core could not inspect the resolved workspace.",
+                    detail=(
+                        str(error)[:500]
+                        or "Workspace inspection failed without a message."
+                    ),
+                    remediation=(
+                        "Review the workspace selection with Core's supported "
+                        "configuration workflow, then rerun `pds doctor`."
+                    ),
+                ),
+                _dependent_workspace_skip(
+                    "Workspace",
+                    "school_year.skipped",
+                    "Active school-year diagnostics require an accessible workspace.",
+                ),
+                _dependent_workspace_skip(
+                    "Core registry",
+                    "registry.skipped",
+                    "Registry diagnostics require an accessible workspace.",
+                ),
+            )
+        )
+
+    workspace_check, root = _workspace_status_check(workspace_status)
+    if root is None:
+        return DoctorReport(
+            (
+                workspace_check,
+                _dependent_workspace_skip(
+                    "Workspace",
+                    "school_year.skipped",
+                    "Active school-year diagnostics require an accessible workspace.",
+                ),
+                _dependent_workspace_skip(
+                    "Core registry",
+                    "registry.skipped",
+                    "Registry diagnostics require an accessible workspace.",
+                ),
+            )
+        )
+
+    return DoctorReport(
+        (
+            workspace_check,
+            _school_year_check(root, active_services.get_active_school_year),
+            *_registry_check(root, active_services.get_academic_registry_status),
+        )
+    )
+
+_SECTION_ORDER: tuple[str, ...] = (
+    "Runtime",
+    "Suite",
+    "Packages",
+    "Dependencies",
+    "Entry points",
+    "Core",
+    "External prerequisites",
+    "Workspace",
+    "Core registry",
+    "Providers",
+    "Modules",
+)
+
+
+def collect_reduced_provider_diagnostics(
+    manifest: ReleaseCompatibilityManifest | None = None,
+    *,
+    version_lookup: DistributionVersionLookup = metadata.version,
+) -> DoctorReport:
+    """Report reduced provider diagnostic fidelity for the current Core contract.
+
+    Failure-isolated routing/publication provider diagnostics and shared module
+    readiness are Core-owned additive contracts. Until the suite-qualified Core
+    release exposes those contracts, doctor reports the limitation explicitly
+    rather than reimplementing strict Core discovery or inspecting module internals.
+    """
+    active_manifest = manifest or load_release_compatibility_manifest()
+    core = _core_component(active_manifest)
+    if core is None:
+        detail = (
+            "The suite manifest does not identify exactly one shared Core "
+            "component."
+        )
+    elif not _qualified_component(core, version_lookup=version_lookup):
+        detail = (
+            "The exact suite-qualified Core package is not installed, so deeper "
+            "provider contract diagnostics are unavailable."
+        )
+    else:
+        detail = (
+            "The suite-qualified Core contract does not yet expose the optional "
+            "failure-isolated provider diagnostic surface."
+        )
+
+    return DoctorReport(
+        (
+            DiagnosticCheck(
+                section="Providers",
+                code="providers.reduced_fidelity",
+                status=DiagnosticStatus.SKIP,
+                summary=(
+                    "Routing/publication provider compatibility has reduced "
+                    "diagnostic fidelity."
+                ),
+                detail=detail,
+            ),
+            DiagnosticCheck(
+                section="Modules",
+                code="module.readiness_unavailable",
+                status=DiagnosticStatus.SKIP,
+                summary="Shared module-reported readiness is not available.",
+                detail=(
+                    "No suite-qualified public module-operations readiness contract "
+                    "is available to doctor; module-private state is not inspected."
+                ),
+            ),
+        )
+    )
+
+
+def collect_doctor_diagnostics(
+    *,
+    workspace: str | Path | None = None,
+) -> DoctorReport:
+    """Collect the complete diagnostic report supported by this suite release."""
+    manifest = load_release_compatibility_manifest()
+    return combine_reports(
+        collect_runtime_package_diagnostics(manifest),
+        collect_environment_dependency_diagnostics(manifest),
+        collect_entry_point_core_diagnostics(manifest),
+        collect_workspace_registry_diagnostics(manifest, workspace=workspace),
+        collect_reduced_provider_diagnostics(manifest),
+    )
+
+
+def _report_sections(report: DoctorReport) -> tuple[str, ...]:
+    present = {check.section for check in report.checks}
+    known = tuple(section for section in _SECTION_ORDER if section in present)
+    extras = tuple(sorted(present - set(_SECTION_ORDER)))
+    return (*known, *extras)
+
+
+def _overall_summary(report: DoctorReport) -> str:
+    failures = report.failure_count
+    warnings = report.warning_count
+    if failures:
+        blocker_label = "blocker" if failures == 1 else "blockers"
+        warning_label = "warning" if warnings == 1 else "warnings"
+        return f"FAIL  {failures} {blocker_label}, {warnings} {warning_label}."
+    if warnings:
+        warning_label = "warning" if warnings == 1 else "warnings"
+        return f"WARN  No blockers; {warnings} {warning_label}."
+    return "PASS  No blocking problems detected."
+
+
+def render_doctor_report(report: DoctorReport) -> str:
+    """Render one deterministic teacher-facing plain-text doctor report."""
+    lines = ["Paper Data Suite doctor", ""]
+    for section in _report_sections(report):
+        lines.append(section)
+        for check in report.for_section(section):
+            lines.append(f"  {check.status.value:<4}  {check.summary}")
+            if check.detail is not None:
+                lines.append(f"        {check.detail}")
+            if check.remediation is not None:
+                lines.append(f"        Fix: {check.remediation}")
+        lines.append("")
+    lines.extend(("Overall", f"  {_overall_summary(report)}", ""))
+    return "\n".join(lines)

--- a/scripts/smoke_test_wheel.py
+++ b/scripts/smoke_test_wheel.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import venv
 import zipfile
@@ -170,6 +171,29 @@ print(json.dumps({
     _assert_clean_directory(cwd)
 
 
+def _assert_installed_package_location(
+    python: Path,
+    *,
+    environment: Path,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> None:
+    code = (
+        "from pathlib import Path; import paper_data_suite; "
+        "print(Path(paper_data_suite.__file__).resolve())"
+    )
+    result = _run([str(python), "-c", code], cwd=cwd, env=env)
+    installed_path = Path(result.stdout.strip()).resolve()
+    try:
+        installed_path.relative_to(environment.resolve())
+    except ValueError as error:
+        raise SmokeTestError(
+            "Smoke test imported paper_data_suite outside the isolated environment: "
+            f"{installed_path}"
+        ) from error
+    _assert_clean_directory(cwd)
+
+
 def _assert_installed_compatibility_manifest(
     python: Path,
     *,
@@ -239,8 +263,85 @@ print(json.dumps({
     _assert_clean_directory(cwd)
 
 
+def _assert_doctor_output(output: str) -> None:
+    required = (
+        "Paper Data Suite doctor",
+        "Runtime",
+        "Suite",
+        "Packages",
+        "Dependencies",
+        "Entry points",
+        "Core",
+        "Workspace",
+        "Core registry",
+        "Providers",
+        "Modules",
+        "Overall",
+        "No accessible workspace currently exists at the resolved path.",
+        "Routing/publication provider compatibility has reduced diagnostic fidelity.",
+        "Shared module-reported readiness is not available.",
+    )
+    missing = [fragment for fragment in required if fragment not in output]
+    if missing:
+        raise SmokeTestError(
+            "Installed doctor output is missing expected content: "
+            + ", ".join(missing)
+        )
+
+
+def _assert_doctor_command(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    missing_workspace: Path,
+) -> None:
+    if missing_workspace.exists():
+        raise SmokeTestError(
+            f"Synthetic absent workspace unexpectedly exists: {missing_workspace}"
+        )
+    result = _run(command, cwd=cwd, env=env)
+    _assert_doctor_output(result.stdout)
+    if missing_workspace.exists():
+        raise SmokeTestError("pds doctor created the synthetic absent workspace.")
+    _assert_clean_directory(cwd)
+
+
+def _assert_doctor_no_network(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    missing_workspace: Path,
+) -> None:
+    code = """
+import socket
+import urllib.request
+
+
+def blocked_network(*args, **kwargs):
+    raise AssertionError("pds doctor attempted network access")
+
+
+socket.create_connection = blocked_network
+urllib.request.urlopen = blocked_network
+urllib.request.urlretrieve = blocked_network
+
+from paper_data_suite.cli import main
+raise SystemExit(main(("doctor",)))
+""".strip()
+    _assert_doctor_command(
+        [str(python), "-c", code],
+        cwd=cwd,
+        env=env,
+        missing_workspace=missing_workspace,
+    )
+
+
 def smoke_test(suite_wheel: Path, core_wheel: Path) -> None:
     """Install and exercise the suite wheel beside only Core."""
+    suite_wheel = suite_wheel.resolve()
+    core_wheel = core_wheel.resolve()
     if not suite_wheel.is_file():
         raise SmokeTestError(f"Suite wheel does not exist: {suite_wheel}")
     if not core_wheel.is_file():
@@ -252,6 +353,7 @@ def smoke_test(suite_wheel: Path, core_wheel: Path) -> None:
         temp_root = Path(temporary)
         environment = temp_root / "venv"
         run_directory = temp_root / "run"
+        missing_workspace = run_directory / "synthetic-missing-workspace"
         run_directory.mkdir()
 
         venv.EnvBuilder(with_pip=True).create(environment)
@@ -259,7 +361,10 @@ def smoke_test(suite_wheel: Path, core_wheel: Path) -> None:
 
         command_env = dict(os.environ)
         command_env["PYTHONDONTWRITEBYTECODE"] = "1"
+        command_env["PYTHONNOUSERSITE"] = "1"
         command_env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+        command_env["PIP_NO_INDEX"] = "1"
+        command_env["PDS_WORKSPACE_ROOT"] = str(missing_workspace)
         command_env.pop("PYTHONPATH", None)
 
         _run(
@@ -301,6 +406,12 @@ def smoke_test(suite_wheel: Path, core_wheel: Path) -> None:
             env=command_env,
             expected_version=expected_version,
         )
+        _assert_installed_package_location(
+            python,
+            environment=environment,
+            cwd=run_directory,
+            env=command_env,
+        )
         _assert_installed_compatibility_manifest(
             python,
             cwd=run_directory,
@@ -331,6 +442,19 @@ def smoke_test(suite_wheel: Path, core_wheel: Path) -> None:
             raise SmokeTestError("Module help does not identify pds.")
         _assert_clean_directory(run_directory)
 
+        _assert_doctor_command(
+            [str(python), "-m", "paper_data_suite", "doctor"],
+            cwd=run_directory,
+            env=command_env,
+            missing_workspace=missing_workspace,
+        )
+        _assert_doctor_no_network(
+            python,
+            cwd=run_directory,
+            env=command_env,
+            missing_workspace=missing_workspace,
+        )
+
         scripts = _scripts_directory(
             python, cwd=run_directory, env=command_env
         )
@@ -358,31 +482,36 @@ def smoke_test(suite_wheel: Path, core_wheel: Path) -> None:
             raise SmokeTestError("Installed pds help does not identify pds.")
         _assert_clean_directory(run_directory)
 
-        console_bare = _run(
-            [str(launcher)],
+        _assert_doctor_command(
+            [str(launcher), "doctor"],
             cwd=run_directory,
             env=command_env,
+            missing_workspace=missing_workspace,
         )
-        if "usage: pds" not in console_bare.stdout:
-            raise SmokeTestError("Bare installed pds did not print help.")
-        _assert_clean_directory(run_directory)
 
 
 def build_parser() -> argparse.ArgumentParser:
-    """Build the smoke-test parser."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument("suite_wheel")
-    parser.add_argument("core_wheel")
+    """Build the installed-wheel smoke-test argument parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Install the built Paper Data Suite wheel beside an exact Core wheel "
+            "and exercise installed package/CLI acceptance outside the source tree."
+        )
+    )
+    parser.add_argument("suite_wheel", type=Path)
+    parser.add_argument("core_wheel", type=Path)
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Run the clean-wheel smoke test."""
-    args = build_parser().parse_args(argv)
-    suite_wheel = Path(cast(str, args.suite_wheel)).resolve()
-    core_wheel = Path(cast(str, args.core_wheel)).resolve()
-    smoke_test(suite_wheel, core_wheel)
-    print(f"Smoke-tested suite wheel: {suite_wheel}")
+    """Run the built-wheel smoke test from the command line."""
+    arguments = build_parser().parse_args(argv)
+    try:
+        smoke_test(arguments.suite_wheel, arguments.core_wheel)
+    except SmokeTestError as error:
+        print(f"Smoke test failed: {error}", file=sys.stderr)
+        return 1
+    print("Smoke test passed.")
     return 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ import pytest
 
 from paper_data_suite import __version__
 from paper_data_suite.cli import main
+from paper_data_suite.doctor import DiagnosticCheck, DiagnosticStatus, DoctorReport
 
 
 def _console_script_path() -> Path:
@@ -99,3 +100,65 @@ def test_installed_console_script_is_read_only(
     assert "usage: pds" in result.stdout or result.stdout.strip() == (
         f"pds {__version__}"
     )
+
+
+def test_doctor_help_returns_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as raised:
+        main(("doctor", "--help"))
+    assert raised.value.code == 0
+    output = capsys.readouterr().out
+    assert "usage: pds doctor" in output
+    assert "--workspace" in output
+
+
+def test_doctor_dispatches_workspace_and_returns_report_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import paper_data_suite.cli as cli
+
+    observed: list[object] = []
+    report = DoctorReport(
+        (
+            DiagnosticCheck(
+                section="Runtime",
+                code="runtime.fail",
+                status=DiagnosticStatus.FAIL,
+                summary="blocked",
+            ),
+        )
+    )
+
+    def collect(*, workspace: object = None) -> DoctorReport:
+        observed.append(workspace)
+        return report
+
+    monkeypatch.setattr(cli, "collect_doctor_diagnostics", collect)
+    monkeypatch.setattr(cli, "render_doctor_report", lambda value: "doctor output\n")
+
+    assert main(("doctor", "--workspace", "D:/PDS Workspace")) == 1
+    assert observed == [Path("D:/PDS Workspace")]
+    assert capsys.readouterr().out == "doctor output\n"
+
+
+def test_doctor_warn_only_returns_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import paper_data_suite.cli as cli
+
+    report = DoctorReport(
+        (
+            DiagnosticCheck(
+                section="Suite",
+                code="suite.warn",
+                status=DiagnosticStatus.WARN,
+                summary="attention",
+            ),
+        )
+    )
+    monkeypatch.setattr(cli, "collect_doctor_diagnostics", lambda **kwargs: report)
+    monkeypatch.setattr(cli, "render_doctor_report", lambda value: "warning\n")
+
+    assert main(("doctor",)) == 0
+    assert capsys.readouterr().out == "warning\n"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,1431 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from importlib import metadata
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paper_data_suite.compatibility import (
+    ComponentCompatibility,
+    EntryPointExpectation,
+    ExternalPrerequisite,
+    PythonCompatibility,
+    ReleaseArtifact,
+    ReleaseCompatibilityManifest,
+    SuiteCompatibility,
+)
+from paper_data_suite.doctor import (
+    DiagnosticCheck,
+    DiagnosticStatus,
+    DoctorReport,
+    EntryPointObservation,
+    collect_doctor_diagnostics,
+    collect_entry_point_core_diagnostics,
+    collect_environment_dependency_diagnostics,
+    collect_reduced_provider_diagnostics,
+    collect_runtime_package_diagnostics,
+    collect_workspace_registry_diagnostics,
+    combine_reports,
+    render_doctor_report,
+)
+
+
+def _component(
+    component_id: str,
+    distribution: str,
+    version: str,
+    *,
+    required: bool,
+    prerequisite: ExternalPrerequisite | None = None,
+    capabilities: tuple[str, ...] = (),
+    entry_points: tuple[EntryPointExpectation, ...] | None = None,
+) -> ComponentCompatibility:
+    return ComponentCompatibility(
+        component_id=component_id,
+        display_name=component_id.title(),
+        repository=f"Paper-Data-Suite/pds-{component_id}",
+        distribution=distribution,
+        import_name=component_id,
+        required=required,
+        compatibility_status="supported",
+        version=version,
+        requires_python=">=3.11",
+        release=ReleaseArtifact(
+            tag=f"v{version}",
+            wheel=f"{distribution.replace('-', '_')}-{version}-py3-none-any.whl",
+            sha256="0" * 64,
+        ),
+        capabilities=capabilities,
+        entry_points=(
+            entry_points
+            if entry_points is not None
+            else (
+                EntryPointExpectation(
+                    group="console_scripts",
+                    name=component_id,
+                    target=f"{component_id}.cli:main",
+                ),
+            )
+        ),
+        external_prerequisites=((prerequisite,) if prerequisite is not None else ()),
+    )
+
+
+def _poppler_prerequisite() -> ExternalPrerequisite:
+    return ExternalPrerequisite(
+        prerequisite_id="poppler_pdftoppm",
+        kind="command",
+        required=True,
+        commands=("pdftoppm",),
+        platforms=("windows", "linux"),
+        purpose="PDF scan rasterization",
+    )
+
+
+def _manifest() -> ReleaseCompatibilityManifest:
+    return ReleaseCompatibilityManifest(
+        record_type="paper_data_suite_release_compatibility_manifest",
+        contract_version="1",
+        suite=SuiteCompatibility(
+            distribution="paper-data-suite",
+            version="0.1.0.dev0",
+            release_status="development",
+        ),
+        python=PythonCompatibility(
+            specifier=">=3.11,<3.15",
+            tested_minors=("3.11", "3.12", "3.13", "3.14"),
+        ),
+        components=(
+            _component(
+                "core",
+                "pds-core",
+                "0.6.0",
+                required=True,
+                capabilities=("shared_core",),
+            ),
+            _component(
+                "optional",
+                "pds-optional",
+                "1.2.3",
+                required=False,
+                prerequisite=_poppler_prerequisite(),
+            ),
+        ),
+    )
+
+
+def _lookup(versions: dict[str, str]):
+    def lookup(distribution: str) -> str:
+        try:
+            return versions[distribution]
+        except KeyError as error:
+            raise metadata.PackageNotFoundError(distribution) from error
+
+    return lookup
+
+
+def _marker_text(*, version: str = "0.1.0.dev0", digest: str = "a" * 64) -> str:
+    return json.dumps(
+        {
+            "record_type": "paper_data_suite_environment",
+            "contract_version": "1",
+            "suite_version": version,
+            "compatibility_manifest_sha256": digest,
+        }
+    )
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = ""):
+    def run(
+        args: object,
+        *,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        del capture_output, text, check, timeout
+        assert args == ("python", "-m", "pip", "check")
+        return subprocess.CompletedProcess(
+            ["python", "-m", "pip", "check"],
+            returncode,
+            stdout,
+            stderr,
+        )
+
+    return run
+
+
+def test_diagnostic_check_rejects_blank_contract_fields() -> None:
+    with pytest.raises(ValueError, match="code"):
+        DiagnosticCheck(
+            section="Runtime",
+            code=" ",
+            status=DiagnosticStatus.PASS,
+            summary="healthy",
+        )
+
+
+def test_report_counts_failures_and_warnings_and_derives_exit_code() -> None:
+    report = DoctorReport(
+        (
+            DiagnosticCheck(
+                section="Runtime",
+                code="runtime.pass",
+                status=DiagnosticStatus.PASS,
+                summary="healthy",
+            ),
+            DiagnosticCheck(
+                section="Runtime",
+                code="runtime.warn",
+                status=DiagnosticStatus.WARN,
+                summary="attention",
+            ),
+        )
+    )
+    assert report.failure_count == 0
+    assert report.warning_count == 1
+    assert report.exit_code == 0
+
+    failed = DoctorReport(
+        report.checks
+        + (
+            DiagnosticCheck(
+                section="Packages",
+                code="package.fail",
+                status=DiagnosticStatus.FAIL,
+                summary="blocked",
+            ),
+        )
+    )
+    assert failed.failure_count == 1
+    assert failed.warning_count == 1
+    assert failed.exit_code == 1
+    assert tuple(check.code for check in failed.for_section("Runtime")) == (
+        "runtime.pass",
+        "runtime.warn",
+    )
+
+
+def test_combine_reports_preserves_order_and_exit_semantics() -> None:
+    first = DoctorReport(
+        (
+            DiagnosticCheck(
+                section="One",
+                code="one.pass",
+                status=DiagnosticStatus.PASS,
+                summary="healthy",
+            ),
+        )
+    )
+    second = DoctorReport(
+        (
+            DiagnosticCheck(
+                section="Two",
+                code="two.fail",
+                status=DiagnosticStatus.FAIL,
+                summary="blocked",
+            ),
+        )
+    )
+
+    combined = combine_reports(first, second)
+    assert tuple(check.code for check in combined.checks) == ("one.pass", "two.fail")
+    assert combined.exit_code == 1
+
+
+def test_runtime_package_diagnostics_accept_exact_qualified_environment() -> None:
+    report = collect_runtime_package_diagnostics(
+        _manifest(),
+        python_version=(3, 11, 9),
+        python_executable=r"C:\PDS\.venv\Scripts\python.exe",
+        version_lookup=_lookup(
+            {
+                "paper-data-suite": "0.1.0.dev0",
+                "pds-core": "0.6.0",
+                "pds-optional": "1.2.3",
+            }
+        ),
+    )
+
+    assert report.exit_code == 0
+    assert tuple((check.code, check.status) for check in report.checks) == (
+        ("python.qualified", DiagnosticStatus.PASS),
+        ("suite.version_match", DiagnosticStatus.PASS),
+        ("package.version_match", DiagnosticStatus.PASS),
+        ("package.version_match", DiagnosticStatus.PASS),
+    )
+    assert r"C:\PDS\.venv\Scripts\python.exe" in (report.checks[0].detail or "")
+
+
+def test_runtime_package_diagnostics_fail_unqualified_python() -> None:
+    report = collect_runtime_package_diagnostics(
+        _manifest(),
+        python_version=(3, 15, 0),
+        python_executable="python",
+        version_lookup=_lookup(
+            {
+                "paper-data-suite": "0.1.0.dev0",
+                "pds-core": "0.6.0",
+            }
+        ),
+    )
+
+    check = report.checks[0]
+    assert check.code == "python.unsupported"
+    assert check.status is DiagnosticStatus.FAIL
+    assert "3.11, 3.12, 3.13, 3.14" in (check.detail or "")
+    assert report.exit_code == 1
+
+
+def test_runtime_package_diagnostics_fail_when_suite_metadata_missing() -> None:
+    report = collect_runtime_package_diagnostics(
+        _manifest(),
+        python_version=(3, 11, 0),
+        python_executable="python",
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+    )
+
+    check = report.checks[1]
+    assert check.code == "suite.distribution_missing"
+    assert check.status is DiagnosticStatus.FAIL
+    assert "0.1.0.dev0" in (check.detail or "")
+
+
+def test_runtime_package_diagnostics_fail_suite_version_mismatch() -> None:
+    report = collect_runtime_package_diagnostics(
+        _manifest(),
+        python_version=(3, 11, 0),
+        python_executable="python",
+        version_lookup=_lookup(
+            {
+                "paper-data-suite": "9.9.9",
+                "pds-core": "0.6.0",
+            }
+        ),
+    )
+
+    check = report.checks[1]
+    assert check.code == "suite.version_mismatch"
+    assert check.status is DiagnosticStatus.FAIL
+    assert "9.9.9" in check.summary
+    assert "0.1.0.dev0" in check.summary
+
+
+def test_runtime_package_diagnostics_fail_required_component_absence() -> None:
+    report = collect_runtime_package_diagnostics(
+        _manifest(),
+        python_version=(3, 11, 0),
+        python_executable="python",
+        version_lookup=_lookup({"paper-data-suite": "0.1.0.dev0"}),
+    )
+
+    core = report.checks[2]
+    optional = report.checks[3]
+    assert core.component_id == "core"
+    assert core.code == "package.required_missing"
+    assert core.status is DiagnosticStatus.FAIL
+    assert optional.code == "package.optional_absent"
+    assert optional.status is DiagnosticStatus.SKIP
+
+
+def test_runtime_package_diagnostics_skip_optional_component_absence() -> None:
+    report = collect_runtime_package_diagnostics(
+        _manifest(),
+        python_version=(3, 11, 0),
+        python_executable="python",
+        version_lookup=_lookup(
+            {
+                "paper-data-suite": "0.1.0.dev0",
+                "pds-core": "0.6.0",
+            }
+        ),
+    )
+
+    optional = report.checks[3]
+    assert optional.component_id == "optional"
+    assert optional.code == "package.optional_absent"
+    assert optional.status is DiagnosticStatus.SKIP
+    assert report.exit_code == 0
+
+
+def test_runtime_package_diagnostics_fail_component_version_mismatch() -> None:
+    report = collect_runtime_package_diagnostics(
+        _manifest(),
+        python_version=(3, 11, 0),
+        python_executable="python",
+        version_lookup=_lookup(
+            {
+                "paper-data-suite": "0.1.0.dev0",
+                "pds-core": "0.6.1",
+                "pds-optional": "2.0.0",
+            }
+        ),
+    )
+
+    core = report.checks[2]
+    optional = report.checks[3]
+    assert core.code == "package.version_mismatch"
+    assert core.status is DiagnosticStatus.FAIL
+    assert "0.6.1" in core.summary
+    assert "0.6.0" in core.summary
+    assert optional.code == "package.version_mismatch"
+    assert optional.status is DiagnosticStatus.FAIL
+    assert report.failure_count == 2
+
+
+def test_runtime_package_diagnostics_do_not_import_optional_components() -> None:
+    observed: list[str] = []
+
+    def lookup(distribution: str) -> str:
+        observed.append(distribution)
+        if distribution == "paper-data-suite":
+            return "0.1.0.dev0"
+        if distribution == "pds-core":
+            return "0.6.0"
+        raise metadata.PackageNotFoundError(distribution)
+
+    collect_runtime_package_diagnostics(
+        _manifest(),
+        python_version=(3, 11, 0),
+        python_executable="python",
+        version_lookup=lookup,
+    )
+
+    assert observed == ["paper-data-suite", "pds-core", "pds-optional"]
+
+
+def test_environment_dependency_diagnostics_accept_matching_marker_and_pip(
+    tmp_path: Path,
+) -> None:
+    marker = tmp_path / ".pds-suite-environment.json"
+    marker.write_text(_marker_text(), encoding="utf-8")
+
+    report = collect_environment_dependency_diagnostics(
+        _manifest(),
+        environment_root=tmp_path,
+        python_executable="python",
+        platform="win32",
+        version_lookup=_lookup(
+            {
+                "pds-core": "0.6.0",
+                "pds-optional": "1.2.3",
+            }
+        ),
+        manifest_digest_lookup=lambda: "a" * 64,
+        command_lookup=lambda command: rf"C:\Tools\{command}.exe",
+        command_runner=_completed(0, "No broken requirements found.\n"),
+    )
+
+    assert tuple((check.code, check.status) for check in report.checks) == (
+        ("suite.marker_match", DiagnosticStatus.PASS),
+        ("dependencies.consistent", DiagnosticStatus.PASS),
+        ("external.command_available", DiagnosticStatus.PASS),
+    )
+    assert marker.read_text(encoding="utf-8") == _marker_text()
+
+
+def test_environment_dependency_diagnostics_warn_when_marker_missing(
+    tmp_path: Path,
+) -> None:
+    report = collect_environment_dependency_diagnostics(
+        _manifest(),
+        environment_root=tmp_path,
+        python_executable="python",
+        platform="win32",
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        command_runner=_completed(0),
+    )
+
+    marker = report.checks[0]
+    prerequisite = report.checks[2]
+    assert marker.code == "suite.marker_missing"
+    assert marker.status is DiagnosticStatus.WARN
+    assert prerequisite.code == "external.not_required"
+    assert prerequisite.status is DiagnosticStatus.SKIP
+    assert report.exit_code == 0
+    assert tuple(tmp_path.iterdir()) == ()
+
+
+def test_environment_dependency_diagnostics_fail_invalid_marker(tmp_path: Path) -> None:
+    (tmp_path / ".pds-suite-environment.json").write_text("{", encoding="utf-8")
+
+    report = collect_environment_dependency_diagnostics(
+        _manifest(),
+        environment_root=tmp_path,
+        python_executable="python",
+        platform="darwin",
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        command_runner=_completed(0),
+    )
+
+    marker = report.checks[0]
+    assert marker.code == "suite.marker_invalid"
+    assert marker.status is DiagnosticStatus.FAIL
+    assert report.exit_code == 1
+
+
+def test_environment_dependency_diagnostics_fail_marker_composition_mismatch(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".pds-suite-environment.json").write_text(
+        _marker_text(version="9.9.9", digest="b" * 64),
+        encoding="utf-8",
+    )
+
+    report = collect_environment_dependency_diagnostics(
+        _manifest(),
+        environment_root=tmp_path,
+        python_executable="python",
+        platform="darwin",
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        manifest_digest_lookup=lambda: "a" * 64,
+        command_runner=_completed(0),
+    )
+
+    marker = report.checks[0]
+    assert marker.code == "suite.marker_mismatch"
+    assert marker.status is DiagnosticStatus.FAIL
+    assert "suite version" in (marker.detail or "")
+    assert "digest" in (marker.detail or "")
+
+
+def test_environment_dependency_diagnostics_report_pip_check_failure(
+    tmp_path: Path,
+) -> None:
+    report = collect_environment_dependency_diagnostics(
+        _manifest(),
+        environment_root=tmp_path,
+        python_executable="python",
+        platform="darwin",
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        command_runner=_completed(
+            1,
+            stderr=(
+                "broken-one requires dependency-x\n"
+                "broken-two requires dependency-y\n"
+            ),
+        ),
+    )
+
+    dependency = report.checks[1]
+    assert dependency.code == "dependencies.inconsistent"
+    assert dependency.status is DiagnosticStatus.FAIL
+    assert "broken-one" in (dependency.detail or "")
+    assert "broken-two" in (dependency.detail or "")
+
+
+def test_environment_dependency_diagnostics_bound_pip_check_output(
+    tmp_path: Path,
+) -> None:
+    output = "\n".join(f"failure-{index}-" + "x" * 200 for index in range(10))
+    report = collect_environment_dependency_diagnostics(
+        _manifest(),
+        environment_root=tmp_path,
+        python_executable="python",
+        platform="darwin",
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        command_runner=_completed(1, stderr=output),
+    )
+
+    detail = report.checks[1].detail or ""
+    assert len(detail) <= 500
+    assert detail.endswith("...")
+
+
+def test_environment_dependency_diagnostics_report_pip_timeout(
+    tmp_path: Path,
+) -> None:
+    def timeout_runner(
+        args: object,
+        *,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        del capture_output, text, check
+        raise subprocess.TimeoutExpired(args, timeout)
+
+    report = collect_environment_dependency_diagnostics(
+        _manifest(),
+        environment_root=tmp_path,
+        python_executable="python",
+        platform="darwin",
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        command_runner=timeout_runner,
+        pip_check_timeout_seconds=3.0,
+    )
+
+    dependency = report.checks[1]
+    assert dependency.code == "dependencies.pip_check_timeout"
+    assert dependency.status is DiagnosticStatus.FAIL
+    assert "3 seconds" in (dependency.detail or "")
+
+
+def test_external_prerequisite_missing_is_failure_for_qualified_consumer(
+    tmp_path: Path,
+) -> None:
+    report = collect_environment_dependency_diagnostics(
+        _manifest(),
+        environment_root=tmp_path,
+        python_executable="python",
+        platform="linux",
+        version_lookup=_lookup(
+            {
+                "pds-core": "0.6.0",
+                "pds-optional": "1.2.3",
+            }
+        ),
+        command_lookup=lambda command: None,
+        command_runner=_completed(0),
+    )
+
+    prerequisite = report.checks[2]
+    assert prerequisite.code == "external.command_missing"
+    assert prerequisite.status is DiagnosticStatus.FAIL
+    assert "Optional" in prerequisite.summary
+    assert "pdftoppm" in (prerequisite.detail or "")
+
+
+def test_external_prerequisite_skips_mismatched_optional_consumer(
+    tmp_path: Path,
+) -> None:
+    lookups: list[str] = []
+
+    def command_lookup(command: str) -> str | None:
+        lookups.append(command)
+        return None
+
+    report = collect_environment_dependency_diagnostics(
+        _manifest(),
+        environment_root=tmp_path,
+        python_executable="python",
+        platform="win32",
+        version_lookup=_lookup(
+            {
+                "pds-core": "0.6.0",
+                "pds-optional": "9.9.9",
+            }
+        ),
+        command_lookup=command_lookup,
+        command_runner=_completed(0),
+    )
+
+    prerequisite = report.checks[2]
+    assert prerequisite.code == "external.not_required"
+    assert prerequisite.status is DiagnosticStatus.SKIP
+    assert lookups == []
+
+
+def test_external_prerequisite_is_platform_scoped(tmp_path: Path) -> None:
+    report = collect_environment_dependency_diagnostics(
+        _manifest(),
+        environment_root=tmp_path,
+        python_executable="python",
+        platform="darwin",
+        version_lookup=_lookup(
+            {
+                "pds-core": "0.6.0",
+                "pds-optional": "1.2.3",
+            }
+        ),
+        command_lookup=lambda command: pytest.fail(
+            f"unexpected command lookup: {command}"
+        ),
+        command_runner=_completed(0),
+    )
+
+    assert len(report.checks) == 2
+
+
+def _entry_point(
+    component_id: str,
+    distribution: str,
+    version: str,
+    *,
+    target: str | None = None,
+) -> EntryPointObservation:
+    return EntryPointObservation(
+        group="console_scripts",
+        name=component_id,
+        target=target or f"{component_id}.cli:main",
+        distribution=distribution,
+        distribution_version=version,
+    )
+
+
+def _core_importer(*, missing: str | None = None, failing: str | None = None):
+    attributes = {
+        "pds_core.workspace": "inspect_workspace_root",
+        "pds_core.school_years": "get_active_school_year",
+        "pds_core.registry_audit": "get_academic_registry_status",
+    }
+
+    def importer(module_name: str) -> object:
+        if module_name == failing:
+            raise ImportError(f"cannot import {module_name}")
+        attribute = attributes[module_name]
+        if module_name == missing:
+            return SimpleNamespace()
+        return SimpleNamespace(**{attribute: lambda: None})
+
+    return importer
+
+
+def test_entry_point_core_diagnostics_accept_exact_metadata_and_core_contracts(
+) -> None:
+    report = collect_entry_point_core_diagnostics(
+        _manifest(),
+        version_lookup=_lookup(
+            {
+                "pds-core": "0.6.0",
+                "pds-optional": "1.2.3",
+            }
+        ),
+        entry_point_inventory_lookup=lambda: (
+            _entry_point("optional", "pds-optional", "1.2.3"),
+            _entry_point("core", "pds-core", "0.6.0"),
+        ),
+        module_importer=_core_importer(),
+    )
+
+    assert tuple((check.code, check.status) for check in report.checks) == (
+        ("entry_point.match", DiagnosticStatus.PASS),
+        ("entry_point.match", DiagnosticStatus.PASS),
+        ("core.contract_available", DiagnosticStatus.PASS),
+        ("core.contract_available", DiagnosticStatus.PASS),
+        ("core.contract_available", DiagnosticStatus.PASS),
+    )
+    assert report.exit_code == 0
+
+
+def test_entry_point_core_diagnostics_skip_unqualified_optional_component() -> None:
+    report = collect_entry_point_core_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        entry_point_inventory_lookup=lambda: (
+            _entry_point("core", "pds-core", "0.6.0"),
+        ),
+        module_importer=_core_importer(),
+    )
+
+    optional = report.checks[1]
+    assert optional.component_id == "optional"
+    assert optional.code == "entry_point.component_unqualified"
+    assert optional.status is DiagnosticStatus.SKIP
+    assert report.exit_code == 0
+
+
+def test_entry_point_core_diagnostics_fail_missing_expected_entry_point() -> None:
+    report = collect_entry_point_core_diagnostics(
+        _manifest(),
+        version_lookup=_lookup(
+            {"pds-core": "0.6.0", "pds-optional": "1.2.3"}
+        ),
+        entry_point_inventory_lookup=lambda: (
+            _entry_point("core", "pds-core", "0.6.0"),
+        ),
+        module_importer=_core_importer(),
+    )
+
+    check = report.checks[1]
+    assert check.component_id == "optional"
+    assert check.code == "entry_point.missing"
+    assert check.status is DiagnosticStatus.FAIL
+
+
+def test_entry_point_core_diagnostics_fail_target_mismatch() -> None:
+    report = collect_entry_point_core_diagnostics(
+        _manifest(),
+        version_lookup=_lookup(
+            {"pds-core": "0.6.0", "pds-optional": "1.2.3"}
+        ),
+        entry_point_inventory_lookup=lambda: (
+            _entry_point("core", "pds-core", "0.6.0"),
+            _entry_point(
+                "optional",
+                "pds-optional",
+                "1.2.3",
+                target="optional.bad:main",
+            ),
+        ),
+        module_importer=_core_importer(),
+    )
+
+    check = report.checks[1]
+    assert check.code == "entry_point.target_mismatch"
+    assert check.status is DiagnosticStatus.FAIL
+    assert "optional.bad:main" in (check.detail or "")
+
+
+def test_entry_point_core_diagnostics_fail_wrong_owner() -> None:
+    report = collect_entry_point_core_diagnostics(
+        _manifest(),
+        version_lookup=_lookup(
+            {"pds-core": "0.6.0", "pds-optional": "1.2.3"}
+        ),
+        entry_point_inventory_lookup=lambda: (
+            _entry_point("core", "pds-core", "0.6.0"),
+            _entry_point("optional", "other-package", "4.5.6"),
+        ),
+        module_importer=_core_importer(),
+    )
+
+    check = report.checks[1]
+    assert check.code == "entry_point.owner_mismatch"
+    assert check.status is DiagnosticStatus.FAIL
+    assert "other-package" in (check.detail or "")
+
+
+def test_entry_point_core_diagnostics_fail_foreign_conflict() -> None:
+    report = collect_entry_point_core_diagnostics(
+        _manifest(),
+        version_lookup=_lookup(
+            {"pds-core": "0.6.0", "pds-optional": "1.2.3"}
+        ),
+        entry_point_inventory_lookup=lambda: (
+            _entry_point("core", "pds-core", "0.6.0"),
+            _entry_point("optional", "pds_optional", "1.2.3"),
+            _entry_point("optional", "other-package", "4.5.6"),
+        ),
+        module_importer=_core_importer(),
+    )
+
+    check = report.checks[1]
+    assert check.code == "entry_point.conflict"
+    assert check.status is DiagnosticStatus.FAIL
+
+
+def test_entry_point_core_diagnostics_fail_duplicate_owner_definition() -> None:
+    optional = _entry_point("optional", "pds-optional", "1.2.3")
+    report = collect_entry_point_core_diagnostics(
+        _manifest(),
+        version_lookup=_lookup(
+            {"pds-core": "0.6.0", "pds-optional": "1.2.3"}
+        ),
+        entry_point_inventory_lookup=lambda: (
+            _entry_point("core", "pds-core", "0.6.0"),
+            optional,
+            optional,
+        ),
+        module_importer=_core_importer(),
+    )
+
+    check = report.checks[1]
+    assert check.code == "entry_point.duplicate"
+    assert check.status is DiagnosticStatus.FAIL
+
+
+def test_entry_point_inventory_failure_does_not_block_core_contract_checks() -> None:
+    def unavailable() -> tuple[EntryPointObservation, ...]:
+        raise RuntimeError("metadata unavailable")
+
+    report = collect_entry_point_core_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        entry_point_inventory_lookup=unavailable,
+        module_importer=_core_importer(),
+    )
+
+    assert report.checks[0].code == "entry_point.inventory_unavailable"
+    assert tuple(check.code for check in report.checks[1:]) == (
+        "core.contract_available",
+        "core.contract_available",
+        "core.contract_available",
+    )
+
+
+def test_core_contract_checks_skip_when_core_version_is_not_qualified() -> None:
+    imported: list[str] = []
+
+    def importer(module_name: str) -> object:
+        imported.append(module_name)
+        return SimpleNamespace()
+
+    report = collect_entry_point_core_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.1"}),
+        entry_point_inventory_lookup=lambda: (),
+        module_importer=importer,
+    )
+
+    core = report.for_section("Core")
+    assert len(core) == 1
+    assert core[0].code == "core.contracts_skipped"
+    assert core[0].status is DiagnosticStatus.SKIP
+    assert imported == []
+
+
+def test_core_contract_checks_isolate_missing_and_failed_public_contracts() -> None:
+    def importer(module_name: str) -> object:
+        if module_name == "pds_core.registry_audit":
+            raise ImportError("registry import failed")
+        if module_name == "pds_core.school_years":
+            return SimpleNamespace()
+        return SimpleNamespace(inspect_workspace_root=lambda: None)
+
+    report = collect_entry_point_core_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        entry_point_inventory_lookup=lambda: (
+            _entry_point("core", "pds-core", "0.6.0"),
+        ),
+        module_importer=importer,
+    )
+
+    core = report.for_section("Core")
+    assert tuple((check.code, check.status) for check in core) == (
+        ("core.contract_available", DiagnosticStatus.PASS),
+        ("core.contract_missing", DiagnosticStatus.FAIL),
+        ("core.contract_import_failed", DiagnosticStatus.FAIL),
+    )
+    assert report.failure_count == 2
+
+
+
+def _workspace_services(
+    *,
+    status: SimpleNamespace,
+    school_year: str | None = "2026-2027",
+    registry: SimpleNamespace | None = None,
+    observed_workspace: list[object] | None = None,
+    observed_verify: list[bool] | None = None,
+):
+    registry_status = registry or SimpleNamespace(
+        canonical_valid=True,
+        contracts_compatible=True,
+        catalog_state="ready",
+        catalog_sources_current=True,
+        lock_count=0,
+        temporary_artifact_count=0,
+        findings=(),
+    )
+
+    def inspect_workspace_root(workspace=None):
+        if observed_workspace is not None:
+            observed_workspace.append(workspace)
+        return status
+
+    def get_active_school_year(root):
+        assert Path(root) == Path(status.root)
+        return school_year
+
+    def get_academic_registry_status(root, *, verify_manifests=False):
+        assert Path(root) == Path(status.root)
+        if observed_verify is not None:
+            observed_verify.append(verify_manifests)
+        return registry_status
+
+    return SimpleNamespace(
+        inspect_workspace_root=inspect_workspace_root,
+        get_active_school_year=get_active_school_year,
+        get_academic_registry_status=get_academic_registry_status,
+    )
+
+
+def _workspace_status(
+    root: Path,
+    *,
+    exists: bool = True,
+    is_dir: bool = True,
+    is_writable: bool = True,
+    source: str = "explicit",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        root=root,
+        source=source,
+        exists=exists,
+        is_dir=is_dir,
+        is_writable=is_writable,
+    )
+
+
+def test_workspace_registry_diagnostics_use_explicit_override_read_only(
+    tmp_path: Path,
+) -> None:
+    observed_workspace: list[object] = []
+    observed_verify: list[bool] = []
+    status = _workspace_status(tmp_path)
+    services = _workspace_services(
+        status=status,
+        observed_workspace=observed_workspace,
+        observed_verify=observed_verify,
+    )
+    before = tuple(tmp_path.iterdir())
+
+    report = collect_workspace_registry_diagnostics(
+        _manifest(),
+        workspace=tmp_path,
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        services=services,
+    )
+
+    assert observed_workspace == [tmp_path]
+    assert observed_verify == [False]
+    assert tuple(tmp_path.iterdir()) == before
+    assert tuple((check.code, check.status) for check in report.checks) == (
+        ("workspace.accessible", DiagnosticStatus.PASS),
+        ("school_year.active", DiagnosticStatus.PASS),
+        ("registry.canonical_valid", DiagnosticStatus.PASS),
+        ("registry.contracts_compatible", DiagnosticStatus.PASS),
+        ("registry.catalog_ready", DiagnosticStatus.PASS),
+        ("registry.coordination_clear", DiagnosticStatus.PASS),
+        ("registry.findings_clear", DiagnosticStatus.PASS),
+    )
+
+
+def test_workspace_registry_diagnostics_skip_when_core_is_unqualified() -> None:
+    report = collect_workspace_registry_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.1"}),
+        module_importer=lambda name: pytest.fail(f"unexpected import: {name}"),
+    )
+
+    assert tuple(check.status for check in report.checks) == (
+        DiagnosticStatus.SKIP,
+        DiagnosticStatus.SKIP,
+        DiagnosticStatus.SKIP,
+    )
+    assert report.checks[0].code == "workspace.core_unqualified"
+
+
+def test_workspace_registry_diagnostics_warn_missing_workspace(tmp_path: Path) -> None:
+    status = _workspace_status(
+        tmp_path / "missing",
+        exists=False,
+        is_dir=False,
+        is_writable=True,
+        source="default",
+    )
+    calls: list[str] = []
+
+    def school_year(root):
+        calls.append("school")
+        return "2026-2027"
+
+    def registry(root, *, verify_manifests=False):
+        calls.append("registry")
+        raise AssertionError("registry should not run")
+
+    services = SimpleNamespace(
+        inspect_workspace_root=lambda workspace=None: status,
+        get_active_school_year=school_year,
+        get_academic_registry_status=registry,
+    )
+    report = collect_workspace_registry_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        services=services,
+    )
+
+    assert report.checks[0].code == "workspace.not_configured"
+    assert report.checks[0].status is DiagnosticStatus.WARN
+    assert tuple(check.status for check in report.checks[1:]) == (
+        DiagnosticStatus.SKIP,
+        DiagnosticStatus.SKIP,
+    )
+    assert calls == []
+    assert report.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    ("is_dir", "is_writable", "code"),
+    [
+        (False, False, "workspace.not_directory"),
+        (True, False, "workspace.not_writable"),
+    ],
+)
+def test_workspace_registry_diagnostics_fail_inaccessible_workspace(
+    tmp_path: Path,
+    is_dir: bool,
+    is_writable: bool,
+    code: str,
+) -> None:
+    status = _workspace_status(
+        tmp_path,
+        is_dir=is_dir,
+        is_writable=is_writable,
+    )
+    report = collect_workspace_registry_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        services=_workspace_services(status=status),
+    )
+
+    assert report.checks[0].code == code
+    assert report.checks[0].status is DiagnosticStatus.FAIL
+    assert report.checks[1].status is DiagnosticStatus.SKIP
+    assert report.checks[2].status is DiagnosticStatus.SKIP
+
+
+def test_workspace_registry_diagnostics_isolate_school_year_failure(
+    tmp_path: Path,
+) -> None:
+    status = _workspace_status(tmp_path)
+    registry_calls: list[bool] = []
+
+    def school_year(root):
+        raise ValueError("invalid school year state")
+
+    healthy_registry = SimpleNamespace(
+        canonical_valid=True,
+        contracts_compatible=True,
+        catalog_state="ready",
+        catalog_sources_current=True,
+        lock_count=0,
+        temporary_artifact_count=0,
+        findings=(),
+    )
+
+    def registry(root, *, verify_manifests=False):
+        registry_calls.append(verify_manifests)
+        return healthy_registry
+
+    services = SimpleNamespace(
+        inspect_workspace_root=lambda workspace=None: status,
+        get_active_school_year=school_year,
+        get_academic_registry_status=registry,
+    )
+    report = collect_workspace_registry_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        services=services,
+    )
+
+    assert report.checks[1].code == "school_year.state_invalid"
+    assert report.checks[1].status is DiagnosticStatus.FAIL
+    assert registry_calls == [False]
+    assert report.checks[2].status is DiagnosticStatus.PASS
+
+
+def test_workspace_registry_diagnostics_warn_no_active_school_year(
+    tmp_path: Path,
+) -> None:
+    status = _workspace_status(tmp_path)
+    report = collect_workspace_registry_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        services=_workspace_services(status=status, school_year=None),
+    )
+
+    assert report.checks[1].code == "school_year.not_active"
+    assert report.checks[1].status is DiagnosticStatus.WARN
+    assert report.exit_code == 0
+
+
+def test_workspace_registry_diagnostics_surface_registry_health(
+    tmp_path: Path,
+) -> None:
+    status = _workspace_status(tmp_path)
+    registry = SimpleNamespace(
+        canonical_valid=False,
+        contracts_compatible=False,
+        catalog_state="invalid",
+        catalog_sources_current=False,
+        lock_count=2,
+        temporary_artifact_count=1,
+        findings=(
+            SimpleNamespace(severity="error", code="catalog.snapshot_mismatch"),
+            SimpleNamespace(severity="warning", code="locks.present"),
+        ),
+    )
+    report = collect_workspace_registry_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        services=_workspace_services(status=status, registry=registry),
+    )
+
+    registry_checks = report.for_section("Core registry")
+    assert tuple((check.code, check.status) for check in registry_checks) == (
+        ("registry.canonical_invalid", DiagnosticStatus.FAIL),
+        ("registry.contracts_incompatible", DiagnosticStatus.FAIL),
+        ("registry.catalog_unhealthy", DiagnosticStatus.FAIL),
+        ("registry.coordination_present", DiagnosticStatus.WARN),
+        ("registry.findings_error", DiagnosticStatus.FAIL),
+    )
+    assert "catalog.snapshot_mismatch" in (registry_checks[-1].detail or "")
+    assert report.exit_code == 1
+
+
+def test_workspace_registry_diagnostics_warn_missing_catalog(tmp_path: Path) -> None:
+    status = _workspace_status(tmp_path)
+    registry = SimpleNamespace(
+        canonical_valid=True,
+        contracts_compatible=None,
+        catalog_state="missing",
+        catalog_sources_current=None,
+        lock_count=0,
+        temporary_artifact_count=0,
+        findings=(),
+    )
+    report = collect_workspace_registry_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        services=_workspace_services(status=status, registry=registry),
+    )
+
+    registry_checks = report.for_section("Core registry")
+    assert registry_checks[1].code == "registry.contracts_not_reported"
+    assert registry_checks[1].status is DiagnosticStatus.SKIP
+    assert registry_checks[2].code == "registry.catalog_missing"
+    assert registry_checks[2].status is DiagnosticStatus.WARN
+    assert report.exit_code == 0
+
+
+def test_workspace_registry_diagnostics_isolate_registry_failure(
+    tmp_path: Path,
+) -> None:
+    status = _workspace_status(tmp_path)
+
+    def registry(root, *, verify_manifests=False):
+        assert verify_manifests is False
+        raise RuntimeError("registry unavailable")
+
+    services = SimpleNamespace(
+        inspect_workspace_root=lambda workspace=None: status,
+        get_active_school_year=lambda root: "2026-2027",
+        get_academic_registry_status=registry,
+    )
+    report = collect_workspace_registry_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        services=services,
+    )
+
+    assert report.checks[0].status is DiagnosticStatus.PASS
+    assert report.checks[1].status is DiagnosticStatus.PASS
+    assert report.checks[2].code == "registry.inspection_failed"
+    assert report.checks[2].status is DiagnosticStatus.FAIL
+
+
+def test_workspace_registry_diagnostics_fail_missing_core_service() -> None:
+    def importer(module_name: str) -> object:
+        if module_name == "pds_core.workspace":
+            return SimpleNamespace()
+        return SimpleNamespace(
+            get_active_school_year=lambda root: None,
+            get_academic_registry_status=lambda root, verify_manifests=False: None,
+        )
+
+    report = collect_workspace_registry_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        module_importer=importer,
+    )
+
+    assert report.checks[0].code == "workspace.core_service_unavailable"
+    assert report.checks[0].status is DiagnosticStatus.FAIL
+    assert report.checks[1].status is DiagnosticStatus.SKIP
+    assert report.checks[2].status is DiagnosticStatus.SKIP
+
+
+def test_workspace_registry_diagnostics_load_public_core_services(
+    tmp_path: Path,
+) -> None:
+    status = _workspace_status(tmp_path, source="saved_config")
+    imports: list[str] = []
+
+    def importer(module_name: str) -> object:
+        imports.append(module_name)
+        if module_name == "pds_core.workspace":
+            return SimpleNamespace(
+                inspect_workspace_root=lambda workspace=None: status
+            )
+        if module_name == "pds_core.school_years":
+            return SimpleNamespace(
+                get_active_school_year=lambda root: "2026-2027"
+            )
+        if module_name == "pds_core.registry_audit":
+            return SimpleNamespace(
+                get_academic_registry_status=lambda root, verify_manifests=False: (
+                    SimpleNamespace(
+                        canonical_valid=True,
+                        contracts_compatible=True,
+                        catalog_state="ready",
+                        catalog_sources_current=True,
+                        lock_count=0,
+                        temporary_artifact_count=0,
+                        findings=(),
+                    )
+                )
+            )
+        raise AssertionError(module_name)
+
+    report = collect_workspace_registry_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        module_importer=importer,
+    )
+
+    assert imports == [
+        "pds_core.workspace",
+        "pds_core.school_years",
+        "pds_core.registry_audit",
+    ]
+    assert report.checks[0].status is DiagnosticStatus.PASS
+    assert report.exit_code == 0
+
+
+def test_workspace_registry_diagnostics_isolate_workspace_inspection_failure(
+) -> None:
+    def inspect(workspace=None):
+        raise ValueError("workspace config is invalid")
+
+    services = SimpleNamespace(
+        inspect_workspace_root=inspect,
+        get_active_school_year=lambda root: pytest.fail("unexpected school-year read"),
+        get_academic_registry_status=lambda root, verify_manifests=False: (
+            pytest.fail("unexpected registry read")
+        ),
+    )
+    report = collect_workspace_registry_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+        services=services,
+    )
+
+    assert report.checks[0].code == "workspace.inspection_failed"
+    assert report.checks[0].status is DiagnosticStatus.FAIL
+    assert report.checks[1].status is DiagnosticStatus.SKIP
+    assert report.checks[2].status is DiagnosticStatus.SKIP
+
+
+def test_reduced_provider_diagnostics_are_explicit_skips() -> None:
+    report = collect_reduced_provider_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.0"}),
+    )
+
+    assert tuple((check.code, check.status) for check in report.checks) == (
+        ("providers.reduced_fidelity", DiagnosticStatus.SKIP),
+        ("module.readiness_unavailable", DiagnosticStatus.SKIP),
+    )
+    assert report.exit_code == 0
+    assert "module-private state is not inspected" in (report.checks[1].detail or "")
+
+
+def test_reduced_provider_diagnostics_do_not_claim_health_without_exact_core() -> None:
+    report = collect_reduced_provider_diagnostics(
+        _manifest(),
+        version_lookup=_lookup({"pds-core": "0.6.1"}),
+    )
+
+    assert all(check.status is DiagnosticStatus.SKIP for check in report.checks)
+    assert "exact suite-qualified Core" in (report.checks[0].detail or "")
+
+
+def test_collect_doctor_diagnostics_combines_supported_surfaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.doctor as doctor
+
+    manifest = _manifest()
+    monkeypatch.setattr(doctor, "load_release_compatibility_manifest", lambda: manifest)
+
+    def report(code: str, section: str) -> DoctorReport:
+        return DoctorReport(
+            (
+                DiagnosticCheck(
+                    section=section,
+                    code=code,
+                    status=DiagnosticStatus.PASS,
+                    summary=code,
+                ),
+            )
+        )
+
+    monkeypatch.setattr(
+        doctor,
+        "collect_runtime_package_diagnostics",
+        lambda active: report("runtime", "Runtime"),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "collect_environment_dependency_diagnostics",
+        lambda active: report("environment", "Suite"),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "collect_entry_point_core_diagnostics",
+        lambda active: report("entry", "Entry points"),
+    )
+
+    observed_workspace: list[object] = []
+
+    def workspace_report(active: object, *, workspace: object = None) -> DoctorReport:
+        observed_workspace.append(workspace)
+        return report("workspace", "Workspace")
+
+    monkeypatch.setattr(
+        doctor,
+        "collect_workspace_registry_diagnostics",
+        workspace_report,
+    )
+    monkeypatch.setattr(
+        doctor,
+        "collect_reduced_provider_diagnostics",
+        lambda active: report("providers", "Providers"),
+    )
+
+    combined = collect_doctor_diagnostics(workspace=Path("teacher-workspace"))
+    assert tuple(check.code for check in combined.checks) == (
+        "runtime",
+        "environment",
+        "entry",
+        "workspace",
+        "providers",
+    )
+    assert observed_workspace == [Path("teacher-workspace")]
+
+
+def test_render_doctor_report_groups_sections_and_remediation() -> None:
+    report = DoctorReport(
+        (
+            DiagnosticCheck(
+                section="Packages",
+                code="package.fail",
+                status=DiagnosticStatus.FAIL,
+                summary="Package is incompatible.",
+                detail="Expected 1.0; observed 2.0.",
+                remediation="Install the qualified package.",
+            ),
+            DiagnosticCheck(
+                section="Runtime",
+                code="python.pass",
+                status=DiagnosticStatus.PASS,
+                summary="Python is qualified.",
+            ),
+            DiagnosticCheck(
+                section="Modules",
+                code="module.skip",
+                status=DiagnosticStatus.SKIP,
+                summary="Readiness is unavailable.",
+            ),
+        )
+    )
+
+    rendered = render_doctor_report(report)
+    assert rendered.startswith("Paper Data Suite doctor\n\nRuntime\n")
+    assert rendered.index("Runtime\n") < rendered.index("Packages\n")
+    assert "  FAIL  Package is incompatible." in rendered
+    assert "        Expected 1.0; observed 2.0." in rendered
+    assert "        Fix: Install the qualified package." in rendered
+    assert "Overall\n  FAIL  1 blocker, 0 warnings." in rendered
+
+
+def test_render_doctor_report_warns_without_failure() -> None:
+    report = DoctorReport(
+        (
+            DiagnosticCheck(
+                section="Suite",
+                code="suite.warn",
+                status=DiagnosticStatus.WARN,
+                summary="Marker is missing.",
+            ),
+        )
+    )
+    assert "Overall\n  WARN  No blockers; 1 warning." in render_doctor_report(report)

--- a/tests/test_smoke_test_wheel.py
+++ b/tests/test_smoke_test_wheel.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import smoke_test_wheel
+
+
+def test_main_invokes_smoke_test_with_cli_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "suite.whl"
+    core = tmp_path / "core.whl"
+    observed: list[tuple[Path, Path]] = []
+
+    def fake_smoke_test(suite_wheel: Path, core_wheel: Path) -> None:
+        observed.append((suite_wheel, core_wheel))
+
+    monkeypatch.setattr(smoke_test_wheel, "smoke_test", fake_smoke_test)
+
+    assert smoke_test_wheel.main((str(suite), str(core))) == 0
+    assert observed == [(suite, core)]
+    assert capsys.readouterr().out.strip() == "Smoke test passed."
+
+
+def test_main_returns_failure_when_smoke_test_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "suite.whl"
+    core = tmp_path / "core.whl"
+
+    def fail_smoke_test(suite_wheel: Path, core_wheel: Path) -> None:
+        del suite_wheel, core_wheel
+        raise smoke_test_wheel.SmokeTestError("synthetic failure")
+
+    monkeypatch.setattr(smoke_test_wheel, "smoke_test", fail_smoke_test)
+
+    assert smoke_test_wheel.main((str(suite), str(core))) == 1
+    assert "synthetic failure" in capsys.readouterr().err
+
+
+def test_doctor_output_assertion_requires_reduced_fidelity_sections() -> None:
+    output = "\n".join(
+        (
+            "Paper Data Suite doctor",
+            "Runtime",
+            "Suite",
+            "Packages",
+            "Dependencies",
+            "Entry points",
+            "Core",
+            "Workspace",
+            "Core registry",
+            "Providers",
+            "Modules",
+            "Overall",
+            "No accessible workspace currently exists at the resolved path.",
+            (
+                "Routing/publication provider compatibility has reduced "
+                "diagnostic fidelity."
+            ),
+            "Shared module-reported readiness is not available.",
+        )
+    )
+
+    smoke_test_wheel._assert_doctor_output(output)
+
+
+def test_doctor_output_assertion_rejects_incomplete_report() -> None:
+    with pytest.raises(smoke_test_wheel.SmokeTestError):
+        smoke_test_wheel._assert_doctor_output("Paper Data Suite doctor\nOverall\n")


### PR DESCRIPTION
## Summary

Implements `pds doctor` for Paper Data Suite issue #6.

This adds a comprehensive, read-only environment diagnostic workflow that compares the running installation against the suite's bundled compatibility manifest, checks shared environment health through public Core APIs, and provides deterministic teacher-facing `PASS`, `WARN`, `FAIL`, and `SKIP` results with bounded remediation guidance.

Closes #6.

## What this adds

- adds the `pds doctor` CLI command;
- supports an invocation-scoped `--workspace PATH` override without saving, creating, selecting, or initializing a workspace;
- adds a typed diagnostic model with stable diagnostic codes and deterministic ordering;
- validates the running Python version against the manifest-qualified Python minors;
- validates the installed `paper-data-suite` version against the bundled suite manifest;
- validates the optional `.pds-suite-environment.json` ownership marker without creating or repairing it;
- checks exact manifest-qualified versions of Core and optional PDS components;
- runs bounded read-only dependency validation through the current interpreter's `pip check`;
- validates manifest-declared entry-point ownership, targets, duplicates, and conflicts without loading optional provider code;
- verifies the required public Core integration contracts;
- performs manifest-driven external-prerequisite checks, including `pdftoppm` only when an installed qualified component requires it;
- inspects workspace resolution, existence, directory state, and writability through Core's public workspace API;
- reports active school-year state through Core's public school-year API;
- reports bounded Core academic-registry health, including canonical state, contracts, catalog state/currency, coordination state, and warning/error findings;
- isolates failures so one diagnostic problem does not suppress unrelated checks;
- emits `SKIP` rather than inventing private compatibility logic where the suite-qualified Core contract does not yet expose failure-isolated provider or module-readiness diagnostics;
- preserves normal `argparse` exit behavior and returns:
  - `0` when no `FAIL` diagnostics exist;
  - `1` when one or more diagnostics fail;
  - `2` for invalid CLI invocation;
- adds operational documentation for `pds doctor`;
- updates the README to document the command and validation workflow.

## Core ownership boundaries

This implementation deliberately does not duplicate Core-owned provider validation or module-private readiness logic.

The currently qualified Core release does not yet expose the future failure-isolated provider diagnostics planned in Core #189 or the shared module-operations/readiness contract planned in Core #191.

Until those public contracts are available, `pds doctor` reports the affected checks as reduced-fidelity `SKIP` results rather than importing private module internals or recreating Core behavior in the suite shell.

## Installed-wheel acceptance

This PR also repairs the existing built-wheel smoke-test script so that its documented CI invocation actually executes the smoke test.

The installed-wheel smoke test now:

- creates an isolated virtual environment;
- installs the exact Core wheel and built suite wheel;
- removes source-shadowing inputs such as `PYTHONPATH`;
- verifies the installed package resolves from the isolated environment;
- exercises both:
  - `python -m paper_data_suite doctor`
  - installed `pds doctor`;
- blocks network access during diagnostic execution;
- uses a deliberately nonexistent synthetic workspace;
- verifies `doctor` does not create that workspace;
- verifies the smoke-test working directory remains clean.

## Validation

Local Windows validation:

```text
66 targeted tests passed

195 full-suite tests passed
3 expected environment-dependent tests skipped

ruff: passed
mypy: passed
git diff --check: passed
```

Package validation:

```text
python -m build
python -m twine check .\dist\*
python .\scripts\check_package.py <suite-wheel>
python .\scripts\smoke_test_wheel.py <suite-wheel> <core-wheel>
```

Result:

```text
Smoke test passed.
```

Manual `pds doctor` validation also confirmed:

- qualified Python and Core are reported correctly;
- an editable development environment without a suite ownership marker produces a nonblocking warning;
- absent optional components are reported as `SKIP`;
- workspace, school-year, catalog, registry, and coordination state are reported independently;
- provider/readiness checks degrade honestly to `SKIP` where the qualified Core contract lacks those optional public APIs;
- overall warning counts are calculated correctly.

A final explicit nonexistent-workspace test confirmed:

```powershell
pds doctor --workspace "$env:TEMP\pds-doctor-nonexistent-workspace"
```

reports the unavailable workspace, skips dependent school-year and registry checks, continues independent diagnostics, and does not create the requested directory.

## Safety and scope

`pds doctor` remains diagnostic only.

It does not:

- install, update, downgrade, or remove packages;
- install Poppler or modify `PATH`;
- contact GitHub or PyPI;
- create or modify a workspace;
- save workspace selection;
- configure a school year;
- rebuild the Core catalog;
- clear coordination locks;
- repair registry or module data;
- inspect private module storage;
- read student evidence merely to determine software health.