### PR TITLE
feat: add guided Core workspace selection and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ The suite shell is in pre-release development at `0.1.0.dev0`.
 
 There is **no supported public v0.1.0 release yet**. The package foundation is
 installable. The shell now provides read-only environment diagnostics through
-`pds doctor`, suite-qualified application inventory through `pds modules`, and
-verified out-of-process application launching through `pds launch <component-id>`.
+`pds doctor`, suite-qualified application inventory through `pds modules`,
+verified out-of-process application launching through `pds launch <component-id>`,
+and Core-backed workspace selection/validation through `pds workspace`.
 Additional teacher-facing workflows are added by later v0.1.0 issues.
 
 The package metadata requires Python 3.11 or newer and
@@ -143,6 +144,47 @@ The operational contract and installed-wheel acceptance requirements are
 documented in
 [`docs/operations/application-discovery-launching.md`](docs/operations/application-discovery-launching.md).
 
+## Workspace selection and validation
+
+Inspect the currently resolved Core workspace without creating or selecting it:
+
+```powershell
+pds workspace show
+```
+
+Run the guided review-before-write setup workflow with:
+
+```powershell
+pds workspace setup
+```
+
+Deterministic direct operations are also available:
+
+```powershell
+pds workspace validate [<path>]
+pds workspace set <path>
+pds workspace reset
+```
+
+The shell preserves Core as the workspace authority. It delegates path
+normalization, resolution precedence, initialization, validation, baseline
+structure, saved selection, and reset to public `pds_core.workspace` services.
+It does not write Core configuration or workspace-marker JSON directly.
+
+Workspace resolution remains Core-defined: an explicit invocation path outranks
+`PDS_WORKSPACE_ROOT`, which outranks Core's saved selection, which outranks Core's
+default location. The shell displays the actual source and refuses to claim that
+a saved preference can override an active `PDS_WORKSPACE_ROOT`.
+
+The guided workflow distinguishes a missing path, an empty directory, an existing
+non-empty directory, and an invalid/unusable candidate without treating absence of
+school-year, class, roster, or module data as workspace corruption. Persistent
+initialization requires explicit `USE` confirmation; cancellation before that point
+leaves selection unchanged.
+
+The operational contract and installed-wheel acceptance requirements are documented
+in [`docs/operations/workspace-setup.md`](docs/operations/workspace-setup.md).
+
 ## Architecture direction
 
 The suite shell is an orchestration and teacher-convenience layer, not a second
@@ -189,6 +231,11 @@ pds doctor
 pds doctor --workspace <path>
 pds modules
 pds launch <component-id>
+pds workspace setup
+pds workspace show
+pds workspace validate [<path>]
+pds workspace set <path>
+pds workspace reset
 
 python -m paper_data_suite
 python -m paper_data_suite --help
@@ -196,13 +243,20 @@ python -m paper_data_suite --version
 python -m paper_data_suite doctor
 python -m paper_data_suite modules
 python -m paper_data_suite launch <component-id>
+python -m paper_data_suite workspace setup
+python -m paper_data_suite workspace show
+python -m paper_data_suite workspace validate [<path>]
+python -m paper_data_suite workspace set <path>
+python -m paper_data_suite workspace reset
 ```
 
-The help/version commands, `doctor`, and `modules` do not create or select a
-workspace or perform classroom-data mutation. `doctor --workspace` is an
-invocation-scoped inspection override only. `launch` crosses only the verified
-public application boundary; module-owned behavior remains owned by the launched
-application.
+The help/version commands, `doctor`, `modules`, and `workspace show` do not
+create or select a workspace or perform classroom-data mutation.
+`doctor --workspace` is an invocation-scoped inspection override only.
+`workspace validate` validates an existing candidate without initializing or
+saving it; `workspace setup`, `set`, and `reset` are the explicit workspace
+mutation surfaces. `launch` crosses only the verified public application
+boundary; module-owned behavior remains owned by the launched application.
 
 ## Development validation
 
@@ -225,9 +279,13 @@ Then validate and smoke-test the built wheel using the exact Core 0.6.0 wheel:
 ```powershell
 python .\scripts\check_package.py <suite-wheel>
 python .\scripts\smoke_test_wheel.py <suite-wheel> <core-wheel>
+python .\scripts\smoke_test_workspace_wheel.py <suite-wheel> <core-wheel>
 ```
 
-The Core-only smoke proves legitimate partial installation behavior. To exercise
+The Core-only smoke proves legitimate partial installation behavior. The dedicated
+workspace smoke uses an isolated synthetic user profile and proves installed
+workspace show/validate/setup/set/reset behavior without touching the developer's
+real Core configuration or workspace. To exercise
 the complete suite-qualified application composition, place every exact component
 wheel declared by the manifest in one artifact directory and run:
 
@@ -272,6 +330,8 @@ Do not place a real classroom PDS workspace inside this repository.
 - [`docs/operations/application-discovery-launching.md`](docs/operations/application-discovery-launching.md)
   — suite-qualified application inventory, safe launcher resolution, and process
   boundary.
+- [`docs/operations/workspace-setup.md`](docs/operations/workspace-setup.md)
+  — Core-backed workspace selection, validation, guided setup, and reset.
 - [`docs/development-plan.md`](docs/development-plan.md) — suite-wide
   pilot-readiness and development program.
 - [`docs/pds-viz-identity.md`](docs/pds-viz-identity.md) — shared Paper Data

--- a/docs/operations/workspace-setup.md
+++ b/docs/operations/workspace-setup.md
@@ -1,0 +1,260 @@
+# Workspace selection and validation
+
+## Purpose
+
+The Paper Data Suite shell provides one guided entry point for selecting and validating the shared local workspace while preserving PDS Core as the workspace authority.
+
+The shell owns presentation and orchestration only:
+
+```text
+teacher
+  -> pds workspace ...
+      -> suite review/presentation
+          -> public pds_core.workspace services
+              -> Core-owned workspace state
+```
+
+The suite does not define a second workspace schema, write Core configuration JSON directly, parse Core's private workspace marker, or route shared workspace setup through sibling applications.
+
+The active suite compatibility manifest remains the release authority. The current `0.1.0.dev0` composition qualifies `pds-core 0.6.0` exactly even though the package dependency range is `pds-core>=0.6,<0.7`. Workspace operations fail closed when the installed Core release does not match that exact qualification.
+
+## Commands
+
+The public commands are:
+
+```powershell
+pds workspace setup
+pds workspace show
+pds workspace validate
+pds workspace validate <path>
+pds workspace set <path>
+pds workspace reset
+```
+
+Equivalent module forms are available through:
+
+```powershell
+python -m paper_data_suite workspace ...
+```
+
+`setup` is the teacher-facing review-before-write workflow. The other commands are deterministic direct operations useful for diagnostics, scripting, recovery, and explicit administration.
+
+## Core resolution precedence
+
+The shell does not implement workspace precedence itself. It consumes Core's resolved path and source.
+
+Core currently resolves in this order:
+
+```text
+explicit invocation path
+  > PDS_WORKSPACE_ROOT
+  > saved Core workspace configuration
+  > Core default workspace root
+```
+
+The shell translates Core's bounded source values into teacher-facing labels such as `environment override`, `saved workspace selection`, and `Core default location` without changing their meaning.
+
+## `pds workspace show`
+
+`show` is informational only. It reports the Core-resolved path, selection source, filesystem accessibility facts, Core configuration path, default workspace path, and a bounded presentation state.
+
+It does not create a missing workspace, save a preference, inspect student records, enumerate classes, or initialize Core metadata.
+
+A missing resolved path is not by itself a command failure. `show` may complete successfully and report `not created yet`.
+
+## `pds workspace validate [<path>]`
+
+`validate` checks whether an existing path can be used by Core without creating or selecting it.
+
+With no path, it validates the currently resolved workspace. With an explicit path, it validates only that candidate.
+
+The shell delegates to Core with creation disabled. Therefore:
+
+- a missing candidate fails and remains absent;
+- an existing writable empty directory can pass;
+- an existing writable non-empty directory can pass if Core accepts it;
+- a regular file, filesystem root, unwritable directory, or other Core-rejected candidate fails;
+- no workspace preference is changed;
+- no missing directory is initialized.
+
+Core may perform its own temporary writeability probe as part of validation. The suite does not create a separate probe.
+
+## `pds workspace set <path>`
+
+`set` is an explicit noninteractive mutation command. It asks Core to initialize the supplied path and then asks Core to save that path as the workspace preference.
+
+The operation may create:
+
+```text
+the workspace directory
+Core workspace metadata
+Core baseline directories
+Core saved workspace configuration
+```
+
+It does not move, copy, merge, or delete a previous workspace, and it does not create school years, classes, rosters, standards, Academic Periods, or module-owned records.
+
+After saving, the suite re-inspects through Core. Success is reported only when Core actually resolves the intended path.
+
+## `PDS_WORKSPACE_ROOT` environment override
+
+`PDS_WORKSPACE_ROOT` outranks the saved Core preference.
+
+If it is active, the shell displays that fact prominently. The guided workflow may initialize or validate the environment-selected path, but it does not edit or remove the environment variable.
+
+A direct attempt to run:
+
+```text
+pds workspace set <different-path>
+```
+
+while the environment override is active fails before initializing the alternate candidate. Saving a different Core preference would not make that path active, so the shell refuses to claim otherwise.
+
+`pds workspace reset` may still clear a saved preference while an environment override exists. The environment-controlled path remains active afterward.
+
+## `pds workspace reset`
+
+`reset` clears only Core's saved workspace preference. It is idempotent when no saved preference exists.
+
+It never deletes workspace files or Core metadata. After reset the shell re-inspects and shows the actual current Core resolution, which may be an environment override or Core's default location.
+
+## Guided `pds workspace setup`
+
+The guided workflow is deliberately low-density:
+
+1. show the current Core-resolved path and source;
+2. let the teacher keep the current location, choose another path, validate only, or quit;
+3. inspect and normalize the candidate through Core;
+4. show whether the candidate is missing, empty, existing/non-empty, or invalid/unusable;
+5. preview what Core will do;
+6. require the exact confirmation word `USE` before persistent mutation;
+7. initialize and, when appropriate, save through Core;
+8. re-inspect and display the actual final resolution.
+
+Blank confirmation, `Q`, Ctrl+C, or EOF cancels safely before mutation. Cancellation is not treated as an operational failure.
+
+An existing non-empty directory receives an explicit warning because Core initialization may add PDS structure beside unrelated files. The suite performs only a shallow emptiness check for this presentation distinction; it does not list or read directory contents.
+
+## Empty versus invalid
+
+The suite uses a small presentation vocabulary over public Core facts:
+
+```text
+missing
+empty directory
+existing non-empty directory
+invalid / unusable
+```
+
+These labels are not a second workspace schema.
+
+A directory is not invalid merely because it has no:
+
+```text
+school year
+classes
+rosters
+standards
+Academic Periods
+module records
+scans
+publications
+```
+
+A synchronized folder is likewise not rejected merely because it is synchronized. This issue contains no OneDrive-, Dropbox-, Google Drive-, or network-share-specific policy.
+
+## Partial completion and failure
+
+Workspace initialization and saved-selection persistence are separate Core operations. The suite does not pretend they are transactionally atomic.
+
+If initialization fails, the new preference is not saved.
+
+If initialization succeeds but saving fails, the shell reports partial completion:
+
+```text
+workspace initialization succeeded
+saved selection did not complete
+```
+
+It does not manually delete Core-created directories or metadata in an attempt to roll back work it does not own.
+
+If saving succeeds but Core subsequently resolves another path, the shell reports failure and shows the actual Core-resolved state rather than claiming success.
+
+## Relationship to `pds doctor`
+
+The responsibilities remain distinct:
+
+```text
+pds workspace
+  -> select, initialize, validate, and reset workspace context
+
+pds doctor
+  -> read-only broader environment and workspace health diagnosis
+```
+
+A newly initialized workspace may legitimately have no active school year and therefore produce later doctor warnings. That does not mean workspace initialization failed.
+
+## Relationship to later setup
+
+Workspace setup intentionally stops before shared classroom configuration.
+
+Later work owns:
+
+```text
+school-year setup
+class creation
+roster import
+standards setup
+Academic Period setup
+```
+
+The expected sequence is:
+
+```text
+select/initialize Core workspace
+  -> configure shared classroom state
+```
+
+## Backup and migration boundary
+
+Selecting a different workspace does not migrate data.
+
+The shell does not automatically:
+
+```text
+copy an old workspace
+move an old workspace
+merge two workspaces
+delete an old workspace
+create a backup
+restore a backup
+```
+
+Backup and restore are separate suite workflows.
+
+## Installed-wheel acceptance
+
+The repository includes a dedicated installed workspace smoke test:
+
+```powershell
+python .\scripts\smoke_test_workspace_wheel.py `
+  <suite-wheel> `
+  <exact-core-0.6.0-wheel>
+```
+
+The smoke test creates a fresh virtual environment and synthetic user home outside the repository, installs only the built suite wheel and exact Core wheel, strips source-shadowing and real workspace overrides, and verifies:
+
+- installed package import comes from the isolated environment;
+- initial `workspace show` does not create Core's default location;
+- validation of a missing candidate fails without creating it;
+- guided module-form setup creates and selects a synthetic workspace;
+- Core baseline directories exist after Core initialization;
+- Core reports the selected path through its public inspection API;
+- installed `pds`/`pds.exe workspace show` observes the saved selection;
+- installed reset removes only the preference and preserves the workspace;
+- direct installed `workspace set` can reselect the initialized workspace;
+- an active `PDS_WORKSPACE_ROOT` prevents a different `set` before candidate mutation;
+- a final reset leaves the initialized workspace intact;
+- the smoke working directory remains clean.
+
+The smoke environment overrides `HOME`, `USERPROFILE`, `APPDATA`, and `XDG_CONFIG_HOME` and removes inherited `PDS_WORKSPACE_ROOT` and `PYTHONPATH` variants. It therefore must not consume or mutate the teacher's actual workspace preference or classroom data.

--- a/paper_data_suite/cli.py
+++ b/paper_data_suite/cli.py
@@ -27,6 +27,13 @@ from paper_data_suite.compatibility import (
     load_release_compatibility_manifest,
 )
 from paper_data_suite.doctor import collect_doctor_diagnostics, render_doctor_report
+from paper_data_suite.workspace_cli import (
+    run_workspace_reset,
+    run_workspace_set,
+    run_workspace_setup,
+    run_workspace_show,
+    run_workspace_validate,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -59,6 +66,51 @@ def build_parser() -> argparse.ArgumentParser:
             "inspect this workspace for this invocation only; do not save or "
             "initialize it"
         ),
+    )
+    workspace = subparsers.add_parser(
+        "workspace",
+        help="inspect, validate, select, or reset the shared Core workspace",
+        description=(
+            "Inspect or explicitly change the shared Paper Data Suite workspace "
+            "through suite-qualified public Core services."
+        ),
+    )
+    workspace.set_defaults(workspace_parser=workspace)
+    workspace_subparsers = workspace.add_subparsers(dest="workspace_command")
+    workspace_subparsers.add_parser(
+        "setup",
+        help="run guided review-before-write workspace setup",
+        description=(
+            "Guided workspace selection through Core with candidate preview, "
+            "explicit confirmation, and safe cancellation."
+        ),
+    )
+    workspace_subparsers.add_parser(
+        "show",
+        help="show the currently resolved workspace without changing it",
+    )
+    workspace_validate = workspace_subparsers.add_parser(
+        "validate",
+        help="validate an existing workspace without creating or saving it",
+    )
+    workspace_validate.add_argument(
+        "path",
+        nargs="?",
+        type=Path,
+        help="optional explicit workspace candidate; default is current resolution",
+    )
+    workspace_set = workspace_subparsers.add_parser(
+        "set",
+        help="initialize and save an explicit workspace through Core",
+    )
+    workspace_set.add_argument(
+        "path",
+        type=Path,
+        help="workspace path to initialize and save",
+    )
+    workspace_subparsers.add_parser(
+        "reset",
+        help="clear only Core's saved workspace preference",
     )
     subparsers.add_parser(
         "modules",
@@ -233,6 +285,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         report = collect_doctor_diagnostics(workspace=arguments.workspace)
         print(render_doctor_report(report), end="")
         return report.exit_code
+    if arguments.command == "workspace":
+        if arguments.workspace_command is None:
+            arguments.workspace_parser.print_help()
+            return 0
+        if arguments.workspace_command == "setup":
+            return run_workspace_setup()
+        if arguments.workspace_command == "show":
+            return run_workspace_show()
+        if arguments.workspace_command == "validate":
+            return run_workspace_validate(arguments.path)
+        if arguments.workspace_command == "set":
+            return run_workspace_set(arguments.path)
+        if arguments.workspace_command == "reset":
+            return run_workspace_reset()
+        raise AssertionError(
+            f"unhandled workspace command: {arguments.workspace_command}"
+        )
     if arguments.command == "modules":
         return _run_modules()
     if arguments.command == "launch":

--- a/paper_data_suite/workspace_cli.py
+++ b/paper_data_suite/workspace_cli.py
@@ -1,0 +1,363 @@
+"""Teacher-facing rendering and deterministic CLI actions for workspace setup."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+from paper_data_suite.workspace_setup import (
+    WorkspaceObservation,
+    WorkspacePartialSuccessError,
+    WorkspacePresentationState,
+    WorkspaceSelectionResult,
+    WorkspaceSetupError,
+    initialize_resolved_workspace,
+    observe_workspace,
+    reset_workspace,
+    set_workspace,
+    validate_workspace,
+)
+
+_SOURCE_LABELS = {
+    "explicit": "explicit path",
+    "environment": "environment override",
+    "saved_config": "saved workspace selection",
+    "default": "Core default location",
+}
+_STATE_LABELS = {
+    WorkspacePresentationState.MISSING: "not created yet",
+    WorkspacePresentationState.EMPTY_DIRECTORY: "empty directory",
+    WorkspacePresentationState.EXISTING_DIRECTORY: "existing non-empty directory",
+    WorkspacePresentationState.INVALID: "invalid / unusable",
+}
+
+InputReader = Callable[[str], str]
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def workspace_source_label(source: str) -> str:
+    """Return bounded teacher-facing wording for one Core selection source."""
+    return _SOURCE_LABELS.get(source, source)
+
+
+def render_workspace_observation(
+    observation: WorkspaceObservation,
+    *,
+    title: str = "Paper Data Suite workspace",
+) -> str:
+    """Render one bounded Core-derived workspace observation."""
+    lines = [
+        title,
+        "",
+        "Path:",
+        f"  {observation.root}",
+        "",
+        "Source:",
+        f"  {workspace_source_label(observation.source)}",
+        "",
+        "State:",
+        f"  {_STATE_LABELS[observation.state]}",
+        "",
+        f"Exists: {_yes_no(observation.exists)}",
+        f"Directory: {_yes_no(observation.is_dir)}",
+        f"Writable: {_yes_no(observation.is_writable)}",
+        "",
+        f"Core configuration: {observation.config_path}",
+        f"Core default workspace: {observation.default_root}",
+        "",
+        f"Detail: {observation.reason}",
+    ]
+    if observation.source == "environment":
+        lines.extend(
+            (
+                "",
+                "PDS_WORKSPACE_ROOT controls the active workspace for this process.",
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _print_failure(error: WorkspaceSetupError) -> None:
+    print(f"Workspace command failed: {error}", file=sys.stderr)
+
+
+def run_workspace_show() -> int:
+    """Inspect and render the current Core-resolved workspace."""
+    try:
+        observation = observe_workspace()
+    except WorkspaceSetupError as error:
+        _print_failure(error)
+        return 1
+    print(render_workspace_observation(observation), end="")
+    return 0
+
+
+def run_workspace_validate(path: Path | None) -> int:
+    """Validate one existing workspace candidate without creating or saving it."""
+    try:
+        observation = validate_workspace(path)
+    except WorkspaceSetupError as error:
+        _print_failure(error)
+        return 1
+    print(
+        render_workspace_observation(
+            observation,
+            title="Workspace validation passed",
+        ),
+        end="",
+    )
+    print("No workspace preference was changed.")
+    return 0
+
+
+def _render_partial_success(error: WorkspacePartialSuccessError) -> None:
+    print(
+        "Workspace initialization succeeded, but workspace selection did not "
+        "complete.",
+        file=sys.stderr,
+    )
+    print(f"Initialized path: {error.initialized_root}", file=sys.stderr)
+    print(f"Detail: {error}", file=sys.stderr)
+    if error.resolved is not None:
+        print(
+            "Current resolved workspace: "
+            f"{error.resolved.root} ({workspace_source_label(error.resolved.source)})",
+            file=sys.stderr,
+        )
+
+
+def run_workspace_set(path: Path) -> int:
+    """Initialize and save one explicitly supplied workspace through Core."""
+    try:
+        result = set_workspace(path)
+    except WorkspacePartialSuccessError as error:
+        _render_partial_success(error)
+        return 1
+    except WorkspaceSetupError as error:
+        _print_failure(error)
+        return 1
+
+    print(
+        render_workspace_observation(
+            result.observation,
+            title="Workspace ready",
+        ),
+        end="",
+    )
+    if result.created:
+        print("Core created and initialized this workspace.")
+    else:
+        print("Core validated and initialized the existing directory.")
+    print("The workspace selection was saved through Core.")
+    print("No previous workspace files were moved, copied, or deleted.")
+    return 0
+
+
+def run_workspace_reset() -> int:
+    """Clear only Core's saved workspace preference and show actual resolution."""
+    try:
+        result = reset_workspace()
+    except WorkspaceSetupError as error:
+        _print_failure(error)
+        return 1
+
+    if result.cleared:
+        print("Cleared the saved workspace preference.")
+    else:
+        print("No saved workspace preference was set.")
+    print("No workspace files were deleted.")
+    print()
+    print(
+        render_workspace_observation(
+            result.observation,
+            title="Current resolved workspace",
+        ),
+        end="",
+    )
+    return 0
+
+
+def _read_setup_input(prompt: str, input_fn: InputReader) -> str | None:
+    """Read one guided-workflow response with safe terminal cancellation."""
+    try:
+        return input_fn(prompt).strip()
+    except (EOFError, KeyboardInterrupt):
+        return None
+
+
+def _cancel_workspace_setup() -> int:
+    print("Workspace setup cancelled. No workspace selection was changed.")
+    return 0
+
+
+def _print_setup_choices(observation: WorkspaceObservation) -> None:
+    print()
+    if observation.source == "environment":
+        print("PDS_WORKSPACE_ROOT controls the active workspace.")
+        print("1. Initialize/use this environment-selected workspace")
+        print("2. Validate this workspace without changing it")
+        print("Q. Quit")
+        return
+    print("1. Use this workspace")
+    print("2. Choose another folder")
+    print("3. Validate this workspace without changing it")
+    print("Q. Quit")
+
+
+def _preview_workspace_effects(observation: WorkspaceObservation) -> None:
+    print()
+    print("Planned workspace action")
+    print()
+    if observation.state is WorkspacePresentationState.MISSING:
+        print("This folder does not exist yet.")
+        print("Core will create and initialize the workspace.")
+    elif observation.state is WorkspacePresentationState.EMPTY_DIRECTORY:
+        print("This folder exists and is empty.")
+        print("An empty directory is not an invalid workspace.")
+        print("Core will initialize Paper Data Suite workspace structure here.")
+    elif observation.state is WorkspacePresentationState.EXISTING_DIRECTORY:
+        print("This folder already contains files or directories.")
+        print("Existing contents will not be moved or deleted.")
+        print("Core initialization may add Paper Data Suite workspace structure here.")
+        print("Confirm only if you intend to adopt this existing directory.")
+    else:
+        print("This candidate is invalid or unusable and will not be changed.")
+        return
+
+    if observation.source == "environment":
+        print()
+        print(
+            "PDS_WORKSPACE_ROOT will remain the active workspace authority for "
+            "this process."
+        )
+    else:
+        print("Core will save this location as the workspace selection.")
+    print("No previous workspace files will be moved, copied, merged, or deleted.")
+
+
+def _render_setup_success(result: WorkspaceSelectionResult) -> None:
+    print()
+    print(
+        render_workspace_observation(
+            result.observation,
+            title="Workspace ready",
+        ),
+        end="",
+    )
+    if result.created:
+        print("Core created and initialized this workspace.")
+    else:
+        print("Core validated and initialized the existing directory.")
+    if result.observation.source == "environment":
+        print("PDS_WORKSPACE_ROOT remains the active workspace authority.")
+    else:
+        print("The workspace selection was saved through Core.")
+    print("No previous workspace files were moved, copied, merged, or deleted.")
+    print("No school year or classroom setup was changed.")
+    print()
+    print("Next: pds doctor")
+
+
+def run_workspace_setup(input_fn: InputReader = input) -> int:
+    """Run the guided review-before-write Core workspace setup workflow."""
+    try:
+        current = observe_workspace()
+    except WorkspaceSetupError as error:
+        _print_failure(error)
+        return 1
+
+    print(
+        render_workspace_observation(
+            current,
+            title="Paper Data Suite workspace setup",
+        ),
+        end="",
+    )
+
+    candidate: WorkspaceObservation | None = None
+    while candidate is None:
+        _print_setup_choices(current)
+        choice = _read_setup_input("Choose an option: ", input_fn)
+        if choice is None or not choice or choice.lower() == "q":
+            return _cancel_workspace_setup()
+
+        if current.source == "environment":
+            if choice == "1":
+                candidate = current
+                break
+            if choice == "2":
+                return run_workspace_validate(None)
+            print("Choose 1, 2, or Q.")
+            continue
+
+        if choice == "1":
+            candidate = current
+            break
+        if choice == "2":
+            raw_path = _read_setup_input("Workspace folder (Q to cancel): ", input_fn)
+            if raw_path is None or not raw_path or raw_path.lower() == "q":
+                return _cancel_workspace_setup()
+            try:
+                candidate = observe_workspace(Path(raw_path))
+            except WorkspaceSetupError as error:
+                _print_failure(error)
+                return 1
+            break
+        if choice == "3":
+            return run_workspace_validate(None)
+        print("Choose 1, 2, 3, or Q.")
+
+    assert candidate is not None
+    print()
+    print(
+        render_workspace_observation(
+            candidate,
+            title="Workspace candidate",
+        ),
+        end="",
+    )
+    _preview_workspace_effects(candidate)
+
+    if candidate.state is WorkspacePresentationState.INVALID:
+        print(
+            "Workspace setup cannot continue with this candidate.",
+            file=sys.stderr,
+        )
+        return 1
+
+    confirmation = _read_setup_input(
+        "Type USE to continue, or press Enter/Q to cancel: ",
+        input_fn,
+    )
+    if confirmation is None or confirmation.upper() != "USE":
+        return _cancel_workspace_setup()
+
+    try:
+        if candidate.source == "environment":
+            result = initialize_resolved_workspace()
+        else:
+            result = set_workspace(candidate.root)
+    except WorkspacePartialSuccessError as error:
+        _render_partial_success(error)
+        return 1
+    except WorkspaceSetupError as error:
+        _print_failure(error)
+        return 1
+
+    _render_setup_success(result)
+    return 0
+
+
+__all__ = (
+    "render_workspace_observation",
+    "run_workspace_reset",
+    "run_workspace_setup",
+    "run_workspace_set",
+    "run_workspace_show",
+    "run_workspace_validate",
+    "workspace_source_label",
+)

--- a/paper_data_suite/workspace_setup.py
+++ b/paper_data_suite/workspace_setup.py
@@ -1,0 +1,534 @@
+"""Suite-owned orchestration over the public Core workspace contract."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from importlib import import_module, metadata
+from pathlib import Path
+from typing import Protocol, cast
+
+from paper_data_suite.compatibility import (
+    ComponentCompatibility,
+    ReleaseCompatibilityManifest,
+    load_release_compatibility_manifest,
+)
+from paper_data_suite.component_inspection import (
+    DistributionVersionLookup,
+    lookup_distribution_version,
+)
+
+ModuleImporter = Callable[[str], object]
+
+
+class WorkspaceSetupError(RuntimeError):
+    """Base class for bounded suite workspace-orchestration failures."""
+
+
+class CoreWorkspaceQualificationError(WorkspaceSetupError):
+    """Raised when the active Core installation is not suite-qualified."""
+
+
+class CoreWorkspaceServiceError(WorkspaceSetupError):
+    """Raised when a required public Core workspace service is unavailable."""
+
+
+class WorkspaceValidationError(WorkspaceSetupError):
+    """Raised when Core rejects a validate-only workspace operation."""
+
+
+class WorkspaceEnvironmentOverrideError(WorkspaceSetupError):
+    """Raised when PDS_WORKSPACE_ROOT prevents a requested selection."""
+
+
+class WorkspaceMutationError(WorkspaceSetupError):
+    """Raised when Core cannot initialize or reset workspace state."""
+
+
+class WorkspacePartialSuccessError(WorkspaceMutationError):
+    """Raised when initialization succeeded but selection could not finish."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        initialized_root: Path,
+        resolved: WorkspaceObservation | None,
+    ) -> None:
+        super().__init__(message)
+        self.initialized_root = initialized_root
+        self.resolved = resolved
+
+
+class WorkspacePresentationState(str, Enum):
+    """Small suite presentation vocabulary over public Core workspace facts."""
+
+    MISSING = "MISSING"
+    EMPTY_DIRECTORY = "EMPTY_DIRECTORY"
+    EXISTING_DIRECTORY = "EXISTING_DIRECTORY"
+    INVALID = "INVALID"
+
+
+class WorkspaceStatusLike(Protocol):
+    """Public Core workspace-status fields consumed by suite orchestration."""
+
+    root: Path
+    source: str
+    exists: bool
+    is_dir: bool
+    is_writable: bool
+    config_path: Path
+    default_root: Path
+
+
+class WorkspaceInspector(Protocol):
+    """Shape of Core's public workspace inspection callable."""
+
+    def __call__(
+        self,
+        explicit_root: str | Path | None = None,
+    ) -> WorkspaceStatusLike: ...
+
+
+class WorkspaceEnsurer(Protocol):
+    """Shape of Core's public workspace validation/initialization callable."""
+
+    def __call__(
+        self,
+        path: str | Path,
+        create: bool = True,
+    ) -> Path: ...
+
+
+class WorkspaceSaver(Protocol):
+    """Shape of Core's public saved-workspace persistence callable."""
+
+    def __call__(self, path: str | Path) -> Path: ...
+
+
+class WorkspaceResetter(Protocol):
+    """Shape of Core's public saved-workspace clearing callable."""
+
+    def __call__(self) -> bool: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CoreWorkspaceServices:
+    """Qualified public Core workspace services used by the suite."""
+
+    inspect_workspace_root: WorkspaceInspector
+    ensure_workspace_root: WorkspaceEnsurer
+    save_workspace_root: WorkspaceSaver
+    clear_saved_workspace_root: WorkspaceResetter
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceObservation:
+    """Teacher-facing bounded view of one Core-resolved workspace candidate."""
+
+    root: Path
+    source: str
+    exists: bool
+    is_dir: bool
+    is_writable: bool
+    config_path: Path
+    default_root: Path
+    state: WorkspacePresentationState
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceSelectionResult:
+    """Result of an explicit Core initialization plus saved selection."""
+
+    observation: WorkspaceObservation
+    created: bool
+    saved: bool
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceResetResult:
+    """Result after clearing only Core's saved workspace preference."""
+
+    cleared: bool
+    observation: WorkspaceObservation
+
+
+def _shared_core_component(
+    manifest: ReleaseCompatibilityManifest,
+) -> ComponentCompatibility:
+    candidates = tuple(
+        component
+        for component in manifest.components
+        if "shared_core" in component.capabilities
+    )
+    if len(candidates) != 1:
+        raise CoreWorkspaceQualificationError(
+            "The suite manifest does not identify exactly one shared Core component."
+        )
+    return candidates[0]
+
+
+def _qualify_core(
+    manifest: ReleaseCompatibilityManifest,
+    *,
+    version_lookup: DistributionVersionLookup,
+) -> ComponentCompatibility:
+    component = _shared_core_component(manifest)
+    try:
+        observed = lookup_distribution_version(component.distribution, version_lookup)
+    except (OSError, TypeError, ValueError) as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise CoreWorkspaceQualificationError(
+            f"Could not inspect {component.distribution}: {message}"
+        ) from error
+
+    if observed != component.version:
+        actual = observed or "not installed"
+        raise CoreWorkspaceQualificationError(
+            f"Installed {component.distribution} is {actual}; this suite qualifies "
+            f"exactly {component.version}. Use the verified Paper Data Suite "
+            "bootstrap/update workflow to restore the qualified environment."
+        )
+    return component
+
+
+def _required_callable(module: object, name: str) -> object:
+    value = getattr(module, name, None)
+    if not callable(value):
+        raise CoreWorkspaceServiceError(
+            f"Suite-qualified Core does not expose public callable "
+            f"pds_core.workspace.{name}."
+        )
+    return value
+
+
+def load_core_workspace_services(
+    manifest: ReleaseCompatibilityManifest | None = None,
+    *,
+    version_lookup: DistributionVersionLookup = metadata.version,
+    module_importer: ModuleImporter = import_module,
+) -> CoreWorkspaceServices:
+    """Qualify Core before importing its public workspace service module."""
+    active_manifest = manifest or load_release_compatibility_manifest()
+    _qualify_core(active_manifest, version_lookup=version_lookup)
+
+    try:
+        module = module_importer("pds_core.workspace")
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise CoreWorkspaceServiceError(
+            f"Could not import public Core workspace services: {message}"
+        ) from error
+
+    return CoreWorkspaceServices(
+        inspect_workspace_root=cast(
+            WorkspaceInspector,
+            _required_callable(module, "inspect_workspace_root"),
+        ),
+        ensure_workspace_root=cast(
+            WorkspaceEnsurer,
+            _required_callable(module, "ensure_workspace_root"),
+        ),
+        save_workspace_root=cast(
+            WorkspaceSaver,
+            _required_callable(module, "save_workspace_root"),
+        ),
+        clear_saved_workspace_root=cast(
+            WorkspaceResetter,
+            _required_callable(module, "clear_saved_workspace_root"),
+        ),
+    )
+
+
+def _status_fields(status: WorkspaceStatusLike) -> tuple[
+    Path,
+    str,
+    bool,
+    bool,
+    bool,
+    Path,
+    Path,
+]:
+    try:
+        root = Path(status.root)
+        source = status.source
+        exists = status.exists
+        is_dir = status.is_dir
+        is_writable = status.is_writable
+        config_path = Path(status.config_path)
+        default_root = Path(status.default_root)
+    except (AttributeError, TypeError, ValueError) as error:
+        raise CoreWorkspaceServiceError(
+            "Core returned an invalid workspace status result."
+        ) from error
+
+    if not isinstance(source, str) or not source.strip():
+        raise CoreWorkspaceServiceError(
+            "Core returned an invalid workspace selection source."
+        )
+    if not all(isinstance(value, bool) for value in (exists, is_dir, is_writable)):
+        raise CoreWorkspaceServiceError(
+            "Core returned invalid workspace access flags."
+        )
+    return (
+        root,
+        source,
+        exists,
+        is_dir,
+        is_writable,
+        config_path,
+        default_root,
+    )
+
+
+def _directory_has_entries(root: Path) -> bool:
+    try:
+        next(root.iterdir())
+    except StopIteration:
+        return False
+    except OSError as error:
+        raise WorkspaceValidationError(
+            f"Could not inspect whether workspace directory is empty: {error}"
+        ) from error
+    return True
+
+
+def _presentation_state(
+    *,
+    root: Path,
+    exists: bool,
+    is_dir: bool,
+    is_writable: bool,
+) -> tuple[WorkspacePresentationState, str]:
+    if not exists:
+        if is_writable:
+            return (
+                WorkspacePresentationState.MISSING,
+                "Workspace directory has not been created yet.",
+            )
+        return (
+            WorkspacePresentationState.INVALID,
+            "Workspace directory does not exist and its parent is not writable.",
+        )
+    if not is_dir:
+        return (
+            WorkspacePresentationState.INVALID,
+            "Workspace path exists but is not a directory.",
+        )
+    if not is_writable:
+        return (
+            WorkspacePresentationState.INVALID,
+            "Workspace directory is not writable according to Core.",
+        )
+    if _directory_has_entries(root):
+        return (
+            WorkspacePresentationState.EXISTING_DIRECTORY,
+            "Workspace candidate is an existing non-empty directory.",
+        )
+    return (
+        WorkspacePresentationState.EMPTY_DIRECTORY,
+        "Workspace candidate is an existing empty directory.",
+    )
+
+
+def observe_workspace(
+    explicit_root: str | Path | None = None,
+    *,
+    services: CoreWorkspaceServices | None = None,
+) -> WorkspaceObservation:
+    """Inspect one workspace candidate without initializing or saving it."""
+    active_services = services or load_core_workspace_services()
+    try:
+        status = active_services.inspect_workspace_root(explicit_root)
+    except WorkspaceSetupError:
+        raise
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise CoreWorkspaceServiceError(
+            f"Core could not inspect the workspace: {message}"
+        ) from error
+
+    (
+        root,
+        source,
+        exists,
+        is_dir,
+        is_writable,
+        config_path,
+        default_root,
+    ) = _status_fields(status)
+    state, reason = _presentation_state(
+        root=root,
+        exists=exists,
+        is_dir=is_dir,
+        is_writable=is_writable,
+    )
+    return WorkspaceObservation(
+        root=root,
+        source=source,
+        exists=exists,
+        is_dir=is_dir,
+        is_writable=is_writable,
+        config_path=config_path,
+        default_root=default_root,
+        state=state,
+        reason=reason,
+    )
+
+
+def validate_workspace(
+    explicit_root: str | Path | None = None,
+    *,
+    services: CoreWorkspaceServices | None = None,
+) -> WorkspaceObservation:
+    """Validate an existing candidate through Core without saving or creating it."""
+    active_services = services or load_core_workspace_services()
+    before = observe_workspace(explicit_root, services=active_services)
+    try:
+        active_services.ensure_workspace_root(before.root, create=False)
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise WorkspaceValidationError(
+            f"Core rejected workspace candidate {before.root}: {message}"
+        ) from error
+    return observe_workspace(explicit_root, services=active_services)
+
+
+def _safe_current_observation(
+    services: CoreWorkspaceServices,
+) -> WorkspaceObservation | None:
+    try:
+        return observe_workspace(services=services)
+    except WorkspaceSetupError:
+        return None
+
+
+def initialize_resolved_workspace(
+    *,
+    services: CoreWorkspaceServices | None = None,
+) -> WorkspaceSelectionResult:
+    """Initialize the current Core-resolved workspace without saving a preference."""
+    active_services = services or load_core_workspace_services()
+    current = observe_workspace(services=active_services)
+    created = not current.exists
+    try:
+        initialized_root = active_services.ensure_workspace_root(
+            current.root,
+            create=True,
+        )
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise WorkspaceMutationError(
+            f"Core could not initialize workspace {current.root}: {message}"
+        ) from error
+
+    resolved = observe_workspace(services=active_services)
+    if resolved.root != Path(initialized_root):
+        raise WorkspaceMutationError(
+            "Core initialized the workspace, but the active resolved workspace "
+            f"is {resolved.root} instead of {initialized_root}."
+        )
+    return WorkspaceSelectionResult(
+        observation=resolved,
+        created=created,
+        saved=False,
+    )
+
+
+def set_workspace(
+    path: str | Path,
+    *,
+    services: CoreWorkspaceServices | None = None,
+) -> WorkspaceSelectionResult:
+    """Initialize one candidate through Core and save it through Core."""
+    active_services = services or load_core_workspace_services()
+    current = observe_workspace(services=active_services)
+    candidate = observe_workspace(path, services=active_services)
+
+    if current.source == "environment" and current.root != candidate.root:
+        raise WorkspaceEnvironmentOverrideError(
+            "PDS_WORKSPACE_ROOT currently controls the active workspace at "
+            f"{current.root}. Remove or change that environment override before "
+            f"selecting {candidate.root}."
+        )
+
+    created = not candidate.exists
+    try:
+        initialized_root = active_services.ensure_workspace_root(
+            candidate.root,
+            create=True,
+        )
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise WorkspaceMutationError(
+            f"Core could not initialize workspace {candidate.root}: {message}"
+        ) from error
+
+    try:
+        saved_root = active_services.save_workspace_root(initialized_root)
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise WorkspacePartialSuccessError(
+            "Core initialized the workspace, but the saved workspace preference "
+            f"could not be updated: {message}",
+            initialized_root=Path(initialized_root),
+            resolved=_safe_current_observation(active_services),
+        ) from error
+
+    resolved = observe_workspace(services=active_services)
+    if resolved.root != Path(saved_root) or resolved.root != Path(initialized_root):
+        raise WorkspacePartialSuccessError(
+            "Core saved the workspace preference, but the active resolved workspace "
+            f"is {resolved.root} instead of {initialized_root}.",
+            initialized_root=Path(initialized_root),
+            resolved=resolved,
+        )
+
+    return WorkspaceSelectionResult(
+        observation=resolved,
+        created=created,
+        saved=True,
+    )
+
+
+def reset_workspace(
+    *,
+    services: CoreWorkspaceServices | None = None,
+) -> WorkspaceResetResult:
+    """Clear only Core's saved workspace preference and report actual resolution."""
+    active_services = services or load_core_workspace_services()
+    try:
+        cleared = active_services.clear_saved_workspace_root()
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise WorkspaceMutationError(
+            f"Core could not clear the saved workspace preference: {message}"
+        ) from error
+    return WorkspaceResetResult(
+        cleared=cleared,
+        observation=observe_workspace(services=active_services),
+    )
+
+
+__all__ = (
+    "CoreWorkspaceQualificationError",
+    "CoreWorkspaceServiceError",
+    "CoreWorkspaceServices",
+    "WorkspaceEnvironmentOverrideError",
+    "WorkspaceMutationError",
+    "WorkspaceObservation",
+    "WorkspacePartialSuccessError",
+    "WorkspacePresentationState",
+    "WorkspaceResetResult",
+    "WorkspaceSelectionResult",
+    "WorkspaceSetupError",
+    "WorkspaceValidationError",
+    "initialize_resolved_workspace",
+    "load_core_workspace_services",
+    "observe_workspace",
+    "reset_workspace",
+    "set_workspace",
+    "validate_workspace",
+)

--- a/scripts/check_package.py
+++ b/scripts/check_package.py
@@ -36,6 +36,8 @@ REQUIRED_PACKAGE_FILES = frozenset(
         "paper_data_suite/compatibility.py",
         "paper_data_suite/component_inspection.py",
         "paper_data_suite/environment_inspection.py",
+        "paper_data_suite/workspace_setup.py",
+        "paper_data_suite/workspace_cli.py",
         "paper_data_suite/data/__init__.py",
         "paper_data_suite/data/release_compatibility_v1.json",
         "paper_data_suite/py.typed",

--- a/scripts/smoke_test_workspace_wheel.py
+++ b/scripts/smoke_test_workspace_wheel.py
@@ -1,0 +1,456 @@
+"""Smoke-test installed workspace workflows from the built suite wheel."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import venv
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import cast
+
+
+class WorkspaceSmokeTestError(RuntimeError):
+    """Raised when installed workspace acceptance fails."""
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    input_text: str | None = None,
+    expected_returncode: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=dict(env),
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != expected_returncode:
+        raise WorkspaceSmokeTestError(
+            "Command returned an unexpected status "
+            f"({result.returncode}, expected {expected_returncode}): "
+            f"{' '.join(command)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _venv_python(environment: Path) -> Path:
+    if os.name == "nt":
+        return environment / "Scripts" / "python.exe"
+    return environment / "bin" / "python"
+
+
+def _scripts_directory(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> Path:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            "import sysconfig; print(sysconfig.get_path('scripts'))",
+        ],
+        cwd=cwd,
+        env=env,
+    )
+    return Path(result.stdout.strip())
+
+
+def _isolated_command_env(
+    base_env: Mapping[str, str],
+    *,
+    user_home: Path,
+) -> dict[str, str]:
+    env = dict(base_env)
+    for key in tuple(env):
+        if key.upper() in {"PYTHONPATH", "PDS_WORKSPACE_ROOT"}:
+            env.pop(key, None)
+
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONNOUSERSITE"] = "1"
+    env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    env["PIP_NO_INDEX"] = "1"
+    env["HOME"] = str(user_home)
+    env["USERPROFILE"] = str(user_home)
+    env["APPDATA"] = str(user_home / "AppData" / "Roaming")
+    env["XDG_CONFIG_HOME"] = str(user_home / ".config")
+    return env
+
+
+def _assert_clean_directory(path: Path) -> None:
+    contents = tuple(path.iterdir())
+    if contents:
+        names = ", ".join(item.name for item in contents)
+        raise WorkspaceSmokeTestError(
+            "Workspace smoke command created working-directory artifacts: " + names
+        )
+
+
+def _assert_installed_suite_location(
+    python: Path,
+    *,
+    environment: Path,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> None:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            (
+                "from pathlib import Path; import paper_data_suite; "
+                "print(Path(paper_data_suite.__file__).resolve())"
+            ),
+        ],
+        cwd=cwd,
+        env=env,
+    )
+    installed_path = Path(result.stdout.strip()).resolve()
+    try:
+        installed_path.relative_to(environment.resolve())
+    except ValueError as error:
+        raise WorkspaceSmokeTestError(
+            "Smoke test imported paper_data_suite outside the isolated environment: "
+            f"{installed_path}"
+        ) from error
+
+
+def _core_workspace_status(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> dict[str, object]:
+    code = """
+import json
+from pds_core.workspace import inspect_workspace_root
+
+status = inspect_workspace_root()
+print(json.dumps({
+    "root": str(status.root),
+    "source": status.source,
+    "exists": status.exists,
+    "is_dir": status.is_dir,
+    "is_writable": status.is_writable,
+}))
+""".strip()
+    result = _run([str(python), "-c", code], cwd=cwd, env=env)
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise WorkspaceSmokeTestError("Core workspace status was not a JSON object.")
+    return cast(dict[str, object], payload)
+
+
+def _assert_show_output(
+    output: str,
+    *,
+    root: Path,
+    source_label: str,
+) -> None:
+    required = (
+        "Paper Data Suite workspace",
+        str(root),
+        source_label,
+        "Core configuration:",
+        "Core default workspace:",
+    )
+    missing = [fragment for fragment in required if fragment not in output]
+    if missing:
+        raise WorkspaceSmokeTestError(
+            "Workspace show output is missing expected content: "
+            + ", ".join(missing)
+        )
+
+
+def _assert_workspace_initialized(root: Path) -> None:
+    required = (
+        root / ".pds",
+        root / "classes",
+        root / "scans_inbox",
+        root / "scans",
+        root / "scans" / "source",
+        root / "scans" / "review",
+    )
+    missing = [str(path) for path in required if not path.is_dir()]
+    if missing:
+        raise WorkspaceSmokeTestError(
+            "Core workspace initialization is missing expected directories: "
+            + ", ".join(missing)
+        )
+
+
+def _assert_status(
+    payload: Mapping[str, object],
+    *,
+    root: Path,
+    source: str,
+    exists: bool,
+) -> None:
+    if payload.get("root") != str(root.resolve()):
+        raise WorkspaceSmokeTestError(
+            f"Core resolved unexpected workspace root: {payload.get('root')!r}"
+        )
+    if payload.get("source") != source:
+        raise WorkspaceSmokeTestError(
+            f"Core reported unexpected workspace source: {payload.get('source')!r}"
+        )
+    if payload.get("exists") is not exists:
+        raise WorkspaceSmokeTestError(
+            f"Core reported unexpected workspace existence: {payload.get('exists')!r}"
+        )
+
+
+def smoke_test_workspace_wheel(suite_wheel: Path, core_wheel: Path) -> None:
+    """Exercise installed workspace setup beside only the exact Core wheel."""
+    suite_wheel = suite_wheel.resolve()
+    core_wheel = core_wheel.resolve()
+    if not suite_wheel.is_file():
+        raise WorkspaceSmokeTestError(f"Suite wheel does not exist: {suite_wheel}")
+    if not core_wheel.is_file():
+        raise WorkspaceSmokeTestError(f"Core wheel does not exist: {core_wheel}")
+
+    with tempfile.TemporaryDirectory(prefix="pds-workspace-smoke-") as temporary:
+        temp_root = Path(temporary)
+        environment = temp_root / "venv"
+        run_directory = temp_root / "run"
+        user_home = temp_root / "user"
+        selected_workspace = temp_root / "selected-workspace"
+        blocked_workspace = temp_root / "blocked-workspace"
+        environment_workspace = temp_root / "environment-workspace"
+        run_directory.mkdir()
+        user_home.mkdir()
+
+        venv.EnvBuilder(with_pip=True).create(environment)
+        python = _venv_python(environment)
+        command_env = _isolated_command_env(os.environ, user_home=user_home)
+
+        _run(
+            [str(python), "-m", "pip", "install", "--no-deps", str(core_wheel)],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _run(
+            [str(python), "-m", "pip", "install", "--no-deps", str(suite_wheel)],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _run(
+            [str(python), "-m", "pip", "check"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _assert_installed_suite_location(
+            python,
+            environment=environment,
+            cwd=run_directory,
+            env=command_env,
+        )
+
+        default_root = (user_home / "Paper Data Suite").resolve()
+        initial = _run(
+            [str(python), "-m", "paper_data_suite", "workspace", "show"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _assert_show_output(
+            initial.stdout,
+            root=default_root,
+            source_label="Core default location",
+        )
+        if default_root.exists():
+            raise WorkspaceSmokeTestError("Workspace show created the default root.")
+
+        validation = _run(
+            [
+                str(python),
+                "-m",
+                "paper_data_suite",
+                "workspace",
+                "validate",
+                str(selected_workspace),
+            ],
+            cwd=run_directory,
+            env=command_env,
+            expected_returncode=1,
+        )
+        if "does not exist" not in f"{validation.stdout}\n{validation.stderr}".lower():
+            raise WorkspaceSmokeTestError(
+                "Validate-only failure did not explain the missing workspace."
+            )
+        if selected_workspace.exists():
+            raise WorkspaceSmokeTestError(
+                "Validate-only command created the missing workspace."
+            )
+
+        guided_input = f"2\n{selected_workspace}\nUSE\n"
+        guided = _run(
+            [str(python), "-m", "paper_data_suite", "workspace", "setup"],
+            cwd=run_directory,
+            env=command_env,
+            input_text=guided_input,
+        )
+        guided_required = (
+            "Workspace candidate",
+            "This folder does not exist yet.",
+            "Workspace ready",
+            "saved workspace selection",
+            "No school year or classroom setup was changed.",
+            "Next: pds doctor",
+        )
+        missing_guided = [
+            fragment for fragment in guided_required if fragment not in guided.stdout
+        ]
+        if missing_guided:
+            raise WorkspaceSmokeTestError(
+                "Guided installed workspace setup is missing expected output: "
+                + ", ".join(missing_guided)
+            )
+        _assert_workspace_initialized(selected_workspace)
+        _assert_status(
+            _core_workspace_status(
+                python,
+                cwd=run_directory,
+                env=command_env,
+            ),
+            root=selected_workspace,
+            source="saved_config",
+            exists=True,
+        )
+
+        scripts = _scripts_directory(
+            python,
+            cwd=run_directory,
+            env=command_env,
+        )
+        launcher = scripts / ("pds.exe" if os.name == "nt" else "pds")
+        if not launcher.is_file():
+            raise WorkspaceSmokeTestError(
+                f"Installed pds launcher does not exist: {launcher}"
+            )
+
+        console_show = _run(
+            [str(launcher), "workspace", "show"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _assert_show_output(
+            console_show.stdout,
+            root=selected_workspace.resolve(),
+            source_label="saved workspace selection",
+        )
+
+        reset = _run(
+            [str(launcher), "workspace", "reset"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        if "No workspace files were deleted." not in reset.stdout:
+            raise WorkspaceSmokeTestError(
+                "Installed workspace reset did not report its deletion boundary."
+            )
+        if not selected_workspace.is_dir():
+            raise WorkspaceSmokeTestError("Workspace reset deleted the workspace.")
+        _assert_status(
+            _core_workspace_status(
+                python,
+                cwd=run_directory,
+                env=command_env,
+            ),
+            root=default_root,
+            source="default",
+            exists=False,
+        )
+
+        direct_set = _run(
+            [str(launcher), "workspace", "set", str(selected_workspace)],
+            cwd=run_directory,
+            env=command_env,
+        )
+        if "Workspace ready" not in direct_set.stdout:
+            raise WorkspaceSmokeTestError(
+                "Installed direct workspace set did not report success."
+            )
+        _assert_status(
+            _core_workspace_status(
+                python,
+                cwd=run_directory,
+                env=command_env,
+            ),
+            root=selected_workspace,
+            source="saved_config",
+            exists=True,
+        )
+
+        override_env = dict(command_env)
+        override_env["PDS_WORKSPACE_ROOT"] = str(environment_workspace)
+        blocked = _run(
+            [str(launcher), "workspace", "set", str(blocked_workspace)],
+            cwd=run_directory,
+            env=override_env,
+            expected_returncode=1,
+        )
+        blocked_output = f"{blocked.stdout}\n{blocked.stderr}".lower()
+        if "pds_workspace_root" not in blocked_output:
+            raise WorkspaceSmokeTestError(
+                "Environment-override refusal did not identify PDS_WORKSPACE_ROOT."
+            )
+        if blocked_workspace.exists():
+            raise WorkspaceSmokeTestError(
+                "Environment-override refusal mutated the blocked candidate."
+            )
+
+        final_reset = _run(
+            [str(launcher), "workspace", "reset"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        if "No workspace files were deleted." not in final_reset.stdout:
+            raise WorkspaceSmokeTestError("Final workspace reset was not bounded.")
+        if not selected_workspace.is_dir():
+            raise WorkspaceSmokeTestError(
+                "Final workspace reset removed initialized workspace data."
+            )
+
+        _assert_clean_directory(run_directory)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the installed workspace smoke-test parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Install the built Paper Data Suite wheel beside the exact Core wheel "
+            "and exercise guided/direct workspace workflows in an isolated user "
+            "configuration outside the source tree."
+        )
+    )
+    parser.add_argument("suite_wheel", type=Path)
+    parser.add_argument("core_wheel", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run installed workspace acceptance from the command line."""
+    arguments = build_parser().parse_args(argv)
+    try:
+        smoke_test_workspace_wheel(arguments.suite_wheel, arguments.core_wheel)
+    except WorkspaceSmokeTestError as error:
+        print(f"Workspace smoke test failed: {error}", file=sys.stderr)
+        return 1
+    print("Workspace wheel smoke test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_import_safety.py
+++ b/tests/test_import_safety.py
@@ -26,6 +26,8 @@ TRACKED_MODULES = (
         "paper_data_suite.applications",
         "paper_data_suite.application_launching",
         "paper_data_suite.cli",
+        "paper_data_suite.workspace_setup",
+        "paper_data_suite.workspace_cli",
     ],
 )
 def test_import_is_side_effect_free(

--- a/tests/test_package_compatibility.py
+++ b/tests/test_package_compatibility.py
@@ -28,6 +28,8 @@ _PACKAGE_FILES = (
     "paper_data_suite/compatibility.py",
     "paper_data_suite/component_inspection.py",
     "paper_data_suite/environment_inspection.py",
+    "paper_data_suite/workspace_setup.py",
+    "paper_data_suite/workspace_cli.py",
     "paper_data_suite/data/__init__.py",
     "paper_data_suite/py.typed",
 )
@@ -170,6 +172,36 @@ def test_package_validator_requires_application_launching_runtime_module(
     _build_wheel(
         wheel,
         omitted_package_file="paper_data_suite/application_launching.py",
+    )
+
+    with pytest.raises(
+        PackageValidationError,
+        match="missing required package files",
+    ):
+        validate_wheel(wheel)
+
+def test_package_validator_requires_workspace_setup_runtime_module(
+    tmp_path: Path,
+) -> None:
+    wheel = tmp_path / "paper_data_suite-0.1.0.dev0-py3-none-any.whl"
+    _build_wheel(
+        wheel,
+        omitted_package_file="paper_data_suite/workspace_setup.py",
+    )
+
+    with pytest.raises(
+        PackageValidationError,
+        match="missing required package files",
+    ):
+        validate_wheel(wheel)
+
+def test_package_validator_requires_workspace_cli_runtime_module(
+    tmp_path: Path,
+) -> None:
+    wheel = tmp_path / "paper_data_suite-0.1.0.dev0-py3-none-any.whl"
+    _build_wheel(
+        wheel,
+        omitted_package_file="paper_data_suite/workspace_cli.py",
     )
 
     with pytest.raises(

--- a/tests/test_smoke_test_workspace_wheel.py
+++ b/tests/test_smoke_test_workspace_wheel.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import smoke_test_workspace_wheel
+
+
+def test_main_invokes_workspace_smoke_with_cli_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "suite.whl"
+    core = tmp_path / "core.whl"
+    observed: list[tuple[Path, Path]] = []
+
+    def fake_smoke(suite_wheel: Path, core_wheel: Path) -> None:
+        observed.append((suite_wheel, core_wheel))
+
+    monkeypatch.setattr(
+        smoke_test_workspace_wheel,
+        "smoke_test_workspace_wheel",
+        fake_smoke,
+    )
+
+    assert smoke_test_workspace_wheel.main((str(suite), str(core))) == 0
+    assert observed == [(suite, core)]
+    assert capsys.readouterr().out.strip() == "Workspace wheel smoke test passed."
+
+
+def test_main_returns_failure_when_workspace_smoke_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "suite.whl"
+    core = tmp_path / "core.whl"
+
+    def fail_smoke(suite_wheel: Path, core_wheel: Path) -> None:
+        del suite_wheel, core_wheel
+        raise smoke_test_workspace_wheel.WorkspaceSmokeTestError("synthetic failure")
+
+    monkeypatch.setattr(
+        smoke_test_workspace_wheel,
+        "smoke_test_workspace_wheel",
+        fail_smoke,
+    )
+
+    assert smoke_test_workspace_wheel.main((str(suite), str(core))) == 1
+    assert "synthetic failure" in capsys.readouterr().err
+
+
+def test_isolated_command_env_removes_workspace_and_pythonpath_variants(
+    tmp_path: Path,
+) -> None:
+    result = smoke_test_workspace_wheel._isolated_command_env(
+        {
+            "PATH": "synthetic",
+            "PYTHONPATH": "source-a",
+            "PythonPath": "source-b",
+            "PDS_WORKSPACE_ROOT": "real-workspace",
+        },
+        user_home=tmp_path / "user",
+    )
+
+    assert result["PATH"] == "synthetic"
+    assert all(key.upper() != "PYTHONPATH" for key in result)
+    assert all(key.upper() != "PDS_WORKSPACE_ROOT" for key in result)
+    assert result["PYTHONNOUSERSITE"] == "1"
+    assert result["HOME"] == str(tmp_path / "user")
+    assert result["USERPROFILE"] == str(tmp_path / "user")
+    assert result["APPDATA"] == str(tmp_path / "user" / "AppData" / "Roaming")
+    assert result["XDG_CONFIG_HOME"] == str(tmp_path / "user" / ".config")
+
+
+def test_show_output_assertion_requires_path_and_source(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    output = "\n".join(
+        (
+            "Paper Data Suite workspace",
+            str(root),
+            "saved workspace selection",
+            "Core configuration:",
+            "Core default workspace:",
+        )
+    )
+
+    smoke_test_workspace_wheel._assert_show_output(
+        output,
+        root=root,
+        source_label="saved workspace selection",
+    )
+
+
+def test_show_output_assertion_rejects_wrong_source(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    with pytest.raises(
+        smoke_test_workspace_wheel.WorkspaceSmokeTestError,
+        match="missing expected content",
+    ):
+        smoke_test_workspace_wheel._assert_show_output(
+            f"Paper Data Suite workspace\n{root}\nCore configuration:\n"
+            "Core default workspace:\n",
+            root=root,
+            source_label="saved workspace selection",
+        )
+
+
+def test_workspace_initialized_assertion_requires_core_directories(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    for relative in (
+        ".pds",
+        "classes",
+        "scans_inbox",
+        "scans",
+        "scans/source",
+        "scans/review",
+    ):
+        (root / relative).mkdir(parents=True, exist_ok=True)
+
+    smoke_test_workspace_wheel._assert_workspace_initialized(root)
+
+
+def test_workspace_initialized_assertion_rejects_incomplete_root(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+
+    with pytest.raises(
+        smoke_test_workspace_wheel.WorkspaceSmokeTestError,
+        match="missing expected directories",
+    ):
+        smoke_test_workspace_wheel._assert_workspace_initialized(root)

--- a/tests/test_workspace_cli.py
+++ b/tests/test_workspace_cli.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paper_data_suite.workspace_cli import (
+    render_workspace_observation,
+    run_workspace_reset,
+    run_workspace_set,
+    run_workspace_show,
+    run_workspace_validate,
+)
+from paper_data_suite.workspace_setup import (
+    WorkspaceMutationError,
+    WorkspaceObservation,
+    WorkspacePartialSuccessError,
+    WorkspacePresentationState,
+    WorkspaceResetResult,
+    WorkspaceSelectionResult,
+    WorkspaceValidationError,
+)
+
+
+def _observation(
+    tmp_path: Path,
+    *,
+    source: str = "saved_config",
+    state: WorkspacePresentationState = WorkspacePresentationState.EMPTY_DIRECTORY,
+) -> WorkspaceObservation:
+    root = tmp_path / "workspace"
+    return WorkspaceObservation(
+        root=root,
+        source=source,
+        exists=state is not WorkspacePresentationState.MISSING,
+        is_dir=state in {
+            WorkspacePresentationState.EMPTY_DIRECTORY,
+            WorkspacePresentationState.EXISTING_DIRECTORY,
+        },
+        is_writable=state is not WorkspacePresentationState.INVALID,
+        config_path=tmp_path / "config.json",
+        default_root=tmp_path / "default",
+        state=state,
+        reason="synthetic workspace state",
+    )
+
+
+def test_renderer_prominently_reports_path_source_and_state(tmp_path: Path) -> None:
+    observation = _observation(tmp_path)
+
+    output = render_workspace_observation(observation)
+
+    assert "Paper Data Suite workspace" in output
+    assert f"  {observation.root}" in output
+    assert "saved workspace selection" in output
+    assert "empty directory" in output
+    assert "Exists: yes" in output
+    assert f"Core configuration: {observation.config_path}" in output
+
+
+def test_renderer_explains_environment_override(tmp_path: Path) -> None:
+    output = render_workspace_observation(
+        _observation(tmp_path, source="environment")
+    )
+
+    assert "environment override" in output
+    assert "PDS_WORKSPACE_ROOT controls the active workspace" in output
+
+
+def test_show_returns_zero_for_missing_informational_state(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    observation = _observation(
+        tmp_path,
+        source="default",
+        state=WorkspacePresentationState.MISSING,
+    )
+    monkeypatch.setattr(workspace_cli, "observe_workspace", lambda: observation)
+
+    assert run_workspace_show() == 0
+    output = capsys.readouterr().out
+    assert "not created yet" in output
+    assert "Core default location" in output
+
+
+def test_show_bounded_failure_returns_one(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    def fail() -> WorkspaceObservation:
+        raise WorkspaceMutationError("Core unavailable")
+
+    monkeypatch.setattr(workspace_cli, "observe_workspace", fail)
+
+    assert run_workspace_show() == 1
+    assert "Workspace command failed: Core unavailable" in capsys.readouterr().err
+
+
+def test_validate_passes_optional_path_and_reports_no_saved_change(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    observation = _observation(tmp_path)
+    observed: list[Path | None] = []
+
+    def validate(path: Path | None) -> WorkspaceObservation:
+        observed.append(path)
+        return observation
+
+    monkeypatch.setattr(workspace_cli, "validate_workspace", validate)
+    candidate = tmp_path / "candidate"
+
+    assert run_workspace_validate(candidate) == 0
+    assert observed == [candidate]
+    output = capsys.readouterr().out
+    assert "Workspace validation passed" in output
+    assert "No workspace preference was changed." in output
+
+
+def test_validate_failure_is_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    def fail(path: Path | None) -> WorkspaceObservation:
+        raise WorkspaceValidationError("candidate does not exist")
+
+    monkeypatch.setattr(workspace_cli, "validate_workspace", fail)
+
+    assert run_workspace_validate(None) == 1
+    assert "candidate does not exist" in capsys.readouterr().err
+
+
+def test_set_success_reports_created_selection_without_move_claim(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    observation = _observation(tmp_path)
+    monkeypatch.setattr(
+        workspace_cli,
+        "set_workspace",
+        lambda path: WorkspaceSelectionResult(
+            observation=observation,
+            created=True,
+            saved=True,
+        ),
+    )
+
+    assert run_workspace_set(tmp_path / "candidate") == 0
+    output = capsys.readouterr().out
+    assert "Workspace ready" in output
+    assert "Core created and initialized this workspace." in output
+    assert "No previous workspace files were moved, copied, or deleted." in output
+
+
+def test_set_partial_success_is_explicitly_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    resolved = _observation(tmp_path, source="default")
+
+    def fail(path: Path) -> WorkspaceSelectionResult:
+        raise WorkspacePartialSuccessError(
+            "saved preference failed",
+            initialized_root=tmp_path / "initialized",
+            resolved=resolved,
+        )
+
+    monkeypatch.setattr(workspace_cli, "set_workspace", fail)
+
+    assert run_workspace_set(tmp_path / "candidate") == 1
+    error = capsys.readouterr().err
+    assert "initialization succeeded" in error
+    assert f"Initialized path: {tmp_path / 'initialized'}" in error
+    assert "Current resolved workspace" in error
+
+
+def test_reset_reports_idempotent_clear_and_current_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    observation = _observation(tmp_path, source="environment")
+    monkeypatch.setattr(
+        workspace_cli,
+        "reset_workspace",
+        lambda: WorkspaceResetResult(cleared=False, observation=observation),
+    )
+
+    assert run_workspace_reset() == 0
+    output = capsys.readouterr().out
+    assert "No saved workspace preference was set." in output
+    assert "No workspace files were deleted." in output
+    assert "environment override" in output

--- a/tests/test_workspace_cli_dispatch.py
+++ b/tests/test_workspace_cli_dispatch.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paper_data_suite.cli import main
+
+
+def test_workspace_without_subcommand_prints_workspace_help(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(("workspace",)) == 0
+    output = capsys.readouterr().out
+    assert "usage: pds workspace" in output
+    assert "setup" in output
+    assert "show" in output
+    assert "validate" in output
+    assert "set" in output
+    assert "reset" in output
+
+
+def test_workspace_help_returns_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as raised:
+        main(("workspace", "--help"))
+    assert raised.value.code == 0
+    assert "usage: pds workspace" in capsys.readouterr().out
+
+
+def test_workspace_setup_help_returns_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as raised:
+        main(("workspace", "setup", "--help"))
+    assert raised.value.code == 0
+    output = capsys.readouterr().out
+    assert "usage: pds workspace setup" in output
+    assert "guided" in output.lower()
+
+
+def test_workspace_validate_help_describes_optional_path(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as raised:
+        main(("workspace", "validate", "--help"))
+    assert raised.value.code == 0
+    output = capsys.readouterr().out
+    assert "usage: pds workspace validate" in output
+    assert "path" in output
+
+
+def test_workspace_setup_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    import paper_data_suite.cli as cli
+
+    monkeypatch.setattr(cli, "run_workspace_setup", lambda: 5)
+
+    assert main(("workspace", "setup")) == 5
+
+
+def test_workspace_show_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    import paper_data_suite.cli as cli
+
+    monkeypatch.setattr(cli, "run_workspace_show", lambda: 7)
+
+    assert main(("workspace", "show")) == 7
+
+
+def test_workspace_validate_dispatches_optional_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.cli as cli
+
+    observed: list[Path | None] = []
+
+    def run(path: Path | None) -> int:
+        observed.append(path)
+        return 0
+
+    monkeypatch.setattr(cli, "run_workspace_validate", run)
+
+    assert main(("workspace", "validate")) == 0
+    assert main(("workspace", "validate", "D:/PDS Workspace")) == 0
+    assert observed == [None, Path("D:/PDS Workspace")]
+
+
+def test_workspace_set_dispatches_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    import paper_data_suite.cli as cli
+
+    observed: list[Path] = []
+
+    def run(path: Path) -> int:
+        observed.append(path)
+        return 0
+
+    monkeypatch.setattr(cli, "run_workspace_set", run)
+
+    assert main(("workspace", "set", "D:/PDS Workspace")) == 0
+    assert observed == [Path("D:/PDS Workspace")]
+
+
+def test_workspace_reset_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    import paper_data_suite.cli as cli
+
+    monkeypatch.setattr(cli, "run_workspace_reset", lambda: 6)
+
+    assert main(("workspace", "reset")) == 6

--- a/tests/test_workspace_guided_cli.py
+++ b/tests/test_workspace_guided_cli.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from paper_data_suite.workspace_cli import run_workspace_setup
+from paper_data_suite.workspace_setup import (
+    WorkspaceMutationError,
+    WorkspaceObservation,
+    WorkspacePartialSuccessError,
+    WorkspacePresentationState,
+    WorkspaceSelectionResult,
+)
+
+
+def _observation(
+    tmp_path: Path,
+    *,
+    root: Path | None = None,
+    source: str = "default",
+    state: WorkspacePresentationState = WorkspacePresentationState.MISSING,
+) -> WorkspaceObservation:
+    actual_root = root or (tmp_path / "workspace")
+    exists = state is not WorkspacePresentationState.MISSING
+    is_dir = state in {
+        WorkspacePresentationState.EMPTY_DIRECTORY,
+        WorkspacePresentationState.EXISTING_DIRECTORY,
+    }
+    return WorkspaceObservation(
+        root=actual_root,
+        source=source,
+        exists=exists,
+        is_dir=is_dir,
+        is_writable=state is not WorkspacePresentationState.INVALID,
+        config_path=tmp_path / "config.json",
+        default_root=tmp_path / "default",
+        state=state,
+        reason="synthetic workspace state",
+    )
+
+
+def _reader(*responses: str) -> Callable[[str], str]:
+    items: Iterator[str] = iter(responses)
+
+    def read(_prompt: str) -> str:
+        return next(items)
+
+    return read
+
+
+def test_setup_uses_missing_current_path_only_after_use_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    current = _observation(tmp_path)
+    ready = _observation(
+        tmp_path,
+        root=current.root,
+        source="saved_config",
+        state=WorkspacePresentationState.EMPTY_DIRECTORY,
+    )
+    selected: list[Path] = []
+    monkeypatch.setattr(workspace_cli, "observe_workspace", lambda path=None: current)
+
+    def set_candidate(path: Path) -> WorkspaceSelectionResult:
+        selected.append(path)
+        return WorkspaceSelectionResult(
+            observation=ready,
+            created=True,
+            saved=True,
+        )
+
+    monkeypatch.setattr(workspace_cli, "set_workspace", set_candidate)
+
+    assert run_workspace_setup(_reader("1", "USE")) == 0
+    assert selected == [current.root]
+    output = capsys.readouterr().out
+    assert "This folder does not exist yet." in output
+    assert "Core will create and initialize the workspace." in output
+    assert "No school year or classroom setup was changed." in output
+    assert "Next: pds doctor" in output
+
+
+def test_setup_custom_empty_folder_is_previewed_before_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    current = _observation(tmp_path)
+    candidate_root = tmp_path / "chosen"
+    candidate = _observation(
+        tmp_path,
+        root=candidate_root,
+        source="explicit",
+        state=WorkspacePresentationState.EMPTY_DIRECTORY,
+    )
+    ready = _observation(
+        tmp_path,
+        root=candidate_root,
+        source="saved_config",
+        state=WorkspacePresentationState.EMPTY_DIRECTORY,
+    )
+    selected: list[Path] = []
+
+    def observe(path: Path | None = None) -> WorkspaceObservation:
+        return current if path is None else candidate
+
+    def set_candidate(path: Path) -> WorkspaceSelectionResult:
+        selected.append(path)
+        return WorkspaceSelectionResult(ready, created=False, saved=True)
+
+    monkeypatch.setattr(workspace_cli, "observe_workspace", observe)
+    monkeypatch.setattr(workspace_cli, "set_workspace", set_candidate)
+
+    assert run_workspace_setup(
+        _reader("2", str(candidate_root), "USE")
+    ) == 0
+    assert selected == [candidate_root]
+    output = capsys.readouterr().out
+    assert "This folder exists and is empty." in output
+    assert "An empty directory is not an invalid workspace." in output
+
+
+def test_setup_existing_nonempty_folder_gets_strong_adoption_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    candidate_root = tmp_path / "existing"
+    current = _observation(tmp_path)
+    candidate = _observation(
+        tmp_path,
+        root=candidate_root,
+        source="explicit",
+        state=WorkspacePresentationState.EXISTING_DIRECTORY,
+    )
+    ready = _observation(
+        tmp_path,
+        root=candidate_root,
+        source="saved_config",
+        state=WorkspacePresentationState.EXISTING_DIRECTORY,
+    )
+    selected: list[Path] = []
+    monkeypatch.setattr(
+        workspace_cli,
+        "observe_workspace",
+        lambda path=None: current if path is None else candidate,
+    )
+    monkeypatch.setattr(
+        workspace_cli,
+        "set_workspace",
+        lambda path: (
+            selected.append(path)
+            or WorkspaceSelectionResult(ready, created=False, saved=True)
+        ),
+    )
+
+    assert run_workspace_setup(
+        _reader("2", str(candidate_root), "USE")
+    ) == 0
+    assert selected == [candidate_root]
+    output = capsys.readouterr().out
+    assert "already contains files or directories" in output
+    assert "Existing contents will not be moved or deleted." in output
+    assert "Confirm only if you intend to adopt this existing directory." in output
+
+
+@pytest.mark.parametrize("response", ["", "q", "Q"])
+def test_setup_initial_menu_cancellation_is_zero_and_does_not_select(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    response: str,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    current = _observation(tmp_path)
+    selected: list[Path] = []
+    monkeypatch.setattr(workspace_cli, "observe_workspace", lambda path=None: current)
+    monkeypatch.setattr(
+        workspace_cli,
+        "set_workspace",
+        lambda path: selected.append(path),  # type: ignore[func-returns-value]
+    )
+
+    assert run_workspace_setup(_reader(response)) == 0
+    assert selected == []
+    assert "Workspace setup cancelled." in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("exception_type", [EOFError, KeyboardInterrupt])
+def test_setup_terminal_cancellation_is_zero_and_does_not_select(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    exception_type: type[BaseException],
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    current = _observation(tmp_path)
+    selected: list[Path] = []
+    monkeypatch.setattr(workspace_cli, "observe_workspace", lambda path=None: current)
+    monkeypatch.setattr(
+        workspace_cli,
+        "set_workspace",
+        lambda path: selected.append(path),  # type: ignore[func-returns-value]
+    )
+
+    def cancel(_prompt: str) -> str:
+        raise exception_type()
+
+    assert run_workspace_setup(cancel) == 0
+    assert selected == []
+    assert "Workspace setup cancelled." in capsys.readouterr().out
+
+
+def test_setup_rejects_confirmation_other_than_use_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    current = _observation(
+        tmp_path,
+        state=WorkspacePresentationState.EMPTY_DIRECTORY,
+    )
+    selected: list[Path] = []
+    monkeypatch.setattr(workspace_cli, "observe_workspace", lambda path=None: current)
+    monkeypatch.setattr(
+        workspace_cli,
+        "set_workspace",
+        lambda path: selected.append(path),  # type: ignore[func-returns-value]
+    )
+
+    assert run_workspace_setup(_reader("1", "NO")) == 0
+    assert selected == []
+    assert "Workspace setup cancelled." in capsys.readouterr().out
+
+
+def test_setup_invalid_custom_candidate_fails_before_confirmation_or_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    current = _observation(tmp_path)
+    invalid = _observation(
+        tmp_path,
+        root=tmp_path / "not-a-directory",
+        source="explicit",
+        state=WorkspacePresentationState.INVALID,
+    )
+    selected: list[Path] = []
+    monkeypatch.setattr(
+        workspace_cli,
+        "observe_workspace",
+        lambda path=None: current if path is None else invalid,
+    )
+    monkeypatch.setattr(
+        workspace_cli,
+        "set_workspace",
+        lambda path: selected.append(path),  # type: ignore[func-returns-value]
+    )
+
+    assert run_workspace_setup(
+        _reader("2", str(invalid.root))
+    ) == 1
+    assert selected == []
+    captured = capsys.readouterr()
+    assert "invalid or unusable" in captured.out
+    assert "cannot continue" in captured.err
+
+
+def test_setup_environment_override_offers_validation_without_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    current = _observation(
+        tmp_path,
+        source="environment",
+        state=WorkspacePresentationState.EMPTY_DIRECTORY,
+    )
+    validated: list[Path | None] = []
+    selected: list[Path] = []
+    monkeypatch.setattr(workspace_cli, "observe_workspace", lambda path=None: current)
+    monkeypatch.setattr(
+        workspace_cli,
+        "run_workspace_validate",
+        lambda path: validated.append(path) or 0,
+    )
+    monkeypatch.setattr(
+        workspace_cli,
+        "set_workspace",
+        lambda path: selected.append(path),  # type: ignore[func-returns-value]
+    )
+
+    assert run_workspace_setup(_reader("2")) == 0
+    assert validated == [None]
+    assert selected == []
+    output = capsys.readouterr().out
+    assert "PDS_WORKSPACE_ROOT controls the active workspace." in output
+    assert "Choose another folder" not in output
+
+
+def test_setup_environment_override_initializes_without_saving_preference(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    current = _observation(
+        tmp_path,
+        source="environment",
+        state=WorkspacePresentationState.EMPTY_DIRECTORY,
+    )
+    initialized = 0
+
+    monkeypatch.setattr(workspace_cli, "observe_workspace", lambda path=None: current)
+
+    def initialize() -> WorkspaceSelectionResult:
+        nonlocal initialized
+        initialized += 1
+        return WorkspaceSelectionResult(current, created=False, saved=False)
+
+    monkeypatch.setattr(workspace_cli, "initialize_resolved_workspace", initialize)
+    monkeypatch.setattr(
+        workspace_cli,
+        "set_workspace",
+        lambda path: pytest.fail(f"unexpected saved selection for {path}"),
+    )
+
+    assert run_workspace_setup(_reader("1", "USE")) == 0
+    assert initialized == 1
+    output = capsys.readouterr().out
+    assert "PDS_WORKSPACE_ROOT will remain the active workspace authority" in output
+    assert "PDS_WORKSPACE_ROOT remains the active workspace authority." in output
+    assert "selection was saved" not in output
+
+
+def test_setup_observation_failure_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    def fail(path: Path | None = None) -> WorkspaceObservation:
+        raise WorkspaceMutationError("Core inspection failed")
+
+    monkeypatch.setattr(workspace_cli, "observe_workspace", fail)
+
+    assert run_workspace_setup(_reader("1")) == 1
+    assert "Core inspection failed" in capsys.readouterr().err
+
+
+def test_setup_partial_success_returns_nonzero_and_reports_initialized_path(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    import paper_data_suite.workspace_cli as workspace_cli
+
+    current = _observation(
+        tmp_path,
+        state=WorkspacePresentationState.EMPTY_DIRECTORY,
+    )
+    monkeypatch.setattr(workspace_cli, "observe_workspace", lambda path=None: current)
+
+    def fail(path: Path) -> WorkspaceSelectionResult:
+        raise WorkspacePartialSuccessError(
+            "saved selection failed",
+            initialized_root=path,
+            resolved=current,
+        )
+
+    monkeypatch.setattr(workspace_cli, "set_workspace", fail)
+
+    assert run_workspace_setup(_reader("1", "USE")) == 1
+    error = capsys.readouterr().err
+    assert "initialization succeeded" in error
+    assert f"Initialized path: {current.root}" in error

--- a/tests/test_workspace_setup.py
+++ b/tests/test_workspace_setup.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from paper_data_suite.compatibility import load_release_compatibility_manifest
+from paper_data_suite.workspace_setup import (
+    CoreWorkspaceQualificationError,
+    CoreWorkspaceServiceError,
+    CoreWorkspaceServices,
+    WorkspaceEnvironmentOverrideError,
+    WorkspaceMutationError,
+    WorkspacePartialSuccessError,
+    WorkspacePresentationState,
+    WorkspaceValidationError,
+    load_core_workspace_services,
+    observe_workspace,
+    reset_workspace,
+    set_workspace,
+    validate_workspace,
+)
+
+
+@dataclass
+class FakeStatus:
+    root: Path
+    source: str
+    exists: bool
+    is_dir: bool
+    is_writable: bool
+    config_path: Path
+    default_root: Path
+
+
+class FakeCoreWorkspace:
+    def __init__(
+        self,
+        tmp_path: Path,
+        *,
+        current_root: Path | None = None,
+        source: str = "default",
+    ) -> None:
+        self.tmp_path = tmp_path
+        self.default_root = tmp_path / "default-workspace"
+        self.config_path = tmp_path / "config.json"
+        self.current_root = current_root or self.default_root
+        self.source = source
+        self.ensure_calls: list[tuple[Path, bool]] = []
+        self.save_calls: list[Path] = []
+        self.reset_calls = 0
+        self.fail_ensure: Exception | None = None
+        self.fail_save: Exception | None = None
+        self.fail_reset: Exception | None = None
+        self.force_post_save_root: Path | None = None
+
+    def inspect(self, explicit_root: str | Path | None = None) -> FakeStatus:
+        root = (
+            Path(explicit_root).resolve()
+            if explicit_root is not None
+            else self.current_root
+        )
+        source = "explicit" if explicit_root is not None else self.source
+        exists = root.exists()
+        is_dir = root.is_dir() if exists else False
+        writable = root.parent.exists() if not exists else is_dir
+        return FakeStatus(
+            root=root,
+            source=source,
+            exists=exists,
+            is_dir=is_dir,
+            is_writable=writable,
+            config_path=self.config_path,
+            default_root=self.default_root,
+        )
+
+    def ensure(self, path: str | Path, create: bool = True) -> Path:
+        root = Path(path)
+        self.ensure_calls.append((root, create))
+        if self.fail_ensure is not None:
+            raise self.fail_ensure
+        if not root.exists():
+            if not create:
+                raise RuntimeError("does not exist")
+            root.mkdir(parents=True)
+        if not root.is_dir():
+            raise RuntimeError("not a directory")
+        return root
+
+    def save(self, path: str | Path) -> Path:
+        root = Path(path)
+        self.save_calls.append(root)
+        if self.fail_save is not None:
+            raise self.fail_save
+        if self.source != "environment":
+            self.current_root = self.force_post_save_root or root
+            self.source = "saved_config"
+        return root
+
+    def reset(self) -> bool:
+        self.reset_calls += 1
+        if self.fail_reset is not None:
+            raise self.fail_reset
+        if self.source == "saved_config":
+            self.current_root = self.default_root
+            self.source = "default"
+            return True
+        return False
+
+    def services(self) -> CoreWorkspaceServices:
+        return CoreWorkspaceServices(
+            inspect_workspace_root=self.inspect,
+            ensure_workspace_root=self.ensure,
+            save_workspace_root=self.save,
+            clear_saved_workspace_root=self.reset,
+        )
+
+
+def test_load_services_qualifies_core_before_import() -> None:
+    manifest = load_release_compatibility_manifest()
+    core = next(
+        component
+        for component in manifest.components
+        if "shared_core" in component.capabilities
+    )
+    events: list[str] = []
+
+    def version_lookup(distribution: str) -> str:
+        events.append(f"version:{distribution}")
+        return core.version
+
+    module = SimpleNamespace(
+        inspect_workspace_root=lambda explicit_root=None: None,
+        ensure_workspace_root=lambda path, create=True: Path(path),
+        save_workspace_root=lambda path: Path(path),
+        clear_saved_workspace_root=lambda: False,
+    )
+
+    def importer(name: str) -> object:
+        events.append(f"import:{name}")
+        return module
+
+    load_core_workspace_services(
+        manifest,
+        version_lookup=version_lookup,
+        module_importer=importer,
+    )
+
+    assert events == [
+        f"version:{core.distribution}",
+        "import:pds_core.workspace",
+    ]
+
+
+def test_load_services_refuses_wrong_core_before_import() -> None:
+    imported = False
+
+    def importer(name: str) -> object:
+        nonlocal imported
+        imported = True
+        return SimpleNamespace()
+
+    with pytest.raises(CoreWorkspaceQualificationError, match="qualifies exactly"):
+        load_core_workspace_services(
+            version_lookup=lambda _distribution: "0.6.99",
+            module_importer=importer,
+        )
+
+    assert imported is False
+
+
+def test_load_services_refuses_missing_core_before_import() -> None:
+    imported = False
+
+    def importer(name: str) -> object:
+        nonlocal imported
+        imported = True
+        return SimpleNamespace()
+
+    from importlib import metadata
+
+    def missing(distribution: str) -> str:
+        raise metadata.PackageNotFoundError(distribution)
+
+    with pytest.raises(CoreWorkspaceQualificationError, match="not installed"):
+        load_core_workspace_services(
+            version_lookup=missing,
+            module_importer=importer,
+        )
+
+    assert imported is False
+
+
+def test_load_services_requires_public_callable() -> None:
+    manifest = load_release_compatibility_manifest()
+    core = next(
+        component
+        for component in manifest.components
+        if "shared_core" in component.capabilities
+    )
+    module = SimpleNamespace(
+        inspect_workspace_root=lambda explicit_root=None: None,
+        ensure_workspace_root=lambda path, create=True: Path(path),
+        save_workspace_root=lambda path: Path(path),
+    )
+
+    with pytest.raises(CoreWorkspaceServiceError, match="clear_saved_workspace_root"):
+        load_core_workspace_services(
+            manifest,
+            version_lookup=lambda _distribution: core.version,
+            module_importer=lambda _name: module,
+        )
+
+
+def test_observe_missing_writable_candidate(tmp_path: Path) -> None:
+    fake = FakeCoreWorkspace(tmp_path)
+    candidate = tmp_path / "missing"
+
+    observation = observe_workspace(candidate, services=fake.services())
+
+    assert observation.root == candidate.resolve()
+    assert observation.state is WorkspacePresentationState.MISSING
+    assert observation.exists is False
+
+
+def test_observe_empty_directory_is_not_invalid(tmp_path: Path) -> None:
+    candidate = tmp_path / "empty"
+    candidate.mkdir()
+    fake = FakeCoreWorkspace(tmp_path)
+
+    observation = observe_workspace(candidate, services=fake.services())
+
+    assert observation.state is WorkspacePresentationState.EMPTY_DIRECTORY
+    assert observation.reason == "Workspace candidate is an existing empty directory."
+
+
+def test_observe_nonempty_directory_without_reading_file_contents(
+    tmp_path: Path,
+) -> None:
+    candidate = tmp_path / "existing"
+    candidate.mkdir()
+    content = candidate / "student-evidence.txt"
+    content.write_text("sensitive synthetic content", encoding="utf-8")
+    fake = FakeCoreWorkspace(tmp_path)
+
+    observation = observe_workspace(candidate, services=fake.services())
+
+    assert observation.state is WorkspacePresentationState.EXISTING_DIRECTORY
+    assert content.read_text(encoding="utf-8") == "sensitive synthetic content"
+
+
+def test_observe_existing_file_is_invalid(tmp_path: Path) -> None:
+    candidate = tmp_path / "not-directory"
+    candidate.write_text("content", encoding="utf-8")
+    fake = FakeCoreWorkspace(tmp_path)
+
+    observation = observe_workspace(candidate, services=fake.services())
+
+    assert observation.state is WorkspacePresentationState.INVALID
+    assert "not a directory" in observation.reason
+
+
+def test_observe_rejects_malformed_status(tmp_path: Path) -> None:
+    fake = FakeCoreWorkspace(tmp_path)
+    services = fake.services()
+    malformed = cast(
+        object,
+        SimpleNamespace(
+            root=tmp_path,
+            source="",
+            exists=True,
+            is_dir=True,
+            is_writable=True,
+            config_path=tmp_path / "config.json",
+            default_root=tmp_path / "default",
+        ),
+    )
+    broken = CoreWorkspaceServices(
+        inspect_workspace_root=cast(
+            object,
+            lambda explicit_root=None: malformed,
+        ),
+        ensure_workspace_root=services.ensure_workspace_root,
+        save_workspace_root=services.save_workspace_root,
+        clear_saved_workspace_root=services.clear_saved_workspace_root,
+    )
+
+    with pytest.raises(CoreWorkspaceServiceError, match="selection source"):
+        observe_workspace(services=broken)
+
+
+def test_validate_missing_candidate_does_not_create_or_save(tmp_path: Path) -> None:
+    fake = FakeCoreWorkspace(tmp_path)
+    candidate = tmp_path / "missing"
+
+    with pytest.raises(WorkspaceValidationError, match="does not exist"):
+        validate_workspace(candidate, services=fake.services())
+
+    assert fake.ensure_calls == [(candidate.resolve(), False)]
+    assert fake.save_calls == []
+    assert not candidate.exists()
+
+
+def test_validate_existing_empty_candidate_does_not_initialize_or_save(
+    tmp_path: Path,
+) -> None:
+    fake = FakeCoreWorkspace(tmp_path)
+    candidate = tmp_path / "empty"
+    candidate.mkdir()
+
+    observation = validate_workspace(candidate, services=fake.services())
+
+    assert observation.state is WorkspacePresentationState.EMPTY_DIRECTORY
+    assert fake.ensure_calls == [(candidate.resolve(), False)]
+    assert fake.save_calls == []
+    assert tuple(candidate.iterdir()) == ()
+
+
+def test_set_missing_candidate_initializes_saves_and_reinspects(tmp_path: Path) -> None:
+    fake = FakeCoreWorkspace(tmp_path)
+    candidate = tmp_path / "new-workspace"
+
+    result = set_workspace(candidate, services=fake.services())
+
+    assert result.created is True
+    assert result.saved is True
+    assert result.observation.root == candidate.resolve()
+    assert result.observation.source == "saved_config"
+    assert candidate.is_dir()
+    assert fake.ensure_calls == [(candidate.resolve(), True)]
+    assert fake.save_calls == [candidate.resolve()]
+
+
+def test_set_existing_directory_preserves_existing_files(tmp_path: Path) -> None:
+    fake = FakeCoreWorkspace(tmp_path)
+    candidate = tmp_path / "existing"
+    candidate.mkdir()
+    preserved = candidate / "preserved.txt"
+    preserved.write_text("keep", encoding="utf-8")
+
+    result = set_workspace(candidate, services=fake.services())
+
+    assert result.created is False
+    assert preserved.read_text(encoding="utf-8") == "keep"
+
+
+def test_set_refuses_different_path_under_environment_override(tmp_path: Path) -> None:
+    environment_root = tmp_path / "environment"
+    environment_root.mkdir()
+    fake = FakeCoreWorkspace(
+        tmp_path,
+        current_root=environment_root.resolve(),
+        source="environment",
+    )
+    candidate = tmp_path / "candidate"
+
+    with pytest.raises(WorkspaceEnvironmentOverrideError, match="PDS_WORKSPACE_ROOT"):
+        set_workspace(candidate, services=fake.services())
+
+    assert fake.ensure_calls == []
+    assert fake.save_calls == []
+    assert not candidate.exists()
+
+
+def test_set_same_path_under_environment_override_is_allowed(tmp_path: Path) -> None:
+    environment_root = tmp_path / "environment"
+    environment_root.mkdir()
+    fake = FakeCoreWorkspace(
+        tmp_path,
+        current_root=environment_root.resolve(),
+        source="environment",
+    )
+
+    result = set_workspace(environment_root, services=fake.services())
+
+    assert result.observation.root == environment_root.resolve()
+    assert result.observation.source == "environment"
+    assert fake.save_calls == [environment_root.resolve()]
+
+
+def test_set_initialization_failure_does_not_save(tmp_path: Path) -> None:
+    fake = FakeCoreWorkspace(tmp_path)
+    fake.fail_ensure = PermissionError("denied")
+
+    with pytest.raises(WorkspaceMutationError, match="could not initialize"):
+        set_workspace(tmp_path / "candidate", services=fake.services())
+
+    assert fake.save_calls == []
+
+
+def test_set_save_failure_reports_partial_success(tmp_path: Path) -> None:
+    fake = FakeCoreWorkspace(tmp_path)
+    fake.fail_save = PermissionError("config denied")
+    candidate = tmp_path / "candidate"
+
+    with pytest.raises(WorkspacePartialSuccessError) as caught:
+        set_workspace(candidate, services=fake.services())
+
+    assert candidate.is_dir()
+    assert caught.value.initialized_root == candidate.resolve()
+    assert caught.value.resolved is not None
+
+
+def test_set_post_save_resolution_mismatch_reports_partial_success(
+    tmp_path: Path,
+) -> None:
+    fake = FakeCoreWorkspace(tmp_path)
+    candidate = tmp_path / "candidate"
+    other = tmp_path / "other"
+    other.mkdir()
+    fake.force_post_save_root = other.resolve()
+
+    with pytest.raises(WorkspacePartialSuccessError, match="active resolved workspace"):
+        set_workspace(candidate, services=fake.services())
+
+    assert candidate.is_dir()
+    assert fake.save_calls == [candidate.resolve()]
+
+
+def test_reset_clears_only_saved_preference_and_reinspects(tmp_path: Path) -> None:
+    saved = tmp_path / "saved"
+    saved.mkdir()
+    preserved = saved / "keep.txt"
+    preserved.write_text("keep", encoding="utf-8")
+    fake = FakeCoreWorkspace(
+        tmp_path,
+        current_root=saved.resolve(),
+        source="saved_config",
+    )
+
+    result = reset_workspace(services=fake.services())
+
+    assert result.cleared is True
+    assert result.observation.source == "default"
+    assert preserved.read_text(encoding="utf-8") == "keep"
+    assert fake.reset_calls == 1
+
+
+def test_reset_under_environment_override_leaves_environment_active(
+    tmp_path: Path,
+) -> None:
+    environment_root = tmp_path / "environment"
+    environment_root.mkdir()
+    fake = FakeCoreWorkspace(
+        tmp_path,
+        current_root=environment_root.resolve(),
+        source="environment",
+    )
+
+    result = reset_workspace(services=fake.services())
+
+    assert result.cleared is False
+    assert result.observation.root == environment_root.resolve()
+    assert result.observation.source == "environment"
+
+
+def test_reset_failure_is_bounded(tmp_path: Path) -> None:
+    fake = FakeCoreWorkspace(tmp_path)
+    fake.fail_reset = PermissionError("config denied")
+
+    with pytest.raises(WorkspaceMutationError, match="could not clear"):
+        reset_workspace(services=fake.services())
+
+
+def test_initialize_resolved_environment_workspace_does_not_save_preference(
+    tmp_path: Path,
+) -> None:
+    environment_root = tmp_path / "environment"
+    fake = FakeCoreWorkspace(
+        tmp_path,
+        current_root=environment_root.resolve(),
+        source="environment",
+    )
+
+    from paper_data_suite.workspace_setup import initialize_resolved_workspace
+
+    result = initialize_resolved_workspace(services=fake.services())
+
+    assert result.created is True
+    assert result.saved is False
+    assert result.observation.root == environment_root.resolve()
+    assert result.observation.source == "environment"
+    assert environment_root.is_dir()
+    assert fake.ensure_calls == [(environment_root.resolve(), True)]
+    assert fake.save_calls == []
+


### PR DESCRIPTION
## Summary

Closes #8.

Implements guided Paper Data Suite workspace selection and validation while preserving PDS Core as the sole authority for workspace resolution, initialization, validation, and saved selection.

The suite now provides:

```text
pds workspace setup
pds workspace show
pds workspace validate [<path>]
pds workspace set <path>
pds workspace reset
```

with equivalent:

```text
python -m paper_data_suite workspace ...
```

forms.

The implementation uses only public `pds_core.workspace` services and the suite's existing exact compatibility machinery. It does not introduce a suite-owned workspace format, write Core configuration directly, parse Core's private workspace marker, or depend on sibling application workspace wrappers.

## What this adds

### Core-backed workspace orchestration

Adds a typed, presentation-independent workspace layer that:

- verifies the exact suite-qualified Core version before using workspace services;
- dynamically loads only public `pds_core.workspace` contracts;
- preserves Core's resolution precedence;
- delegates validation, initialization, saved selection, and reset to Core;
- distinguishes missing, empty, existing non-empty, and invalid/unusable candidates for presentation purposes;
- performs validation without initializing a missing workspace;
- prevents an active `PDS_WORKSPACE_ROOT` override from being misleadingly superseded;
- reports initialization/save partial-success states honestly;
- re-inspects Core's actual resolution after mutations rather than assuming success.

### Deterministic workspace commands

Adds:

```text
pds workspace show
pds workspace validate [<path>]
pds workspace set <path>
pds workspace reset
```

`show` is informational and non-mutating.

`validate` uses Core validation without saving a preference or initializing a missing candidate.

`set` explicitly initializes through Core and saves through Core.

`reset` clears only Core's saved workspace preference and never deletes workspace data.

### Guided setup

Adds:

```text
pds workspace setup
```

The guided workflow:

- prominently displays the current Core-resolved workspace and source;
- lets the teacher keep the current location or provide another path;
- previews missing, empty, existing non-empty, and unusable candidate states;
- warns before adopting an existing non-empty directory;
- requires explicit `USE` confirmation before persistent mutation;
- supports safe cancellation before writes;
- handles Ctrl+C and EOF without traceback;
- explains active environment overrides rather than pretending a saved preference can replace them;
- initializes an environment-controlled active workspace without unnecessarily writing a saved preference;
- leaves old workspaces and unrelated existing files untouched.

### Safety and ownership boundaries

The implementation intentionally does **not**:

- write `.pds/workspace.json` directly;
- parse or reproduce Core workspace-marker semantics;
- write Core's configuration JSON directly;
- duplicate Core path-normalization or resolution logic;
- import ScoreForm, Quillan, Concord, Vitrine, or other sibling applications for workspace management;
- move, merge, copy, or delete previous workspaces;
- create school years, classes, rosters, standards, or Academic Periods;
- add cloud-provider-specific behavior.

Core remains authoritative for the shared workspace.

### Documentation

Adds:

```text
docs/operations/workspace-setup.md
```

and updates the README with:

- workspace command usage;
- Core ownership and exact compatibility behavior;
- resolution precedence;
- environment-override behavior;
- guided setup semantics;
- empty-versus-invalid distinctions;
- reset and data-preservation behavior;
- installed-wheel acceptance instructions.

### Installed-wheel acceptance

Adds a dedicated workspace wheel smoke test that runs against:

```text
paper-data-suite 0.1.0.dev0
pds-core 0.6.0
```

inside a clean isolated environment with synthetic:

```text
HOME
USERPROFILE
APPDATA
XDG_CONFIG_HOME
workspace paths
```

The acceptance test proves the built package—not the source checkout—can:

- inspect an absent workspace without creating it;
- reject validate-only creation of a missing path;
- initialize and save a synthetic workspace;
- resolve the saved location correctly;
- create Core-owned baseline workspace structure;
- exercise the installed `pds` console boundary, including `pds.exe` on Windows;
- refuse a conflicting alternate `set` while `PDS_WORKSPACE_ROOT` is active;
- reset only the saved preference;
- preserve the initialized workspace after reset;
- avoid using the developer's real user configuration or workspace.

## Validation

Local validation completed successfully on Windows / Python 3.11.9:

```text
329 passed, 4 skipped
```

The four skips are existing platform/tooling skips for unavailable symlink/Pwsh capabilities.

Also passed:

```text
python -m ruff check .
python -m mypy
python -m pip check
python .\scripts\validate_compatibility_manifest.py
git diff --check
```

Package validation also passed:

```text
python -m build
python -m twine check .\dist\*
python .\scripts\check_package.py <suite-wheel>
python .\scripts\smoke_test_wheel.py <suite-wheel> <core-0.6.0-wheel>
python .\scripts\smoke_test_workspace_wheel.py <suite-wheel> <core-0.6.0-wheel>
```

Results:

```text
Successfully built wheel and sdist
Twine checks passed
Package wheel validation passed
Existing Core-only installed-wheel smoke passed
Workspace installed-wheel smoke passed
```

## Scope boundary

This PR establishes only the shared Core-backed workspace foundation.

It deliberately does not implement the next guided shared-setup work for:

```text
school year
classes
rosters
standards
Academic Periods
```

Those remain separate follow-on work under the v0.1.0 suite milestone.