### PR TITLE
feat: add guided shared classroom setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ There is **no supported public v0.1.0 release yet**. The package foundation is
 installable. The shell now provides read-only environment diagnostics through
 `pds doctor`, suite-qualified application inventory through `pds modules`,
 verified out-of-process application launching through `pds launch <component-id>`,
-and Core-backed workspace selection/validation through `pds workspace`.
-Additional teacher-facing workflows are added by later v0.1.0 issues.
+Core-backed workspace selection/validation through `pds workspace`, and guided
+shared classroom setup through `pds setup`. Additional teacher-facing workflows
+are added by later v0.1.0 issues.
 
 The package metadata requires Python 3.11 or newer and
 `pds-core>=0.6,<0.7`. Those broad package requirements do **not** by themselves
@@ -185,6 +186,59 @@ leaves selection unchanged.
 The operational contract and installed-wheel acceptance requirements are documented
 in [`docs/operations/workspace-setup.md`](docs/operations/workspace-setup.md).
 
+## Shared classroom setup
+
+After selecting and initializing a workspace, run the guided shared classroom
+workflow with:
+
+```powershell
+pds setup
+```
+
+Equivalent module invocation:
+
+```powershell
+python -m paper_data_suite setup
+```
+
+`pds setup` operates only on the workspace already resolved by Core. It reviews
+the active school year, explicit class IDs, optional teacher-selected roster CSVs,
+shared standards, and an optional initial Academic Period calendar. It does not
+select or initialize another workspace.
+
+The workflow is review-before-write. All proposed state is validated in memory and
+shown in a final review. Only exact uppercase `APPLY` authorizes persistent Core
+writes; `E` returns to in-memory editing and `Q` cancels. Writer services are not
+loaded until final `APPLY`. Before the first mutation the suite re-reads the
+reviewed Core state and refuses stale plans.
+
+Roster imports remain Core-validated and class-scoped. Existing differing rosters
+are shown as whole-roster replacements; the suite does not invent row-level merge
+semantics. Starter standards packs are Core-provided and must be selected
+explicitly. Existing Academic Period calendars are kept unchanged; a new initial
+calendar requires every period field explicitly and is shown in the final review.
+
+A recommended first-time pilot sequence is:
+
+```powershell
+pds doctor
+pds workspace setup
+pds doctor
+pds setup
+pds modules
+```
+
+Then launch a qualified teacher application explicitly, for example:
+
+```powershell
+pds launch scoreform
+```
+
+The operational contract, duplicate/conflict rules, APPLY ordering, privacy
+boundaries, partial-success behavior, and installed-wheel acceptance are documented
+in
+[`docs/operations/shared-classroom-setup.md`](docs/operations/shared-classroom-setup.md).
+
 ## Architecture direction
 
 The suite shell is an orchestration and teacher-convenience layer, not a second
@@ -231,6 +285,7 @@ pds doctor
 pds doctor --workspace <path>
 pds modules
 pds launch <component-id>
+pds setup
 pds workspace setup
 pds workspace show
 pds workspace validate [<path>]
@@ -243,6 +298,7 @@ python -m paper_data_suite --version
 python -m paper_data_suite doctor
 python -m paper_data_suite modules
 python -m paper_data_suite launch <component-id>
+python -m paper_data_suite setup
 python -m paper_data_suite workspace setup
 python -m paper_data_suite workspace show
 python -m paper_data_suite workspace validate [<path>]
@@ -255,8 +311,10 @@ create or select a workspace or perform classroom-data mutation.
 `doctor --workspace` is an invocation-scoped inspection override only.
 `workspace validate` validates an existing candidate without initializing or
 saving it; `workspace setup`, `set`, and `reset` are the explicit workspace
-mutation surfaces. `launch` crosses only the verified public application
-boundary; module-owned behavior remains owned by the launched application.
+mutation surfaces. `pds setup` is the explicit shared-classroom mutation surface
+and remains read-only until exact final `APPLY`. `launch` crosses only the verified
+public application boundary; module-owned behavior remains owned by the launched
+application.
 
 ## Development validation
 
@@ -280,13 +338,17 @@ Then validate and smoke-test the built wheel using the exact Core 0.6.0 wheel:
 python .\scripts\check_package.py <suite-wheel>
 python .\scripts\smoke_test_wheel.py <suite-wheel> <core-wheel>
 python .\scripts\smoke_test_workspace_wheel.py <suite-wheel> <core-wheel>
+python .\scripts\smoke_test_classroom_setup_wheel.py <suite-wheel> <core-wheel>
 ```
 
 The Core-only smoke proves legitimate partial installation behavior. The dedicated
 workspace smoke uses an isolated synthetic user profile and proves installed
 workspace show/validate/setup/set/reset behavior without touching the developer's
-real Core configuration or workspace. To exercise
-the complete suite-qualified application composition, place every exact component
+real Core configuration or workspace. The dedicated classroom setup smoke uses a
+separate isolated profile to prove exact-`APPLY` authorization, cancellation with
+no classroom mutation, Core-owned school-year application, absence of persisted
+suite setup-plan artifacts, and idempotent reruns. To exercise the complete
+suite-qualified application composition, place every exact component
 wheel declared by the manifest in one artifact directory and run:
 
 ```powershell
@@ -332,6 +394,8 @@ Do not place a real classroom PDS workspace inside this repository.
   boundary.
 - [`docs/operations/workspace-setup.md`](docs/operations/workspace-setup.md)
   — Core-backed workspace selection, validation, guided setup, and reset.
+- [`docs/operations/shared-classroom-setup.md`](docs/operations/shared-classroom-setup.md)
+  — guided school-year, class, roster, standards, and Academic Period setup.
 - [`docs/development-plan.md`](docs/development-plan.md) — suite-wide
   pilot-readiness and development program.
 - [`docs/pds-viz-identity.md`](docs/pds-viz-identity.md) — shared Paper Data

--- a/docs/operations/shared-classroom-setup.md
+++ b/docs/operations/shared-classroom-setup.md
@@ -1,0 +1,303 @@
+# Guided shared classroom setup
+
+`pds setup` is the suite-level guided workflow for configuring the shared
+classroom state owned by PDS Core after a workspace has already been selected
+and initialized.
+
+Equivalent invocation:
+
+```text
+python -m paper_data_suite setup
+```
+
+The workflow is intentionally bounded. It can review and initially configure:
+
+1. the active school year;
+2. Core class metadata;
+3. Core class rosters;
+4. the shared standards library through an explicitly selected Core starter pack;
+5. an initial Academic Period calendar.
+
+It is not a general-purpose Core administration surface and it does not create
+module-owned records.
+
+## Ownership boundary
+
+The suite owns orchestration and terminal presentation only. PDS Core remains
+authoritative for:
+
+- workspace resolution and canonical paths;
+- school-year validation and state;
+- class and student identifiers;
+- class metadata models and persistence;
+- roster parsing, validation, and persistence;
+- standards models, starter-pack contents, merge semantics, and persistence;
+- Academic Period models, hierarchy validation, revisions, and persistence.
+
+The suite does not write Core JSON or CSV files directly and does not maintain a
+second setup schema or persisted setup-plan file.
+
+The active release-compatibility manifest must qualify the installed Core
+release exactly before Core setup services are used. The current development
+manifest qualifies `pds-core==0.6.0`.
+
+## Workspace precondition
+
+`pds setup` operates only on the workspace already resolved by Core. It does not
+select, create, or initialize another workspace.
+
+Before collecting classroom information it displays the resolved workspace path
+and resolution source and requires the workspace to exist, be a directory, and
+be writable.
+
+If no usable workspace is resolved, run:
+
+```text
+pds workspace setup
+```
+
+then rerun `pds setup`.
+
+## Review-before-write invariant
+
+The central safety rule is:
+
+```text
+no persistent setup mutation before final APPLY
+```
+
+Before final confirmation, the command may read relevant Core-owned state, read
+a teacher-selected roster CSV, load bundled Core starter standards, create Core
+model values in memory, and ask Core to validate them.
+
+Before final confirmation it does not open a school year, create class metadata,
+write a roster, install standards, write an Academic Period revision, or persist
+a suite setup plan.
+
+The final decision is:
+
+```text
+APPLY   apply the reviewed plan
+E       edit the in-memory plan
+Q       cancel
+```
+
+Only exact uppercase `APPLY` authorizes Core writes. `apply`, `Apply`, blank
+input, EOF, and `Q` do not authorize mutation.
+
+Writer services are loaded only after exact `APPLY` is accepted.
+
+## Initial assessment
+
+The first screen is read-only and summarizes:
+
+- resolved workspace path and Core resolution source;
+- active school year, if any;
+- valid discovered class folders;
+- class metadata presence;
+- roster presence and student counts;
+- standards definition/profile counts;
+- available Core starter standards packs;
+- the current Academic Period calendar revision and period count when relevant.
+
+Roster rows, student names, and student identifiers are not dumped during this
+assessment.
+
+Malformed or internally inconsistent existing shared state stops setup rather
+than being silently repaired or interpreted by the suite.
+
+## School year
+
+The school year is explicit and must use Core's consecutive `YYYY-YYYY` format.
+The suite does not infer it from today's date, a roster, class names, Academic
+Period dates, locale, district, or prior context.
+
+Behavior:
+
+- no open year: `OPEN` after final `APPLY`;
+- same open year: `KEEP`;
+- different open year: `REFUSE` until the lifecycle conflict is resolved through
+  an explicit Core workflow.
+
+The suite never silently closes or overwrites another open school year.
+
+## Classes
+
+The teacher enters zero or more explicit Core `class_id` values. Core validates
+each identifier and Core creates the candidate class metadata for the selected
+school year.
+
+Classification:
+
+- `NEW`: no conflicting Core metadata exists;
+- `EXISTING_MATCH`: existing metadata already binds the class to the selected
+  school year;
+- `CONFLICT`: existing metadata is incompatible or an incomplete state cannot be
+  interpreted safely.
+
+Existing legitimate Core-owned `module_details` are preserved. New metadata does
+not invent course names, teacher names, room numbers, section labels, periods, or
+module configuration.
+
+## Rosters
+
+A roster is optional for each selected class. The teacher supplies the CSV path
+explicitly.
+
+Core requires the canonical fields:
+
+```text
+class_id
+student_id
+last_name
+first_name
+period
+```
+
+Supported optional columns are preserved by Core.
+
+The suite does not rewrite headers, infer identifiers, coerce numeric IDs, split
+a mixed-class CSV, infer the target `class_id`, deduplicate by name, or discard
+invalid rows.
+
+Structured Core roster diagnostics are rendered using row/column location and a
+bounded value-free explanation. The suite does not echo `RosterIssue.value` or
+student data from validation failures.
+
+For an existing class roster, `student_id` is the class-scoped identity key. The
+preview reports counts for:
+
+- `NEW` students;
+- `UNCHANGED` students;
+- `CONFLICTING_EXISTING` students;
+- existing students absent from the incoming whole roster.
+
+An absent roster produces `CREATE`. A materially identical import produces
+`KEEP`. Any different valid import is a whole-roster `REPLACE`; the suite does
+not implement row-level merge semantics. Replacement remains protected by Core's
+overwrite behavior and occurs only after the reviewed final `APPLY`.
+
+## Standards
+
+The existing shared standards library can always be kept unchanged.
+
+Available starter packs come only from the qualified Core release. The command
+shows Core-provided pack ID, title, source, grade bands, courses, standard count,
+and profile count. No pack is selected automatically.
+
+In particular, the presence of an NJSLS starter pack does not cause the suite to
+infer New Jersey, a subject, or a course.
+
+For an explicitly selected pack the suite asks Core to perform a dry in-memory
+merge with `overwrite_conflicts=False`. The review reports additions, identical
+records, and conflicts for standards and profiles. Any conflicting protected
+record blocks `APPLY`; the guided workflow never enables overwrite merely to
+finish setup.
+
+## Academic Periods
+
+If a current Core Academic Period calendar already exists for the selected school
+year, guided setup keeps it unchanged. This workflow is not a calendar revision
+editor.
+
+If no current calendar exists, the teacher may either skip Academic Period setup
+or explicitly configure an initial calendar.
+
+Each proposed period requires all Core fields:
+
+```text
+period_id
+period_type
+label
+start_date
+end_date
+parent_period_id or none
+sequence
+lifecycle
+```
+
+The terminal displays Core's allowed period types and lifecycle values but does
+not choose defaults. The complete calendar hierarchy is validated by Core in
+memory. The final review lists every proposed period definition before `APPLY`.
+
+A new calendar is written as revision `1` with Core's expected-current-revision
+protection.
+
+## APPLY preflight and write ordering
+
+After exact `APPLY`, the suite first re-reads the reviewed shared state before any
+mutation. If the workspace, Core-owned state, selected roster source, standards
+baseline, or Academic Period state changed after review, setup refuses the write
+and instructs the teacher to rerun `pds setup`.
+
+If preflight succeeds, writes are sequenced through public Core services in this
+order:
+
+1. open the school year if needed;
+2. create required class metadata/folders;
+3. create or explicitly replace reviewed rosters;
+4. install the explicitly selected starter standards pack if needed;
+5. create the initial Academic Period calendar if needed.
+
+After each successful step, enough Core state is re-read to verify the intended
+result.
+
+Roster replacement receives a just-in-time recheck before `overwrite=True` is
+used. Standards receive a just-in-time baseline recheck and are installed with
+`overwrite_conflicts=False`.
+
+## Failure and rerun semantics
+
+These operations span several Core domains and are not one cross-domain
+transaction.
+
+If a later Core operation fails after earlier writes succeeded, the command:
+
+- reports the successful Core writes;
+- reports the failure;
+- does not claim rollback;
+- does not attempt a speculative cross-domain rollback;
+- instructs the teacher to rerun `pds setup` so current Core state is reassessed.
+
+Safe reruns are part of the workflow. Already-matching state is classified as
+`KEEP` and a fully current reviewed setup completes as a no-op.
+
+## Recommended first-time pilot sequence
+
+After installing the suite-qualified environment:
+
+```text
+pds doctor
+pds workspace setup
+pds doctor
+pds setup
+pds modules
+```
+
+Then launch an available teacher application explicitly, for example:
+
+```text
+pds launch scoreform
+```
+
+`pds workspace setup` and `pds setup` are deliberately separate. The first owns
+workspace selection/initialization; the second configures shared classroom state
+inside the already resolved workspace.
+
+## Installed-wheel acceptance
+
+After building the suite wheel, run the dedicated classroom setup smoke test with
+the exact qualified Core wheel:
+
+```text
+python .\scripts\smoke_test_classroom_setup_wheel.py <suite-wheel> <core-wheel>
+```
+
+The smoke test creates an isolated virtual environment and synthetic user profile,
+removes inherited `PYTHONPATH` and `PDS_WORKSPACE_ROOT`, and verifies both installed
+entry surfaces. It proves that lowercase `apply` does not authorize mutation,
+cancellation leaves shared classroom state unchanged, exact `APPLY` opens the
+explicit school year, no suite setup-plan artifact is persisted, and a rerun of
+already-current state is an idempotent no-op.
+
+All smoke-test data is synthetic.

--- a/paper_data_suite/classroom_apply.py
+++ b/paper_data_suite/classroom_apply.py
@@ -1,0 +1,840 @@
+"""Final APPLY execution for guided shared classroom setup.
+
+The execution layer is loaded only after the teacher has reviewed an in-memory
+plan and chosen exact ``APPLY``.  It composes public, suite-qualified PDS Core
+writers, performs a fresh read-only preflight before the first mutation, uses
+Core overwrite/concurrency protections, verifies each successful step, and
+reports partial success without claiming a cross-domain rollback.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib import import_module, metadata
+from pathlib import Path
+from typing import Protocol, cast
+
+from paper_data_suite.classroom_planning import (
+    AcademicPeriodAction,
+    ClassDisposition,
+    ComparableRosterLike,
+    CoreClassroomPlanningServices,
+    RosterAction,
+    SchoolYearDisposition,
+    SharedSetupPlan,
+    StandardsAction,
+    StarterMergeResultLike,
+    load_core_classroom_planning_services,
+    plan_starter_standards,
+)
+from paper_data_suite.classroom_setup import (
+    ClassMetadataLike,
+    ClassroomSetupError,
+    SharedSetupAssessment,
+    StandardsLibraryLike,
+    assess_shared_setup,
+)
+from paper_data_suite.compatibility import ReleaseCompatibilityManifest
+from paper_data_suite.component_inspection import DistributionVersionLookup
+
+ModuleImporter = Callable[[str], object]
+Clock = Callable[[], datetime]
+
+
+class ClassroomSetupApplyError(ClassroomSetupError):
+    """Raised when a reviewed shared setup plan cannot be applied safely."""
+
+
+class CoreClassroomApplyServiceError(ClassroomSetupApplyError):
+    """Raised when a required public Core APPLY service is unavailable."""
+
+
+class ClassroomSetupPreflightError(ClassroomSetupApplyError):
+    """Raised when state changed after review and before the first mutation."""
+
+
+class ClassroomSetupVerificationError(ClassroomSetupApplyError):
+    """Raised when Core state does not match a completed intended action."""
+
+
+class ClassroomSetupPartialSuccessError(ClassroomSetupApplyError):
+    """Raised when a later failure follows one or more successful Core writes."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        completed_actions: tuple[str, ...],
+        changed_actions: tuple[str, ...],
+    ) -> None:
+        super().__init__(message)
+        self.completed_actions = completed_actions
+        self.changed_actions = changed_actions
+
+
+class SchoolYearOpener(Protocol):
+    def __call__(
+        self,
+        workspace_root: str | Path,
+        school_year: str,
+        *,
+        opened_at: datetime,
+        overwrite: bool = False,
+    ) -> object: ...
+
+
+class ClassMetadataWriter(Protocol):
+    def __call__(
+        self,
+        workspace_root: str | Path,
+        metadata_value: ClassMetadataLike,
+        *,
+        overwrite: bool = False,
+    ) -> Path: ...
+
+
+class ClassRosterWriter(Protocol):
+    def __call__(
+        self,
+        workspace_root: str | Path,
+        roster: ComparableRosterLike,
+        *,
+        overwrite: bool = False,
+    ) -> Path: ...
+
+
+class StarterStandardsInstaller(Protocol):
+    def __call__(
+        self,
+        workspace_root: str | Path,
+        pack_id: str,
+        existing_library: StandardsLibraryLike,
+        *,
+        overwrite_conflicts: bool = False,
+    ) -> StarterMergeResultLike: ...
+
+
+class AcademicPeriodCalendarWriter(Protocol):
+    def __call__(
+        self,
+        workspace_root: str | Path,
+        calendar: object,
+        *,
+        expected_current_revision: int | None,
+    ) -> Path: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CoreClassroomApplyServices:
+    """Exact-qualified public Core services reachable after final APPLY."""
+
+    planning: CoreClassroomPlanningServices
+    open_school_year: SchoolYearOpener
+    write_class_metadata_for_class: ClassMetadataWriter
+    write_class_roster: ClassRosterWriter
+    install_starter_standards_library: StarterStandardsInstaller
+    write_academic_period_calendar: AcademicPeriodCalendarWriter
+
+
+@dataclass(frozen=True, slots=True)
+class SetupApplyResult:
+    """Verified outcome of one complete APPLY attempt."""
+
+    completed_actions: tuple[str, ...]
+    changed_actions: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SetupPreflight:
+    """Fresh Core state validated immediately before the first mutation."""
+
+    assessment: SharedSetupAssessment
+
+
+def _required_callable(module: object, module_name: str, name: str) -> object:
+    value = getattr(module, name, None)
+    if not callable(value):
+        raise CoreClassroomApplyServiceError(
+            "Suite-qualified Core does not expose public callable "
+            f"{module_name}.{name}."
+        )
+    return value
+
+
+def _import_core_module(module_name: str, module_importer: ModuleImporter) -> object:
+    try:
+        return module_importer(module_name)
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise CoreClassroomApplyServiceError(
+            f"Could not import public Core APPLY services from {module_name}: {message}"
+        ) from error
+
+
+def load_core_classroom_apply_services(
+    manifest: ReleaseCompatibilityManifest | None = None,
+    *,
+    version_lookup: DistributionVersionLookup = metadata.version,
+    module_importer: ModuleImporter = import_module,
+) -> CoreClassroomApplyServices:
+    """Qualify Core exactly, then load only public writers used by APPLY."""
+    planning = load_core_classroom_planning_services(
+        manifest,
+        version_lookup=version_lookup,
+        module_importer=module_importer,
+    )
+    school_years = _import_core_module("pds_core.school_years", module_importer)
+    classes = _import_core_module("pds_core.classes", module_importer)
+    class_metadata = _import_core_module("pds_core.class_metadata", module_importer)
+    starter_standards = _import_core_module(
+        "pds_core.starter_standards",
+        module_importer,
+    )
+    academic_period_storage = _import_core_module(
+        "pds_core.academic_period_storage",
+        module_importer,
+    )
+    return CoreClassroomApplyServices(
+        planning=planning,
+        open_school_year=cast(
+            SchoolYearOpener,
+            _required_callable(
+                school_years,
+                "pds_core.school_years",
+                "open_school_year",
+            ),
+        ),
+        write_class_metadata_for_class=cast(
+            ClassMetadataWriter,
+            _required_callable(
+                class_metadata,
+                "pds_core.class_metadata",
+                "write_class_metadata_for_class",
+            ),
+        ),
+        write_class_roster=cast(
+            ClassRosterWriter,
+            _required_callable(
+                classes,
+                "pds_core.classes",
+                "write_class_roster",
+            ),
+        ),
+        install_starter_standards_library=cast(
+            StarterStandardsInstaller,
+            _required_callable(
+                starter_standards,
+                "pds_core.starter_standards",
+                "install_starter_standards_library",
+            ),
+        ),
+        write_academic_period_calendar=cast(
+            AcademicPeriodCalendarWriter,
+            _required_callable(
+                academic_period_storage,
+                "pds_core.academic_period_storage",
+                "write_academic_period_calendar",
+            ),
+        ),
+    )
+
+
+def _metadata_material(value: ClassMetadataLike | None) -> object:
+    if value is None:
+        return None
+    return (
+        value.class_id,
+        value.school_year,
+        dict(value.module_details),
+    )
+
+
+def _student_material(value: object) -> tuple[object, ...]:
+    return (
+        getattr(value, "class_id"),
+        getattr(value, "student_id"),
+        getattr(value, "last_name"),
+        getattr(value, "first_name"),
+        getattr(value, "period"),
+        tuple(sorted(cast(Mapping[str, str], getattr(value, "extra_fields")).items())),
+    )
+
+
+def _roster_material(value: ComparableRosterLike | None) -> object:
+    if value is None:
+        return None
+    return (
+        value.class_id,
+        tuple(value.columns),
+        tuple(_student_material(student) for student in value.students),
+    )
+
+
+def _standards_material(value: StandardsLibraryLike) -> tuple[object, ...]:
+    return (tuple(value.standards), tuple(value.profiles))
+
+
+def _school_year_state_material(value: object | None) -> object:
+    if value is None:
+        return None
+    return (
+        getattr(value, "active_school_year"),
+        getattr(value, "opened_at"),
+        getattr(value, "closed_at"),
+    )
+
+
+def _starter_pack_material(value: object) -> tuple[object, ...]:
+    return (
+        getattr(value, "pack_id"),
+        getattr(value, "title"),
+        getattr(value, "source"),
+        tuple(getattr(value, "grade_bands")),
+        tuple(getattr(value, "courses")),
+        getattr(value, "standard_count"),
+        getattr(value, "profile_count"),
+    )
+
+
+def _calendar_material(value: object | None) -> object:
+    if value is None:
+        return None
+    return (
+        getattr(value, "school_year"),
+        getattr(value, "calendar_revision"),
+        tuple(getattr(value, "periods")),
+    )
+
+
+def _assessment_material(value: SharedSetupAssessment) -> tuple[object, ...]:
+    classes = tuple(
+        (
+            item.class_id,
+            _metadata_material(item.metadata),
+            _roster_material(cast(ComparableRosterLike | None, item.roster)),
+        )
+        for item in sorted(value.classes, key=lambda item: item.class_id)
+    )
+    starters = tuple(
+        _starter_pack_material(pack) for pack in value.starter_standards_packs
+    )
+    return (
+        value.workspace_root,
+        value.workspace_source,
+        _school_year_state_material(value.school_year_state),
+        classes,
+        _standards_material(value.standards_library),
+        starters,
+        _calendar_material(value.academic_period_calendar),
+        value.academic_period_revision,
+    )
+
+
+def _preflight_period_state(
+    assessment: SharedSetupAssessment,
+    plan: SharedSetupPlan,
+    services: CoreClassroomApplyServices,
+) -> None:
+    period_plan = plan.academic_periods
+    if period_plan is None:
+        return
+    readers = services.planning.readers
+    try:
+        current = readers.load_current_academic_period_calendar(
+            assessment.workspace_root,
+            period_plan.school_year,
+        )
+        revision = readers.get_current_academic_period_calendar_revision(
+            assessment.workspace_root,
+            period_plan.school_year,
+        )
+    except Exception as error:
+        message = str(error)[:500] or error.__class__.__name__
+        raise ClassroomSetupPreflightError(
+            "Core could not re-check Academic Period state before APPLY: "
+            f"{message}"
+        ) from error
+
+    if period_plan.action in {
+        AcademicPeriodAction.CREATE,
+        AcademicPeriodAction.SKIP,
+    }:
+        if current is not None or revision is not None:
+            raise ClassroomSetupPreflightError(
+                "Academic Period state changed after review. Rerun 'pds setup' "
+                "before applying changes."
+            )
+        return
+    if period_plan.action is AcademicPeriodAction.KEEP:
+        candidate = period_plan.candidate_calendar
+        if (
+            candidate is None
+            or revision != candidate.calendar_revision
+            or _calendar_material(current) != _calendar_material(candidate)
+        ):
+            raise ClassroomSetupPreflightError(
+                "The reviewed Academic Period calendar changed before APPLY. "
+                "Rerun 'pds setup'."
+            )
+
+
+def _preflight_roster_sources(
+    plan: SharedSetupPlan,
+    services: CoreClassroomApplyServices,
+) -> None:
+    for roster_plan in plan.rosters:
+        try:
+            current_source = services.planning.load_roster(roster_plan.source_path)
+        except Exception as error:
+            message = str(error)[:500] or error.__class__.__name__
+            raise ClassroomSetupPreflightError(
+                f"Roster source for {roster_plan.class_id} could not be revalidated: "
+                f"{message}"
+            ) from error
+        if _roster_material(current_source) != _roster_material(
+            roster_plan.incoming_roster
+        ):
+            raise ClassroomSetupPreflightError(
+                f"Roster source for {roster_plan.class_id} changed after review. "
+                "Rerun 'pds setup' before applying it."
+            )
+
+
+def _preflight_standards(
+    assessment: SharedSetupAssessment,
+    plan: SharedSetupPlan,
+    services: CoreClassroomApplyServices,
+) -> None:
+    standards_plan = plan.standards
+    if standards_plan is None:
+        return
+    try:
+        current_plan = plan_starter_standards(
+            assessment,
+            standards_plan.pack_id,
+            services=services.planning,
+        )
+    except Exception as error:
+        message = str(error)[:500] or error.__class__.__name__
+        raise ClassroomSetupPreflightError(
+            "Selected starter standards could not be revalidated before APPLY: "
+            f"{message}"
+        ) from error
+    if (
+        current_plan.action is not standards_plan.action
+        or _standards_material(current_plan.candidate_library)
+        != _standards_material(standards_plan.candidate_library)
+    ):
+        raise ClassroomSetupPreflightError(
+            "Starter standards merge results changed after review. "
+            "Rerun 'pds setup' before applying them."
+        )
+
+
+def preflight_setup_plan(
+    reviewed_assessment: SharedSetupAssessment,
+    plan: SharedSetupPlan,
+    *,
+    services: CoreClassroomApplyServices,
+) -> SetupPreflight:
+    """Re-read all reviewed shared state before permitting the first mutation."""
+    if not plan.can_apply:
+        raise ClassroomSetupPreflightError(
+            "The reviewed setup plan still contains a blocking conflict."
+        )
+    try:
+        current = assess_shared_setup(services=services.planning.readers)
+    except ClassroomSetupError:
+        raise
+    except Exception as error:
+        message = str(error)[:500] or error.__class__.__name__
+        raise ClassroomSetupPreflightError(
+            f"Core shared state could not be re-assessed before APPLY: {message}"
+        ) from error
+
+    if current.workspace_root != reviewed_assessment.workspace_root:
+        raise ClassroomSetupPreflightError(
+            "The resolved Core workspace changed after review. Rerun 'pds setup'."
+        )
+    if _assessment_material(current) != _assessment_material(reviewed_assessment):
+        raise ClassroomSetupPreflightError(
+            "Core shared state changed after review. No setup mutation was made; "
+            "rerun 'pds setup' to review the current state."
+        )
+
+    _preflight_roster_sources(plan, services)
+    _preflight_standards(current, plan, services)
+    _preflight_period_state(current, plan, services)
+    return SetupPreflight(assessment=current)
+
+
+def _apply_time(clock: Clock) -> datetime:
+    value = clock()
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ClassroomSetupApplyError("setup APPLY clock must be timezone-aware")
+    return value
+
+
+def _verify_school_year(
+    root: Path,
+    school_year: str,
+    services: CoreClassroomApplyServices,
+) -> None:
+    try:
+        state = services.planning.readers.load_school_year_state(root)
+    except Exception as error:
+        raise ClassroomSetupVerificationError(
+            f"Could not verify school year after APPLY: {error}"
+        ) from error
+    if (
+        state is None
+        or state.closed_at is not None
+        or state.active_school_year != school_year
+    ):
+        raise ClassroomSetupVerificationError(
+            f"Core did not report school year {school_year} as open after APPLY."
+        )
+
+
+def _verify_class(
+    root: Path,
+    class_id: str,
+    expected: ClassMetadataLike,
+    services: CoreClassroomApplyServices,
+) -> None:
+    try:
+        current = services.planning.readers.load_class_metadata_for_class(
+            root,
+            class_id,
+        )
+    except Exception as error:
+        raise ClassroomSetupVerificationError(
+            f"Could not verify class {class_id} after APPLY: {error}"
+        ) from error
+    if _metadata_material(current) != _metadata_material(expected):
+        raise ClassroomSetupVerificationError(
+            f"Core class metadata for {class_id} differs from the reviewed result."
+        )
+
+
+def _verify_roster(
+    root: Path,
+    expected: ComparableRosterLike,
+    services: CoreClassroomApplyServices,
+) -> None:
+    try:
+        current = services.planning.readers.load_class_roster(
+            root,
+            expected.class_id,
+        )
+    except Exception as error:
+        raise ClassroomSetupVerificationError(
+            f"Could not verify roster for {expected.class_id}: {error}"
+        ) from error
+    if _roster_material(cast(ComparableRosterLike, current)) != _roster_material(
+        expected
+    ):
+        raise ClassroomSetupVerificationError(
+            f"Core roster for {expected.class_id} differs from the reviewed import."
+        )
+
+
+def _verify_standards(
+    root: Path,
+    expected: StandardsLibraryLike,
+    services: CoreClassroomApplyServices,
+) -> None:
+    try:
+        current = services.planning.readers.load_workspace_standards_library(root)
+    except Exception as error:
+        raise ClassroomSetupVerificationError(
+            f"Could not verify standards after APPLY: {error}"
+        ) from error
+    if _standards_material(current) != _standards_material(expected):
+        raise ClassroomSetupVerificationError(
+            "Core standards library differs from the reviewed merge result."
+        )
+
+
+def _verify_academic_periods(
+    root: Path,
+    expected: object,
+    services: CoreClassroomApplyServices,
+) -> None:
+    school_year = cast(str, getattr(expected, "school_year"))
+    revision = cast(int, getattr(expected, "calendar_revision"))
+    readers = services.planning.readers
+    try:
+        current = readers.load_current_academic_period_calendar(root, school_year)
+        current_revision = readers.get_current_academic_period_calendar_revision(
+            root,
+            school_year,
+        )
+    except Exception as error:
+        raise ClassroomSetupVerificationError(
+            f"Could not verify Academic Period calendar after APPLY: {error}"
+        ) from error
+    if (
+        current_revision != revision
+        or _calendar_material(current) != _calendar_material(expected)
+    ):
+        raise ClassroomSetupVerificationError(
+            "Core Academic Period current calendar differs from the reviewed result."
+        )
+
+
+def _jit_check_roster_replacement(
+    root: Path,
+    plan_roster: object,
+    services: CoreClassroomApplyServices,
+) -> None:
+    expected_existing = cast(
+        ComparableRosterLike | None,
+        getattr(plan_roster, "existing_roster"),
+    )
+    if expected_existing is None:
+        raise ClassroomSetupApplyError(
+            "Reviewed roster replacement is missing its existing Core baseline."
+        )
+    class_id = cast(str, getattr(plan_roster, "class_id"))
+    try:
+        current = services.planning.readers.load_class_roster(root, class_id)
+    except Exception as error:
+        raise ClassroomSetupApplyError(
+            f"Could not re-check existing roster for {class_id}: {error}"
+        ) from error
+    if _roster_material(cast(ComparableRosterLike, current)) != _roster_material(
+        expected_existing
+    ):
+        raise ClassroomSetupApplyError(
+            f"Roster for {class_id} changed during APPLY; replacement was refused."
+        )
+
+
+def _jit_check_standards(
+    root: Path,
+    expected: StandardsLibraryLike,
+    services: CoreClassroomApplyServices,
+) -> StandardsLibraryLike:
+    try:
+        current = services.planning.readers.load_workspace_standards_library(root)
+    except Exception as error:
+        raise ClassroomSetupApplyError(
+            f"Could not re-check standards immediately before install: {error}"
+        ) from error
+    if _standards_material(current) != _standards_material(expected):
+        raise ClassroomSetupApplyError(
+            "Standards library changed during APPLY; starter installation was refused."
+        )
+    return current
+
+
+def _execute_after_preflight(
+    preflight: SetupPreflight,
+    plan: SharedSetupPlan,
+    services: CoreClassroomApplyServices,
+    *,
+    clock: Clock,
+) -> SetupApplyResult:
+    root = preflight.assessment.workspace_root
+    completed: list[str] = []
+    changed: list[str] = []
+
+    try:
+        school = plan.school_year
+        if school.disposition is SchoolYearDisposition.NEW:
+            services.open_school_year(
+                root,
+                school.requested_school_year,
+                opened_at=_apply_time(clock),
+                overwrite=False,
+            )
+            changed.append(f"school_year:OPEN:{school.requested_school_year}")
+        _verify_school_year(
+            root,
+            school.requested_school_year,
+            services,
+        )
+        school_action = (
+            "OPEN"
+            if school.disposition is SchoolYearDisposition.NEW
+            else "KEEP"
+        )
+        completed.append(
+            f"school_year:{school_action}:{school.requested_school_year}"
+        )
+
+        for class_plan in plan.classes:
+            expected_metadata = class_plan.candidate_metadata
+            if class_plan.disposition is ClassDisposition.NEW:
+                expected_metadata = services.planning.create_class_metadata(
+                    class_plan.class_id,
+                    class_plan.school_year,
+                    created_at=_apply_time(clock),
+                    module_details=dict(class_plan.candidate_metadata.module_details),
+                )
+                services.write_class_metadata_for_class(
+                    root,
+                    expected_metadata,
+                    overwrite=False,
+                )
+                changed.append(f"class:CREATE:{class_plan.class_id}")
+            _verify_class(root, class_plan.class_id, expected_metadata, services)
+            action = (
+                "CREATE"
+                if class_plan.disposition is ClassDisposition.NEW
+                else "KEEP"
+            )
+            completed.append(f"class:{action}:{class_plan.class_id}")
+
+        for roster_plan in plan.rosters:
+            if roster_plan.action is RosterAction.CREATE:
+                services.write_class_roster(
+                    root,
+                    roster_plan.incoming_roster,
+                    overwrite=False,
+                )
+                changed.append(f"roster:CREATE:{roster_plan.class_id}")
+            elif roster_plan.action is RosterAction.REPLACE:
+                _jit_check_roster_replacement(root, roster_plan, services)
+                services.write_class_roster(
+                    root,
+                    roster_plan.incoming_roster,
+                    overwrite=True,
+                )
+                changed.append(f"roster:REPLACE:{roster_plan.class_id}")
+            elif roster_plan.action is not RosterAction.KEEP:
+                raise ClassroomSetupApplyError(
+                    f"Roster action {roster_plan.action.value} is not APPLY-eligible."
+                )
+            _verify_roster(root, roster_plan.incoming_roster, services)
+            completed.append(
+                f"roster:{roster_plan.action.value}:{roster_plan.class_id}"
+            )
+
+        standards_plan = plan.standards
+        if standards_plan is not None:
+            if standards_plan.action is StandardsAction.INSTALL:
+                baseline = _jit_check_standards(
+                    root,
+                    preflight.assessment.standards_library,
+                    services,
+                )
+                services.install_starter_standards_library(
+                    root,
+                    standards_plan.pack_id,
+                    baseline,
+                    overwrite_conflicts=False,
+                )
+                changed.append(f"standards:INSTALL:{standards_plan.pack_id}")
+            elif standards_plan.action is not StandardsAction.KEEP:
+                raise ClassroomSetupApplyError(
+                    f"Standards action {standards_plan.action.value} is not "
+                    "APPLY-eligible."
+                )
+            _verify_standards(root, standards_plan.candidate_library, services)
+            completed.append(
+                f"standards:{standards_plan.action.value}:{standards_plan.pack_id}"
+            )
+
+        period_plan = plan.academic_periods
+        if period_plan is not None:
+            if period_plan.action is AcademicPeriodAction.CREATE:
+                candidate = period_plan.candidate_calendar
+                if candidate is None:
+                    raise ClassroomSetupApplyError(
+                        "Reviewed Academic Period creation has no candidate calendar."
+                    )
+                services.write_academic_period_calendar(
+                    root,
+                    candidate,
+                    expected_current_revision=None,
+                )
+                changed.append(
+                    "academic_periods:CREATE:"
+                    f"{period_plan.school_year}:revision-1"
+                )
+                _verify_academic_periods(root, candidate, services)
+            elif period_plan.action is AcademicPeriodAction.KEEP:
+                candidate = period_plan.candidate_calendar
+                if candidate is None:
+                    raise ClassroomSetupApplyError(
+                        "Reviewed Academic Period KEEP has no current calendar."
+                    )
+                _verify_academic_periods(root, candidate, services)
+            elif period_plan.action is not AcademicPeriodAction.SKIP:
+                raise ClassroomSetupApplyError(
+                    f"Academic Period action {period_plan.action.value} is not "
+                    "APPLY-eligible."
+                )
+            completed.append(
+                "academic_periods:"
+                f"{period_plan.action.value}:{period_plan.school_year}"
+            )
+    except Exception as error:
+        if isinstance(error, ClassroomSetupApplyError):
+            if changed:
+                raise ClassroomSetupPartialSuccessError(
+                    f"{error} Some earlier Core writes succeeded; no rollback was "
+                    "attempted. Rerun 'pds setup' to assess the resulting state.",
+                    completed_actions=tuple(completed),
+                    changed_actions=tuple(changed),
+                ) from error
+            raise
+
+        message = str(error)[:500] or error.__class__.__name__
+        failure = ClassroomSetupApplyError(
+            f"Core setup operation failed: {message}"
+        )
+        if changed:
+            raise ClassroomSetupPartialSuccessError(
+                f"{failure} Some earlier Core writes succeeded; no rollback was "
+                "attempted. Rerun 'pds setup' to assess the resulting state.",
+                completed_actions=tuple(completed),
+                changed_actions=tuple(changed),
+            ) from error
+        raise failure from error
+
+    return SetupApplyResult(
+        completed_actions=tuple(completed),
+        changed_actions=tuple(changed),
+    )
+
+
+def execute_shared_setup_plan(
+    reviewed_assessment: SharedSetupAssessment,
+    plan: SharedSetupPlan,
+    *,
+    services: CoreClassroomApplyServices | None = None,
+    clock: Clock = lambda: datetime.now(timezone.utc),
+) -> SetupApplyResult:
+    """Apply one exact reviewed plan after a mutation-free fresh preflight."""
+    active_services = services or load_core_classroom_apply_services()
+    preflight = preflight_setup_plan(
+        reviewed_assessment,
+        plan,
+        services=active_services,
+    )
+    return _execute_after_preflight(
+        preflight,
+        plan,
+        active_services,
+        clock=clock,
+    )
+
+
+__all__ = (
+    "ClassroomSetupApplyError",
+    "ClassroomSetupPartialSuccessError",
+    "ClassroomSetupPreflightError",
+    "ClassroomSetupVerificationError",
+    "CoreClassroomApplyServiceError",
+    "CoreClassroomApplyServices",
+    "SetupApplyResult",
+    "SetupPreflight",
+    "execute_shared_setup_plan",
+    "load_core_classroom_apply_services",
+    "preflight_setup_plan",
+)

--- a/paper_data_suite/classroom_planning.py
+++ b/paper_data_suite/classroom_planning.py
@@ -1,0 +1,1062 @@
+"""In-memory proposal planning for guided shared classroom setup.
+
+This module composes public, suite-qualified PDS Core validators, factories, and
+readers to produce a reviewable setup plan.  It deliberately exposes no Core
+setup writers: persistent mutation belongs to the later APPLY execution layer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from importlib import import_module, metadata
+from pathlib import Path
+from typing import Protocol, cast
+
+from paper_data_suite.classroom_setup import (
+    ClassroomSetupError,
+    ClassSetupAssessment,
+    CoreClassroomServices,
+    SharedSetupAssessment,
+    StandardsLibraryLike,
+    load_core_classroom_services,
+)
+from paper_data_suite.compatibility import ReleaseCompatibilityManifest
+from paper_data_suite.component_inspection import DistributionVersionLookup
+
+ModuleImporter = Callable[[str], object]
+
+
+class ClassroomSetupPlanningError(ClassroomSetupError):
+    """Raised when a proposed shared setup cannot be validated in memory."""
+
+
+class CoreClassroomPlanningServiceError(ClassroomSetupPlanningError):
+    """Raised when a required public Core planning service is unavailable."""
+
+
+class RosterSourcePlanningError(ClassroomSetupPlanningError):
+    """Raised when Core rejects a teacher-selected roster source."""
+
+    def __init__(self, message: str, *, diagnostics: Sequence[str] = ()) -> None:
+        super().__init__(message)
+        self.diagnostics = tuple(diagnostics)
+
+
+class SchoolYearDisposition(str, Enum):
+    """Guided classification for a proposed school year."""
+
+    NEW = "NEW"
+    EXISTING_MATCH = "EXISTING_MATCH"
+    CONFLICT = "CONFLICT"
+
+
+class ClassDisposition(str, Enum):
+    """Guided classification for one proposed class."""
+
+    NEW = "NEW"
+    EXISTING_MATCH = "EXISTING_MATCH"
+    CONFLICT = "CONFLICT"
+
+
+class RosterAction(str, Enum):
+    """Whole-roster action after Core-valid model comparison."""
+
+    CREATE = "CREATE"
+    KEEP = "KEEP"
+    REPLACE = "REPLACE"
+    REFUSE = "REFUSE"
+
+
+class StandardsAction(str, Enum):
+    """Guided action for one explicitly selected Core starter pack."""
+
+    INSTALL = "INSTALL"
+    KEEP = "KEEP"
+    REFUSE = "REFUSE"
+
+
+class AcademicPeriodAction(str, Enum):
+    """Guided action for initial Academic Period configuration."""
+
+    CREATE = "CREATE"
+    KEEP = "KEEP"
+    SKIP = "SKIP"
+    REFUSE = "REFUSE"
+
+
+class ClassMetadataLike(Protocol):
+    class_id: str
+    school_year: str
+    module_details: Mapping[str, object]
+
+
+class ComparableStudentLike(Protocol):
+    class_id: str
+    student_id: str
+    last_name: str
+    first_name: str
+    period: str
+    extra_fields: Mapping[str, str]
+
+
+class ComparableRosterLike(Protocol):
+    class_id: str
+    students: Sequence[ComparableStudentLike]
+    columns: Sequence[str]
+    source_path: Path | None
+
+
+class StarterMergeResultLike(Protocol):
+    pack_id: str
+    target_path: Path
+    standards_added: int
+    standards_skipped: int
+    standards_overwritten: int
+    profiles_added: int
+    profiles_skipped: int
+    profiles_overwritten: int
+    standard_conflicts: Sequence[str]
+    profile_conflicts: Sequence[str]
+
+    @property
+    def has_conflicts(self) -> bool: ...
+
+    @property
+    def changed_count(self) -> int: ...
+
+
+class AcademicPeriodCalendarLike(Protocol):
+    school_year: str
+    calendar_revision: int
+    periods: Sequence[object]
+
+
+class IdentifierValidator(Protocol):
+    def __call__(self, value: object, field_name: str = "identifier") -> str: ...
+
+
+class SchoolYearValidator(Protocol):
+    def __call__(self, value: object) -> str: ...
+
+
+class ClassMetadataFactory(Protocol):
+    def __call__(
+        self,
+        class_id: str,
+        school_year: str,
+        *,
+        created_at: datetime,
+        updated_at: datetime | None = None,
+        module_details: Mapping[str, object] | None = None,
+    ) -> ClassMetadataLike: ...
+
+
+class RosterLoader(Protocol):
+    def __call__(self, path: str | Path) -> ComparableRosterLike: ...
+
+
+class StandardsLibraryPathGetter(Protocol):
+    def __call__(self, workspace_root: str | Path) -> Path: ...
+
+
+class StarterStandardsLibraryLoader(Protocol):
+    def __call__(self, pack_id: str) -> StandardsLibraryLike: ...
+
+
+class StandardsLibraryMerger(Protocol):
+    def __call__(
+        self,
+        pack_id: str,
+        target_path: str | Path,
+        existing_library: StandardsLibraryLike,
+        starter_library: StandardsLibraryLike,
+        *,
+        overwrite_conflicts: bool = False,
+    ) -> tuple[StandardsLibraryLike, StarterMergeResultLike]: ...
+
+
+class AcademicPeriodValidator(Protocol):
+    def __call__(self, value: object) -> object: ...
+
+
+class AcademicPeriodCalendarFactory(Protocol):
+    def __call__(
+        self,
+        *,
+        schema_version: str,
+        record_type: str,
+        school_year: str,
+        calendar_revision: int,
+        created_at: datetime,
+        updated_at: datetime,
+        periods: Sequence[object],
+    ) -> AcademicPeriodCalendarLike: ...
+
+
+class AcademicPeriodCalendarValidator(Protocol):
+    def __call__(self, value: object) -> AcademicPeriodCalendarLike: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CoreClassroomPlanningServices:
+    """Qualified public Core services that are safe before final APPLY."""
+
+    readers: CoreClassroomServices
+    validate_identifier: IdentifierValidator
+    validate_school_year: SchoolYearValidator
+    create_class_metadata: ClassMetadataFactory
+    load_roster: RosterLoader
+    standards_library_path: StandardsLibraryPathGetter
+    load_starter_standards_library: StarterStandardsLibraryLoader
+    merge_standards_libraries: StandardsLibraryMerger
+    validate_academic_period: AcademicPeriodValidator
+    academic_period_calendar_factory: AcademicPeriodCalendarFactory
+    validate_academic_period_calendar: AcademicPeriodCalendarValidator
+    academic_period_calendar_schema_version: str
+    academic_period_calendar_record_type: str
+    academic_period_types: frozenset[str]
+    academic_period_lifecycles: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class SchoolYearPlan:
+    requested_school_year: str
+    disposition: SchoolYearDisposition
+    reason: str
+
+    @property
+    def blocks_apply(self) -> bool:
+        return self.disposition is SchoolYearDisposition.CONFLICT
+
+
+@dataclass(frozen=True, slots=True)
+class ClassPlan:
+    class_id: str
+    school_year: str
+    disposition: ClassDisposition
+    candidate_metadata: ClassMetadataLike
+    existing: ClassSetupAssessment | None
+    reason: str
+
+    @property
+    def blocks_apply(self) -> bool:
+        return self.disposition is ClassDisposition.CONFLICT
+
+
+@dataclass(frozen=True, slots=True)
+class RosterPlan:
+    class_id: str
+    source_path: Path
+    incoming_roster: ComparableRosterLike
+    existing_roster: ComparableRosterLike | None
+    action: RosterAction
+    incoming_student_count: int
+    existing_student_count: int | None
+    new_count: int
+    unchanged_count: int
+    conflicting_existing_count: int
+    removed_existing_count: int
+    reason: str
+
+    @property
+    def blocks_apply(self) -> bool:
+        return self.action is RosterAction.REFUSE
+
+
+@dataclass(frozen=True, slots=True)
+class StandardsPlan:
+    pack_id: str
+    action: StandardsAction
+    candidate_library: StandardsLibraryLike
+    target_path: Path
+    standards_to_add: int
+    standards_identical: int
+    standard_conflicts: tuple[str, ...]
+    profiles_to_add: int
+    profiles_identical: int
+    profile_conflicts: tuple[str, ...]
+    reason: str
+
+    @property
+    def blocks_apply(self) -> bool:
+        return self.action is StandardsAction.REFUSE
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicPeriodPlan:
+    school_year: str
+    action: AcademicPeriodAction
+    candidate_calendar: AcademicPeriodCalendarLike | None
+    period_count: int
+    reason: str
+
+    @property
+    def blocks_apply(self) -> bool:
+        return self.action is AcademicPeriodAction.REFUSE
+
+
+@dataclass(frozen=True, slots=True)
+class SharedSetupPlan:
+    """One complete, in-memory, reviewable proposal before APPLY."""
+
+    school_year: SchoolYearPlan
+    classes: tuple[ClassPlan, ...]
+    rosters: tuple[RosterPlan, ...]
+    standards: StandardsPlan | None
+    academic_periods: AcademicPeriodPlan | None
+
+    @property
+    def blocking_reasons(self) -> tuple[str, ...]:
+        reasons: list[str] = []
+        if self.school_year.blocks_apply:
+            reasons.append(self.school_year.reason)
+        reasons.extend(plan.reason for plan in self.classes if plan.blocks_apply)
+        reasons.extend(plan.reason for plan in self.rosters if plan.blocks_apply)
+        if self.standards is not None and self.standards.blocks_apply:
+            reasons.append(self.standards.reason)
+        if self.academic_periods is not None and self.academic_periods.blocks_apply:
+            reasons.append(self.academic_periods.reason)
+        return tuple(reasons)
+
+    @property
+    def can_apply(self) -> bool:
+        return not self.blocking_reasons
+
+
+def _required_callable(module: object, module_name: str, name: str) -> object:
+    value = getattr(module, name, None)
+    if not callable(value):
+        raise CoreClassroomPlanningServiceError(
+            "Suite-qualified Core does not expose public callable "
+            f"{module_name}.{name}."
+        )
+    return value
+
+
+def _required_text(module: object, module_name: str, name: str) -> str:
+    value = getattr(module, name, None)
+    if not isinstance(value, str) or not value:
+        raise CoreClassroomPlanningServiceError(
+            "Suite-qualified Core does not expose public text contract "
+            f"{module_name}.{name}."
+        )
+    return value
+
+
+def _required_text_set(module: object, module_name: str, name: str) -> frozenset[str]:
+    value = getattr(module, name, None)
+    if not isinstance(value, (set, frozenset)) or not all(
+        isinstance(item, str) and item for item in value
+    ):
+        raise CoreClassroomPlanningServiceError(
+            "Suite-qualified Core does not expose public text-set contract "
+            f"{module_name}.{name}."
+        )
+    return frozenset(value)
+
+
+def _import_core_module(module_name: str, module_importer: ModuleImporter) -> object:
+    try:
+        return module_importer(module_name)
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise CoreClassroomPlanningServiceError(
+            "Could not import public Core planning services from "
+            f"{module_name}: {message}"
+        ) from error
+
+
+def load_core_classroom_planning_services(
+    manifest: ReleaseCompatibilityManifest | None = None,
+    *,
+    version_lookup: DistributionVersionLookup = metadata.version,
+    module_importer: ModuleImporter = import_module,
+) -> CoreClassroomPlanningServices:
+    """Qualify Core exactly, then load public pre-APPLY planning contracts."""
+    readers = load_core_classroom_services(
+        manifest,
+        version_lookup=version_lookup,
+        module_importer=module_importer,
+    )
+
+    identifiers = _import_core_module("pds_core.identifiers", module_importer)
+    school_years = _import_core_module("pds_core.school_years", module_importer)
+    class_metadata = _import_core_module("pds_core.class_metadata", module_importer)
+    rosters = _import_core_module("pds_core.rosters", module_importer)
+    standards = _import_core_module("pds_core.standards", module_importer)
+    starter_standards = _import_core_module(
+        "pds_core.starter_standards",
+        module_importer,
+    )
+    academic_periods = _import_core_module("pds_core.academic_periods", module_importer)
+
+    return CoreClassroomPlanningServices(
+        readers=readers,
+        validate_identifier=cast(
+            IdentifierValidator,
+            _required_callable(
+                identifiers,
+                "pds_core.identifiers",
+                "validate_identifier",
+            ),
+        ),
+        validate_school_year=cast(
+            SchoolYearValidator,
+            _required_callable(
+                school_years,
+                "pds_core.school_years",
+                "validate_school_year",
+            ),
+        ),
+        create_class_metadata=cast(
+            ClassMetadataFactory,
+            _required_callable(
+                class_metadata,
+                "pds_core.class_metadata",
+                "create_class_metadata",
+            ),
+        ),
+        load_roster=cast(
+            RosterLoader,
+            _required_callable(rosters, "pds_core.rosters", "load_roster"),
+        ),
+        standards_library_path=cast(
+            StandardsLibraryPathGetter,
+            _required_callable(
+                standards,
+                "pds_core.standards",
+                "standards_library_path",
+            ),
+        ),
+        load_starter_standards_library=cast(
+            StarterStandardsLibraryLoader,
+            _required_callable(
+                starter_standards,
+                "pds_core.starter_standards",
+                "load_starter_standards_library",
+            ),
+        ),
+        merge_standards_libraries=cast(
+            StandardsLibraryMerger,
+            _required_callable(
+                starter_standards,
+                "pds_core.starter_standards",
+                "merge_standards_libraries",
+            ),
+        ),
+        validate_academic_period=cast(
+            AcademicPeriodValidator,
+            _required_callable(
+                academic_periods,
+                "pds_core.academic_periods",
+                "validate_academic_period",
+            ),
+        ),
+        academic_period_calendar_factory=cast(
+            AcademicPeriodCalendarFactory,
+            _required_callable(
+                academic_periods,
+                "pds_core.academic_periods",
+                "AcademicPeriodCalendar",
+            ),
+        ),
+        validate_academic_period_calendar=cast(
+            AcademicPeriodCalendarValidator,
+            _required_callable(
+                academic_periods,
+                "pds_core.academic_periods",
+                "validate_academic_period_calendar",
+            ),
+        ),
+        academic_period_calendar_schema_version=_required_text(
+            academic_periods,
+            "pds_core.academic_periods",
+            "ACADEMIC_PERIOD_CALENDAR_SCHEMA_VERSION",
+        ),
+        academic_period_calendar_record_type=_required_text(
+            academic_periods,
+            "pds_core.academic_periods",
+            "ACADEMIC_PERIOD_CALENDAR_RECORD_TYPE",
+        ),
+        academic_period_types=_required_text_set(
+            academic_periods,
+            "pds_core.academic_periods",
+            "ACADEMIC_PERIOD_TYPES",
+        ),
+        academic_period_lifecycles=_required_text_set(
+            academic_periods,
+            "pds_core.academic_periods",
+            "ACADEMIC_PERIOD_LIFECYCLES",
+        ),
+    )
+
+
+def _planning_failure(area: str, error: Exception) -> ClassroomSetupPlanningError:
+    message = str(error)[:500] or error.__class__.__name__
+    return ClassroomSetupPlanningError(
+        f"Core rejected the proposed {area}: {message}"
+    )
+
+
+def plan_school_year(
+    assessment: SharedSetupAssessment,
+    requested_school_year: str,
+    *,
+    services: CoreClassroomPlanningServices,
+) -> SchoolYearPlan:
+    """Validate and classify one explicitly requested school year through Core."""
+    try:
+        validated = services.validate_school_year(requested_school_year)
+    except Exception as error:
+        raise _planning_failure("school year", error) from error
+
+    active = assessment.active_school_year
+    if active is None:
+        return SchoolYearPlan(
+            requested_school_year=validated,
+            disposition=SchoolYearDisposition.NEW,
+            reason=f"No school year is currently open; {validated} can be opened.",
+        )
+    if active == validated:
+        return SchoolYearPlan(
+            requested_school_year=validated,
+            disposition=SchoolYearDisposition.EXISTING_MATCH,
+            reason=f"School year {validated} is already open.",
+        )
+    return SchoolYearPlan(
+        requested_school_year=validated,
+        disposition=SchoolYearDisposition.CONFLICT,
+        reason=(
+            f"School year {active} is already open; guided setup will not replace "
+            f"it with {validated}. Resolve the lifecycle state through Core first."
+        ),
+    )
+
+
+def _assessment_class(
+    assessment: SharedSetupAssessment,
+    class_id: str,
+) -> ClassSetupAssessment | None:
+    return next(
+        (item for item in assessment.classes if item.class_id == class_id),
+        None,
+    )
+
+
+def plan_class(
+    assessment: SharedSetupAssessment,
+    class_id: str,
+    school_year: str,
+    *,
+    planning_time: datetime,
+    services: CoreClassroomPlanningServices,
+) -> ClassPlan:
+    """Validate and classify one explicit class proposal through Core."""
+    try:
+        validated_class_id = services.validate_identifier(class_id, "class_id")
+        validated_school_year = services.validate_school_year(school_year)
+        candidate = services.create_class_metadata(
+            validated_class_id,
+            validated_school_year,
+            created_at=planning_time,
+            module_details={},
+        )
+    except Exception as error:
+        raise _planning_failure("class", error) from error
+
+    existing = _assessment_class(assessment, validated_class_id)
+    if existing is None:
+        return ClassPlan(
+            class_id=validated_class_id,
+            school_year=validated_school_year,
+            disposition=ClassDisposition.NEW,
+            candidate_metadata=candidate,
+            existing=None,
+            reason="No existing Core class folder or metadata was discovered.",
+        )
+
+    metadata_value = existing.metadata
+    if metadata_value is None:
+        if existing.roster is not None:
+            return ClassPlan(
+                class_id=validated_class_id,
+                school_year=validated_school_year,
+                disposition=ClassDisposition.CONFLICT,
+                candidate_metadata=candidate,
+                existing=existing,
+                reason=(
+                    f"Class {validated_class_id} has a roster but no valid class "
+                    "metadata; guided setup will not guess its school year."
+                ),
+            )
+        return ClassPlan(
+            class_id=validated_class_id,
+            school_year=validated_school_year,
+            disposition=ClassDisposition.NEW,
+            candidate_metadata=candidate,
+            existing=existing,
+            reason=(
+                f"Class folder {validated_class_id} exists without metadata or a "
+                "roster; guided setup can finish this unambiguous class setup."
+            ),
+        )
+
+    if (
+        metadata_value.class_id == validated_class_id
+        and metadata_value.school_year == validated_school_year
+    ):
+        return ClassPlan(
+            class_id=validated_class_id,
+            school_year=validated_school_year,
+            disposition=ClassDisposition.EXISTING_MATCH,
+            candidate_metadata=metadata_value,
+            existing=existing,
+            reason=(
+                f"Class {validated_class_id} already has matching Core metadata for "
+                f"{validated_school_year}."
+            ),
+        )
+
+    return ClassPlan(
+        class_id=validated_class_id,
+        school_year=validated_school_year,
+        disposition=ClassDisposition.CONFLICT,
+        candidate_metadata=candidate,
+        existing=existing,
+        reason=(
+            f"Class {validated_class_id} has existing Core metadata for school year "
+            f"{metadata_value.school_year}; guided setup will not overwrite it."
+        ),
+    )
+
+
+_ROSTER_DIAGNOSTIC_MESSAGES = {
+    "invalid_header": "A roster header is invalid.",
+    "blank_header": "A roster header must not be blank.",
+    "duplicate_header": "A roster header appears more than once.",
+    "missing_required_column": "A required roster column is missing.",
+    "missing_required_field": "A required roster field is missing.",
+    "non_string_value": "A roster field must contain text.",
+    "blank_required_value": "A required roster field must not be blank.",
+    "invalid_class_id": "A class_id is not a valid Core identifier.",
+    "inconsistent_class_id": "The roster contains more than one class_id.",
+    "invalid_student_id": "A student_id is not a valid Core identifier.",
+    "duplicate_student_id": "A student_id appears more than once.",
+    "empty_roster": "The roster contains no valid student rows.",
+    "missing_header": "The roster CSV is missing its header row.",
+    "malformed_row": "A roster CSV row does not match the header shape.",
+}
+
+
+def _roster_diagnostics(error: Exception) -> tuple[str, ...]:
+    """Render bounded structured Core diagnostics without echoing row values."""
+    issues = getattr(error, "issues", ())
+    try:
+        materialized = tuple(issues)
+    except TypeError:
+        return ()
+
+    diagnostics: list[str] = []
+    for issue in materialized[:5]:
+        code = getattr(issue, "code", None)
+        row_number = getattr(issue, "row_number", None)
+        column = getattr(issue, "column", None)
+        location: list[str] = []
+        if isinstance(row_number, int):
+            location.append(f"row {row_number}")
+        if isinstance(column, str) and column:
+            location.append(f"column {column}")
+        prefix = f"{' / '.join(location)}: " if location else ""
+        message = (
+            _ROSTER_DIAGNOSTIC_MESSAGES.get(
+                code,
+                "Core rejected this roster entry.",
+            )
+            if isinstance(code, str)
+            else "Core rejected this roster entry."
+        )
+        diagnostics.append(prefix + message)
+    return tuple(diagnostics)
+
+
+def _student_material(student: ComparableStudentLike) -> tuple[object, ...]:
+    return (
+        student.class_id,
+        student.student_id,
+        student.last_name,
+        student.first_name,
+        student.period,
+        tuple(sorted(student.extra_fields.items())),
+    )
+
+
+def _roster_material(roster: ComparableRosterLike) -> tuple[object, ...]:
+    return (
+        roster.class_id,
+        tuple(roster.columns),
+        tuple(_student_material(student) for student in roster.students),
+    )
+
+
+def plan_roster_import(
+    assessment: SharedSetupAssessment,
+    class_id: str,
+    source_path: str | Path,
+    *,
+    services: CoreClassroomPlanningServices,
+) -> RosterPlan:
+    """Load a roster through Core and classify a whole-roster setup action."""
+    try:
+        validated_class_id = services.validate_identifier(class_id, "class_id")
+    except Exception as error:
+        raise _planning_failure("roster target class", error) from error
+
+    source = Path(source_path)
+    try:
+        incoming = services.load_roster(source)
+    except Exception as error:
+        diagnostics = _roster_diagnostics(error)
+        if diagnostics:
+            message = f"Core rejected roster source {source}."
+        else:
+            detail = str(error)[:300] or error.__class__.__name__
+            message = f"Core could not load roster source {source}: {detail}"
+        raise RosterSourcePlanningError(
+            message,
+            diagnostics=diagnostics,
+        ) from error
+
+    existing_assessment = _assessment_class(assessment, validated_class_id)
+    existing = (
+        None
+        if existing_assessment is None
+        else cast(ComparableRosterLike | None, existing_assessment.roster)
+    )
+
+    incoming_count = len(incoming.students)
+    existing_count = None if existing is None else len(existing.students)
+
+    if incoming.class_id != validated_class_id:
+        return RosterPlan(
+            class_id=validated_class_id,
+            source_path=source,
+            incoming_roster=incoming,
+            existing_roster=existing,
+            action=RosterAction.REFUSE,
+            incoming_student_count=incoming_count,
+            existing_student_count=existing_count,
+            new_count=0,
+            unchanged_count=0,
+            conflicting_existing_count=0,
+            removed_existing_count=0,
+            reason=(
+                f"Roster source belongs to class {incoming.class_id}, not explicitly "
+                f"selected class {validated_class_id}."
+            ),
+        )
+
+    if existing is None:
+        return RosterPlan(
+            class_id=validated_class_id,
+            source_path=source,
+            incoming_roster=incoming,
+            existing_roster=None,
+            action=RosterAction.CREATE,
+            incoming_student_count=incoming_count,
+            existing_student_count=None,
+            new_count=incoming_count,
+            unchanged_count=0,
+            conflicting_existing_count=0,
+            removed_existing_count=0,
+            reason=f"Class {validated_class_id} has no existing Core roster.",
+        )
+
+    existing_by_id = {student.student_id: student for student in existing.students}
+    incoming_ids = {student.student_id for student in incoming.students}
+    new_count = 0
+    unchanged_count = 0
+    conflicting_count = 0
+    for student in incoming.students:
+        current = existing_by_id.get(student.student_id)
+        if current is None:
+            new_count += 1
+        elif _student_material(current) == _student_material(student):
+            unchanged_count += 1
+        else:
+            conflicting_count += 1
+    removed_count = sum(
+        1 for student in existing.students if student.student_id not in incoming_ids
+    )
+
+    if _roster_material(existing) == _roster_material(incoming):
+        action = RosterAction.KEEP
+        reason = f"Imported roster for {validated_class_id} is materially identical."
+    else:
+        action = RosterAction.REPLACE
+        reason = (
+            f"Imported roster for {validated_class_id} differs from the existing "
+            "Core roster and therefore requires whole-roster replacement."
+        )
+
+    return RosterPlan(
+        class_id=validated_class_id,
+        source_path=source,
+        incoming_roster=incoming,
+        existing_roster=existing,
+        action=action,
+        incoming_student_count=incoming_count,
+        existing_student_count=len(existing.students),
+        new_count=new_count,
+        unchanged_count=unchanged_count,
+        conflicting_existing_count=conflicting_count,
+        removed_existing_count=removed_count,
+        reason=reason,
+    )
+
+
+def plan_starter_standards(
+    assessment: SharedSetupAssessment,
+    pack_id: str,
+    *,
+    services: CoreClassroomPlanningServices,
+) -> StandardsPlan:
+    """Dry-merge one explicitly selected Core starter standards pack."""
+    available = {pack.pack_id for pack in assessment.starter_standards_packs}
+    if pack_id not in available:
+        raise ClassroomSetupPlanningError(
+            f"Starter standards pack {pack_id!r} is not advertised by qualified Core."
+        )
+
+    try:
+        starter = services.load_starter_standards_library(pack_id)
+        target = services.standards_library_path(assessment.workspace_root)
+        candidate, result = services.merge_standards_libraries(
+            pack_id,
+            target,
+            assessment.standards_library,
+            starter,
+            overwrite_conflicts=False,
+        )
+    except Exception as error:
+        raise _planning_failure("starter standards selection", error) from error
+
+    standard_conflicts = tuple(result.standard_conflicts)
+    profile_conflicts = tuple(result.profile_conflicts)
+    if standard_conflicts or profile_conflicts:
+        action = StandardsAction.REFUSE
+        reason = (
+            f"Starter standards pack {pack_id} conflicts with protected existing "
+            "standards or profiles; guided setup will not overwrite them."
+        )
+    elif result.changed_count == 0:
+        action = StandardsAction.KEEP
+        reason = f"Starter standards pack {pack_id} is already fully present."
+    else:
+        action = StandardsAction.INSTALL
+        reason = f"Starter standards pack {pack_id} can be merged without conflicts."
+
+    return StandardsPlan(
+        pack_id=pack_id,
+        action=action,
+        candidate_library=candidate,
+        target_path=Path(result.target_path),
+        standards_to_add=result.standards_added,
+        standards_identical=result.standards_skipped,
+        standard_conflicts=standard_conflicts,
+        profiles_to_add=result.profiles_added,
+        profiles_identical=result.profiles_skipped,
+        profile_conflicts=profile_conflicts,
+        reason=reason,
+    )
+
+
+def plan_academic_periods(
+    assessment: SharedSetupAssessment,
+    school_year: str,
+    period_values: Sequence[Mapping[str, object]] | None,
+    *,
+    planning_time: datetime,
+    services: CoreClassroomPlanningServices,
+) -> AcademicPeriodPlan:
+    """Validate an explicit initial calendar proposal, or represent an explicit skip."""
+    try:
+        validated_school_year = services.validate_school_year(school_year)
+    except Exception as error:
+        raise _planning_failure("Academic Period school year", error) from error
+
+    existing = assessment.academic_period_calendar
+    existing_revision = assessment.academic_period_revision
+    if existing is None or existing.school_year != validated_school_year:
+        try:
+            existing = services.readers.load_current_academic_period_calendar(
+                assessment.workspace_root,
+                validated_school_year,
+            )
+            existing_revision = (
+                services.readers.get_current_academic_period_calendar_revision(
+                    assessment.workspace_root,
+                    validated_school_year,
+                )
+            )
+        except Exception as error:
+            raise _planning_failure(
+                "existing Academic Period calendar", error
+            ) from error
+
+    if existing is None and existing_revision is not None:
+        raise ClassroomSetupPlanningError(
+            "Core reports an Academic Period revision but no current calendar for "
+            f"{validated_school_year}."
+        )
+    if existing is not None:
+        if existing_revision is None:
+            raise ClassroomSetupPlanningError(
+                "Core reports a current Academic Period calendar without a current "
+                f"revision for {validated_school_year}."
+            )
+        if existing.school_year != validated_school_year:
+            raise ClassroomSetupPlanningError(
+                "Core returned an Academic Period calendar for the wrong school year."
+            )
+        if existing.calendar_revision != existing_revision:
+            raise ClassroomSetupPlanningError(
+                "Core Academic Period calendar and current revision pointer disagree."
+            )
+        if period_values is not None:
+            return AcademicPeriodPlan(
+                school_year=validated_school_year,
+                action=AcademicPeriodAction.REFUSE,
+                candidate_calendar=None,
+                period_count=len(existing.periods),
+                reason=(
+                    f"Academic Period calendar for {validated_school_year} already "
+                    "exists; guided setup does not revise existing calendars."
+                ),
+            )
+        return AcademicPeriodPlan(
+            school_year=validated_school_year,
+            action=AcademicPeriodAction.KEEP,
+            candidate_calendar=existing,
+            period_count=len(existing.periods),
+            reason=(
+                f"Academic Period calendar for {validated_school_year} is already "
+                "configured and will be kept unchanged."
+            ),
+        )
+
+    if period_values is None:
+        return AcademicPeriodPlan(
+            school_year=validated_school_year,
+            action=AcademicPeriodAction.SKIP,
+            candidate_calendar=None,
+            period_count=0,
+            reason="Academic Period setup was explicitly skipped.",
+        )
+
+    try:
+        periods = tuple(
+            services.validate_academic_period(period_value)
+            for period_value in period_values
+        )
+        candidate = services.academic_period_calendar_factory(
+            schema_version=services.academic_period_calendar_schema_version,
+            record_type=services.academic_period_calendar_record_type,
+            school_year=validated_school_year,
+            calendar_revision=1,
+            created_at=planning_time,
+            updated_at=planning_time,
+            periods=periods,
+        )
+        validated = services.validate_academic_period_calendar(candidate)
+    except Exception as error:
+        raise _planning_failure("Academic Period calendar", error) from error
+
+    return AcademicPeriodPlan(
+        school_year=validated_school_year,
+        action=AcademicPeriodAction.CREATE,
+        candidate_calendar=validated,
+        period_count=len(validated.periods),
+        reason=(
+            f"Initial Academic Period calendar revision 1 for {validated_school_year} "
+            "is valid in memory."
+        ),
+    )
+
+
+def assemble_shared_setup_plan(
+    school_year: SchoolYearPlan,
+    *,
+    classes: Sequence[ClassPlan] = (),
+    rosters: Sequence[RosterPlan] = (),
+    standards: StandardsPlan | None = None,
+    academic_periods: AcademicPeriodPlan | None = None,
+) -> SharedSetupPlan:
+    """Assemble domain plans and reject internally inconsistent proposal wiring."""
+    class_plans = tuple(classes)
+    roster_plans = tuple(rosters)
+
+    class_ids = [plan.class_id for plan in class_plans]
+    if len(class_ids) != len(set(class_ids)):
+        raise ClassroomSetupPlanningError(
+            "A shared setup plan cannot contain the same class_id more than once."
+        )
+    roster_ids = [plan.class_id for plan in roster_plans]
+    if len(roster_ids) != len(set(roster_ids)):
+        raise ClassroomSetupPlanningError(
+            "A shared setup plan cannot contain more than one roster import per class."
+        )
+
+    requested_year = school_year.requested_school_year
+    for class_plan in class_plans:
+        if class_plan.school_year != requested_year:
+            raise ClassroomSetupPlanningError(
+                f"Class {class_plan.class_id} targets {class_plan.school_year}, not "
+                f"selected school year {requested_year}."
+            )
+    known_class_ids = set(class_ids)
+    for roster_plan in roster_plans:
+        if roster_plan.class_id not in known_class_ids:
+            raise ClassroomSetupPlanningError(
+                f"Roster for {roster_plan.class_id} has no corresponding class plan."
+            )
+    if academic_periods is not None and academic_periods.school_year != requested_year:
+        raise ClassroomSetupPlanningError(
+            "Academic Period proposal does not target the selected school year."
+        )
+
+    return SharedSetupPlan(
+        school_year=school_year,
+        classes=class_plans,
+        rosters=roster_plans,
+        standards=standards,
+        academic_periods=academic_periods,
+    )
+
+
+__all__ = (
+    "AcademicPeriodAction",
+    "AcademicPeriodPlan",
+    "ClassDisposition",
+    "ClassPlan",
+    "ClassroomSetupPlanningError",
+    "CoreClassroomPlanningServiceError",
+    "CoreClassroomPlanningServices",
+    "RosterAction",
+    "RosterPlan",
+    "RosterSourcePlanningError",
+    "SchoolYearDisposition",
+    "SchoolYearPlan",
+    "SharedSetupPlan",
+    "StandardsAction",
+    "StandardsPlan",
+    "assemble_shared_setup_plan",
+    "load_core_classroom_planning_services",
+    "plan_academic_periods",
+    "plan_class",
+    "plan_roster_import",
+    "plan_school_year",
+    "plan_starter_standards",
+)

--- a/paper_data_suite/classroom_setup.py
+++ b/paper_data_suite/classroom_setup.py
@@ -1,0 +1,571 @@
+"""Read-only assessment for guided shared classroom setup.
+
+This module is a suite-owned orchestration layer over public, suite-qualified
+PDS Core services.  It deliberately performs no setup mutation while loading
+Core services or assessing the currently resolved workspace.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from importlib import import_module, metadata
+from pathlib import Path
+from typing import Protocol, cast
+
+from paper_data_suite.compatibility import ReleaseCompatibilityManifest
+from paper_data_suite.component_inspection import DistributionVersionLookup
+from paper_data_suite.workspace_setup import (
+    CoreWorkspaceQualificationError,
+    CoreWorkspaceServiceError,
+    CoreWorkspaceServices,
+    load_core_workspace_services,
+)
+
+ModuleImporter = Callable[[str], object]
+
+
+class ClassroomSetupError(RuntimeError):
+    """Base class for bounded guided classroom-setup failures."""
+
+
+class CoreClassroomServiceError(ClassroomSetupError):
+    """Raised when a required public Core classroom service is unavailable."""
+
+
+class ClassroomSetupAssessmentError(ClassroomSetupError):
+    """Raised when current Core-owned shared state cannot be trusted."""
+
+
+class ClassroomWorkspaceError(ClassroomSetupAssessmentError):
+    """Raised when the currently resolved workspace is not usable for setup."""
+
+
+class WorkspaceStatusLike(Protocol):
+    """Public Core workspace status fields consumed during assessment."""
+
+    root: Path
+    source: str
+    exists: bool
+    is_dir: bool
+    is_writable: bool
+
+
+class SchoolYearStateLike(Protocol):
+    """Public Core school-year state fields consumed during assessment."""
+
+    active_school_year: str
+    opened_at: datetime
+    closed_at: datetime | None
+
+
+class ClassFolderLike(Protocol):
+    """Public Core class-folder fields consumed during assessment."""
+
+    class_id: str
+    class_dir: Path
+    roster_path: Path
+    metadata_path: Path
+
+
+class ClassMetadataLike(Protocol):
+    """Public Core class metadata fields consumed during assessment."""
+
+    class_id: str
+    school_year: str
+    module_details: Mapping[str, object]
+
+
+class StudentRecordLike(Protocol):
+    """Public Core roster student fields used only for bounded counts."""
+
+    student_id: str
+
+
+class RosterLike(Protocol):
+    """Public Core roster fields consumed during assessment."""
+
+    class_id: str
+    students: Sequence[StudentRecordLike]
+    columns: Sequence[str]
+
+
+class StandardsLibraryLike(Protocol):
+    """Public Core standards-library fields consumed during assessment."""
+
+    standards: Sequence[object]
+    profiles: Sequence[object]
+
+
+class StarterStandardsPackLike(Protocol):
+    """Public Core starter-pack metadata fields consumed during assessment."""
+
+    pack_id: str
+    title: str
+    source: str
+    grade_bands: Sequence[str]
+    courses: Sequence[str]
+    standard_count: int
+    profile_count: int
+
+
+class AcademicPeriodCalendarLike(Protocol):
+    """Public Core Academic Period calendar fields consumed during assessment."""
+
+    school_year: str
+    calendar_revision: int
+    periods: Sequence[object]
+
+
+class WorkspaceInspector(Protocol):
+    def __call__(
+        self,
+        explicit_root: str | Path | None = None,
+    ) -> WorkspaceStatusLike: ...
+
+
+class SchoolYearLoader(Protocol):
+    def __call__(self, workspace_root: str | Path) -> SchoolYearStateLike | None: ...
+
+
+class ClassFolderLister(Protocol):
+    def __call__(
+        self,
+        workspace_root: str | Path,
+        *,
+        require_roster: bool = False,
+        load_rosters: bool = False,
+        require_metadata: bool = False,
+        load_metadata: bool = False,
+    ) -> tuple[ClassFolderLike, ...]: ...
+
+
+class ClassMetadataLoader(Protocol):
+    def __call__(
+        self,
+        workspace_root: str | Path,
+        class_id: str,
+    ) -> ClassMetadataLike: ...
+
+
+class ClassRosterLoader(Protocol):
+    def __call__(
+        self,
+        workspace_root: str | Path,
+        class_id: str,
+    ) -> RosterLike: ...
+
+
+class WorkspaceStandardsLoader(Protocol):
+    def __call__(self, workspace_root: str | Path) -> StandardsLibraryLike: ...
+
+
+class StarterStandardsPackLister(Protocol):
+    def __call__(self) -> tuple[StarterStandardsPackLike, ...]: ...
+
+
+class CurrentAcademicPeriodCalendarLoader(Protocol):
+    def __call__(
+        self,
+        workspace_root: str | Path,
+        school_year: str,
+    ) -> AcademicPeriodCalendarLike | None: ...
+
+
+class CurrentAcademicPeriodRevisionGetter(Protocol):
+    def __call__(
+        self,
+        workspace_root: str | Path,
+        school_year: str,
+    ) -> int | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CoreClassroomServices:
+    """Qualified public Core services used by the read-only setup assessment."""
+
+    inspect_workspace_root: WorkspaceInspector
+    load_school_year_state: SchoolYearLoader
+    list_class_folders: ClassFolderLister
+    load_class_metadata_for_class: ClassMetadataLoader
+    load_class_roster: ClassRosterLoader
+    load_workspace_standards_library: WorkspaceStandardsLoader
+    list_starter_standards_packs: StarterStandardsPackLister
+    load_current_academic_period_calendar: CurrentAcademicPeriodCalendarLoader
+    get_current_academic_period_calendar_revision: CurrentAcademicPeriodRevisionGetter
+
+
+@dataclass(frozen=True, slots=True)
+class ClassSetupAssessment:
+    """Bounded read-only status for one Core-valid class folder."""
+
+    class_id: str
+    metadata: ClassMetadataLike | None
+    roster: RosterLike | None
+
+    @property
+    def has_metadata(self) -> bool:
+        return self.metadata is not None
+
+    @property
+    def has_roster(self) -> bool:
+        return self.roster is not None
+
+    @property
+    def student_count(self) -> int | None:
+        if self.roster is None:
+            return None
+        return len(self.roster.students)
+
+
+@dataclass(frozen=True, slots=True)
+class SharedSetupAssessment:
+    """Read-only Core-derived shared classroom state before teacher input."""
+
+    workspace_root: Path
+    workspace_source: str
+    school_year_state: SchoolYearStateLike | None
+    classes: tuple[ClassSetupAssessment, ...]
+    standards_library: StandardsLibraryLike
+    starter_standards_packs: tuple[StarterStandardsPackLike, ...]
+    academic_period_calendar: AcademicPeriodCalendarLike | None
+    academic_period_revision: int | None
+
+    @property
+    def active_school_year(self) -> str | None:
+        state = self.school_year_state
+        if state is None or state.closed_at is not None:
+            return None
+        return state.active_school_year
+
+    @property
+    def standards_count(self) -> int:
+        return len(self.standards_library.standards)
+
+    @property
+    def standards_profile_count(self) -> int:
+        return len(self.standards_library.profiles)
+
+
+def _required_callable(module: object, module_name: str, name: str) -> object:
+    value = getattr(module, name, None)
+    if not callable(value):
+        raise CoreClassroomServiceError(
+            "Suite-qualified Core does not expose public callable "
+            f"{module_name}.{name}."
+        )
+    return value
+
+
+def _import_core_module(module_name: str, module_importer: ModuleImporter) -> object:
+    try:
+        return module_importer(module_name)
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise CoreClassroomServiceError(
+            f"Could not import public Core setup services from {module_name}: {message}"
+        ) from error
+
+
+def load_core_classroom_services(
+    manifest: ReleaseCompatibilityManifest | None = None,
+    *,
+    version_lookup: DistributionVersionLookup = metadata.version,
+    module_importer: ModuleImporter = import_module,
+) -> CoreClassroomServices:
+    """Qualify Core exactly, then load only public UI-neutral setup services.
+
+    Qualification is delegated to the suite's existing workspace integration,
+    so this workflow cannot accept a merely package-compatible but unqualified
+    Core release.  No setup state is read or written by this loader.
+    """
+    try:
+        workspace_services: CoreWorkspaceServices = load_core_workspace_services(
+            manifest,
+            version_lookup=version_lookup,
+            module_importer=module_importer,
+        )
+    except (CoreWorkspaceQualificationError, CoreWorkspaceServiceError):
+        raise
+
+    school_years = _import_core_module("pds_core.school_years", module_importer)
+    classes = _import_core_module("pds_core.classes", module_importer)
+    class_metadata = _import_core_module("pds_core.class_metadata", module_importer)
+    standards = _import_core_module("pds_core.standards", module_importer)
+    starter_standards = _import_core_module(
+        "pds_core.starter_standards",
+        module_importer,
+    )
+    academic_period_storage = _import_core_module(
+        "pds_core.academic_period_storage",
+        module_importer,
+    )
+
+    return CoreClassroomServices(
+        inspect_workspace_root=workspace_services.inspect_workspace_root,
+        load_school_year_state=cast(
+            SchoolYearLoader,
+            _required_callable(
+                school_years,
+                "pds_core.school_years",
+                "load_school_year_state",
+            ),
+        ),
+        list_class_folders=cast(
+            ClassFolderLister,
+            _required_callable(classes, "pds_core.classes", "list_class_folders"),
+        ),
+        load_class_metadata_for_class=cast(
+            ClassMetadataLoader,
+            _required_callable(
+                class_metadata,
+                "pds_core.class_metadata",
+                "load_class_metadata_for_class",
+            ),
+        ),
+        load_class_roster=cast(
+            ClassRosterLoader,
+            _required_callable(classes, "pds_core.classes", "load_class_roster"),
+        ),
+        load_workspace_standards_library=cast(
+            WorkspaceStandardsLoader,
+            _required_callable(
+                standards,
+                "pds_core.standards",
+                "load_workspace_standards_library",
+            ),
+        ),
+        list_starter_standards_packs=cast(
+            StarterStandardsPackLister,
+            _required_callable(
+                starter_standards,
+                "pds_core.starter_standards",
+                "list_starter_standards_packs",
+            ),
+        ),
+        load_current_academic_period_calendar=cast(
+            CurrentAcademicPeriodCalendarLoader,
+            _required_callable(
+                academic_period_storage,
+                "pds_core.academic_period_storage",
+                "load_current_academic_period_calendar",
+            ),
+        ),
+        get_current_academic_period_calendar_revision=cast(
+            CurrentAcademicPeriodRevisionGetter,
+            _required_callable(
+                academic_period_storage,
+                "pds_core.academic_period_storage",
+                "get_current_academic_period_calendar_revision",
+            ),
+        ),
+    )
+
+
+def _workspace_for_assessment(services: CoreClassroomServices) -> WorkspaceStatusLike:
+    try:
+        status = services.inspect_workspace_root()
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise ClassroomWorkspaceError(
+            f"Core could not inspect the currently resolved workspace: {message}"
+        ) from error
+
+    try:
+        root = Path(status.root)
+        source = status.source
+        exists = status.exists
+        is_dir = status.is_dir
+        is_writable = status.is_writable
+    except (AttributeError, TypeError, ValueError) as error:
+        raise ClassroomWorkspaceError(
+            "Core returned an invalid workspace status result."
+        ) from error
+
+    if not isinstance(source, str) or not source.strip():
+        raise ClassroomWorkspaceError(
+            "Core returned an invalid workspace resolution source."
+        )
+    if not all(isinstance(value, bool) for value in (exists, is_dir, is_writable)):
+        raise ClassroomWorkspaceError("Core returned invalid workspace access flags.")
+    if not exists:
+        raise ClassroomWorkspaceError(
+            f"The currently resolved workspace does not exist: {root}. "
+            "Run 'pds workspace setup' first."
+        )
+    if not is_dir:
+        raise ClassroomWorkspaceError(
+            f"The currently resolved workspace is not a directory: {root}. "
+            "Run 'pds workspace setup' to select a usable workspace."
+        )
+    if not is_writable:
+        raise ClassroomWorkspaceError(
+            f"The currently resolved workspace is not writable: {root}. "
+            "Fix workspace access or run 'pds workspace setup'."
+        )
+    return status
+
+
+def _bounded_core_failure(area: str, error: Exception) -> ClassroomSetupAssessmentError:
+    message = str(error)[:500] or error.__class__.__name__
+    return ClassroomSetupAssessmentError(
+        f"Existing Core {area} state could not be validated: {message}"
+    )
+
+
+def _assess_classes(
+    workspace_root: Path,
+    services: CoreClassroomServices,
+) -> tuple[ClassSetupAssessment, ...]:
+    try:
+        folders = services.list_class_folders(workspace_root)
+    except Exception as error:
+        raise _bounded_core_failure("class-folder", error) from error
+
+    assessed: list[ClassSetupAssessment] = []
+    for folder in folders:
+        try:
+            class_id = folder.class_id
+            metadata_path = Path(folder.metadata_path)
+            roster_path = Path(folder.roster_path)
+        except (AttributeError, TypeError, ValueError) as error:
+            raise ClassroomSetupAssessmentError(
+                "Core returned an invalid class-folder result."
+            ) from error
+
+        metadata_value: ClassMetadataLike | None = None
+        if metadata_path.is_file():
+            try:
+                metadata_value = services.load_class_metadata_for_class(
+                    workspace_root,
+                    class_id,
+                )
+            except Exception as error:
+                raise _bounded_core_failure(
+                    f"class metadata for {class_id!r}",
+                    error,
+                ) from error
+
+        roster_value: RosterLike | None = None
+        if roster_path.is_file():
+            try:
+                roster_value = services.load_class_roster(workspace_root, class_id)
+            except Exception as error:
+                raise _bounded_core_failure(
+                    f"roster for class {class_id!r}",
+                    error,
+                ) from error
+
+        assessed.append(
+            ClassSetupAssessment(
+                class_id=class_id,
+                metadata=metadata_value,
+                roster=roster_value,
+            )
+        )
+    return tuple(assessed)
+
+
+def assess_shared_setup(
+    *,
+    services: CoreClassroomServices | None = None,
+) -> SharedSetupAssessment:
+    """Read current shared Core state without performing setup mutation.
+
+    The workspace is inspected but not initialized or re-selected.  Existing
+    canonical records are loaded only through public Core readers.  Any
+    malformed or internally inconsistent state aborts assessment instead of
+    allowing a guided setup plan to be constructed on top of it.
+    """
+    active_services = services or load_core_classroom_services()
+    workspace_status = _workspace_for_assessment(active_services)
+    workspace_root = Path(workspace_status.root)
+
+    try:
+        school_year_state = active_services.load_school_year_state(workspace_root)
+    except Exception as error:
+        raise _bounded_core_failure("school-year", error) from error
+
+    classes = _assess_classes(workspace_root, active_services)
+
+    try:
+        standards_library = active_services.load_workspace_standards_library(
+            workspace_root
+        )
+    except Exception as error:
+        raise _bounded_core_failure("standards-library", error) from error
+
+    try:
+        starter_packs = active_services.list_starter_standards_packs()
+    except Exception as error:
+        raise _bounded_core_failure("starter-standards", error) from error
+
+    active_school_year: str | None = None
+    if school_year_state is not None and school_year_state.closed_at is None:
+        active_school_year = school_year_state.active_school_year
+
+    academic_period_calendar: AcademicPeriodCalendarLike | None = None
+    academic_period_revision: int | None = None
+    if active_school_year is not None:
+        try:
+            academic_period_calendar = (
+                active_services.load_current_academic_period_calendar(
+                    workspace_root,
+                    active_school_year,
+                )
+            )
+            academic_period_revision = (
+                active_services.get_current_academic_period_calendar_revision(
+                    workspace_root,
+                    active_school_year,
+                )
+            )
+        except Exception as error:
+            raise _bounded_core_failure("Academic Period calendar", error) from error
+
+        if academic_period_calendar is None and academic_period_revision is not None:
+            raise ClassroomSetupAssessmentError(
+                "Existing Core Academic Period state is inconsistent: a current "
+                "revision exists but no current calendar could be loaded."
+            )
+        if academic_period_calendar is not None:
+            if academic_period_revision is None:
+                raise ClassroomSetupAssessmentError(
+                    "Existing Core Academic Period state is inconsistent: a current "
+                    "calendar exists but its revision could not be resolved."
+                )
+            if academic_period_calendar.school_year != active_school_year:
+                raise ClassroomSetupAssessmentError(
+                    "Existing Core Academic Period state is inconsistent: the current "
+                    "calendar school year does not match the active school year."
+                )
+            if academic_period_calendar.calendar_revision != academic_period_revision:
+                raise ClassroomSetupAssessmentError(
+                    "Existing Core Academic Period state is inconsistent: the current "
+                    "calendar and revision pointer disagree."
+                )
+
+    return SharedSetupAssessment(
+        workspace_root=workspace_root,
+        workspace_source=workspace_status.source,
+        school_year_state=school_year_state,
+        classes=classes,
+        standards_library=standards_library,
+        starter_standards_packs=tuple(starter_packs),
+        academic_period_calendar=academic_period_calendar,
+        academic_period_revision=academic_period_revision,
+    )
+
+
+__all__ = (
+    "ClassSetupAssessment",
+    "ClassroomSetupAssessmentError",
+    "ClassroomSetupError",
+    "ClassroomWorkspaceError",
+    "CoreClassroomServiceError",
+    "CoreClassroomServices",
+    "SharedSetupAssessment",
+    "assess_shared_setup",
+    "load_core_classroom_services",
+)

--- a/paper_data_suite/classroom_setup_cli.py
+++ b/paper_data_suite/classroom_setup_cli.py
@@ -1,0 +1,723 @@
+"""Interactive orchestration for guided shared classroom setup.
+
+Collection and review compose only read-only assessment and in-memory planning
+services.  The Core APPLY service bundle is loaded only after exact ``APPLY``;
+cancellation and edit paths never acquire setup writers.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+
+from paper_data_suite.classroom_apply import (
+    ClassroomSetupPartialSuccessError,
+    CoreClassroomApplyServices,
+    SetupApplyResult,
+    execute_shared_setup_plan,
+    load_core_classroom_apply_services,
+)
+from paper_data_suite.classroom_planning import (
+    AcademicPeriodAction,
+    AcademicPeriodPlan,
+    ClassDisposition,
+    ClassPlan,
+    ClassroomSetupPlanningError,
+    CoreClassroomPlanningServices,
+    RosterPlan,
+    RosterSourcePlanningError,
+    SchoolYearDisposition,
+    SchoolYearPlan,
+    SharedSetupPlan,
+    StandardsPlan,
+    assemble_shared_setup_plan,
+    load_core_classroom_planning_services,
+    plan_academic_periods,
+    plan_class,
+    plan_roster_import,
+    plan_school_year,
+    plan_starter_standards,
+)
+from paper_data_suite.classroom_setup import (
+    ClassroomSetupError,
+    SharedSetupAssessment,
+    assess_shared_setup,
+)
+from paper_data_suite.workspace_cli import workspace_source_label
+from paper_data_suite.workspace_setup import (
+    CoreWorkspaceQualificationError,
+    CoreWorkspaceServiceError,
+)
+
+InputReader = Callable[[str], str]
+Clock = Callable[[], datetime]
+
+
+class SetupReviewDecision(str, Enum):
+    """Final pre-APPLY decision returned by the review screen."""
+
+    APPLY = "APPLY"
+    EDIT = "E"
+    CANCEL = "Q"
+
+
+@dataclass(frozen=True, slots=True)
+class SetupCollectionResult:
+    """One interactive collection result before final review."""
+
+    plan: SharedSetupPlan | None
+    cancelled: bool
+
+
+def _read(prompt: str, input_fn: InputReader) -> str | None:
+    try:
+        return input_fn(prompt).strip()
+    except (EOFError, KeyboardInterrupt):
+        return None
+
+
+def _join(values: Sequence[str]) -> str:
+    items = tuple(values)
+    return ", ".join(str(item) for item in items) if items else "none"
+
+
+def render_initial_setup_assessment(assessment: SharedSetupAssessment) -> str:
+    """Render bounded Core-derived state before collecting proposed changes."""
+    lines = [
+        "Paper Data Suite shared classroom setup",
+        "",
+        "Workspace:",
+        f"  {assessment.workspace_root}",
+        "Source:",
+        f"  {workspace_source_label(assessment.workspace_source)}",
+        "",
+        "Current shared state",
+        f"  Active school year: {assessment.active_school_year or 'none'}",
+        f"  Classes discovered: {len(assessment.classes)}",
+    ]
+    for item in assessment.classes:
+        metadata = "metadata" if item.has_metadata else "no metadata"
+        if item.student_count is None:
+            roster = "no roster"
+        else:
+            roster = f"roster with {item.student_count} students"
+        lines.append(f"    {item.class_id}: {metadata}; {roster}")
+    lines.extend(
+        (
+            f"  Standards: {assessment.standards_count} definitions; "
+            f"{assessment.standards_profile_count} profiles",
+            "  Academic Period calendar: "
+            + (
+                "none for the active school year"
+                if assessment.academic_period_calendar is None
+                else (
+                    f"revision {assessment.academic_period_revision}; "
+                    f"{len(assessment.academic_period_calendar.periods)} periods"
+                )
+            ),
+            "",
+            "No setup changes have been made.",
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+def render_starter_standards_packs(assessment: SharedSetupAssessment) -> str:
+    """Render only Core-advertised starter-pack metadata."""
+    lines = ["Available Core starter standards packs"]
+    if not assessment.starter_standards_packs:
+        lines.append("  none")
+        return "\n".join(lines) + "\n"
+    for pack in assessment.starter_standards_packs:
+        lines.extend(
+            (
+                f"  {pack.pack_id} — {pack.title}",
+                f"    Source: {pack.source}",
+                f"    Grade bands: {_join(pack.grade_bands)}",
+                f"    Courses: {_join(pack.courses)}",
+                f"    Standards: {pack.standard_count}",
+                f"    Profiles: {pack.profile_count}",
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _school_year_action(disposition: SchoolYearDisposition) -> str:
+    return {
+        SchoolYearDisposition.NEW: "OPEN",
+        SchoolYearDisposition.EXISTING_MATCH: "KEEP",
+        SchoolYearDisposition.CONFLICT: "REFUSE",
+    }[disposition]
+
+
+def _class_action(disposition: ClassDisposition) -> str:
+    return {
+        ClassDisposition.NEW: "CREATE",
+        ClassDisposition.EXISTING_MATCH: "KEEP",
+        ClassDisposition.CONFLICT: "REFUSE",
+    }[disposition]
+
+
+def render_setup_plan(
+    assessment: SharedSetupAssessment,
+    plan: SharedSetupPlan,
+) -> str:
+    """Render one bounded final plan without dumping roster rows."""
+    lines = [
+        "Shared setup review",
+        "",
+        f"Workspace: {assessment.workspace_root}",
+        f"Source: {workspace_source_label(assessment.workspace_source)}",
+        "",
+        "School year",
+        f"  {plan.school_year.requested_school_year}: "
+        f"{_school_year_action(plan.school_year.disposition)}",
+        f"  {plan.school_year.reason}",
+        "",
+        "Classes",
+    ]
+    if not plan.classes:
+        lines.append("  No class changes selected.")
+    for item in plan.classes:
+        lines.append(f"  {item.class_id}: {_class_action(item.disposition)}")
+        lines.append(f"    {item.reason}")
+
+    lines.extend(("", "Rosters"))
+    roster_by_class = {item.class_id: item for item in plan.rosters}
+    if not plan.classes:
+        lines.append("  No roster changes selected.")
+    for class_plan in plan.classes:
+        roster = roster_by_class.get(class_plan.class_id)
+        if roster is None:
+            existing = class_plan.existing
+            if existing is not None and existing.has_roster:
+                lines.append(f"  {class_plan.class_id}: KEEP existing roster")
+            else:
+                lines.append(f"  {class_plan.class_id}: SKIP roster setup")
+            continue
+        lines.extend(
+            (
+                f"  {roster.class_id}: {roster.action.value}",
+                f"    Incoming students: {roster.incoming_student_count}",
+                "    Existing students: "
+                + (
+                    "none"
+                    if roster.existing_student_count is None
+                    else str(roster.existing_student_count)
+                ),
+                f"    New: {roster.new_count}",
+                f"    Unchanged: {roster.unchanged_count}",
+                f"    Conflicting existing: {roster.conflicting_existing_count}",
+                f"    Existing absent from import: {roster.removed_existing_count}",
+                f"    {roster.reason}",
+            )
+        )
+
+    lines.extend(("", "Standards"))
+    if plan.standards is None:
+        lines.append("  KEEP existing library; no starter pack selected.")
+    else:
+        standards = plan.standards
+        lines.extend(
+            (
+                f"  Pack {standards.pack_id}: {standards.action.value}",
+                f"    Standards to add: {standards.standards_to_add}",
+                f"    Standards identical: {standards.standards_identical}",
+                f"    Standards conflicts: {len(standards.standard_conflicts)}",
+                f"    Profiles to add: {standards.profiles_to_add}",
+                f"    Profiles identical: {standards.profiles_identical}",
+                f"    Profiles conflicts: {len(standards.profile_conflicts)}",
+                f"    {standards.reason}",
+            )
+        )
+
+    lines.extend(("", "Academic Periods"))
+    if plan.academic_periods is None:
+        lines.append("  SKIP")
+    else:
+        periods = plan.academic_periods
+        lines.extend(
+            (
+                f"  {periods.action.value}",
+                f"    Period count: {periods.period_count}",
+                f"    {periods.reason}",
+            )
+        )
+        if (
+            periods.action is AcademicPeriodAction.CREATE
+            and periods.candidate_calendar is not None
+        ):
+            lines.append("    Reviewed period definitions:")
+            for period in periods.candidate_calendar.periods:
+                parent = getattr(period, "parent_period_id", None) or "none"
+                lines.append(
+                    "      "
+                    f"{getattr(period, 'period_id')} | "
+                    f"{getattr(period, 'period_type')} | "
+                    f"{getattr(period, 'label')} | "
+                    f"{getattr(period, 'start_date')}.."
+                    f"{getattr(period, 'end_date')} | "
+                    f"parent={parent} | "
+                    f"sequence={getattr(period, 'sequence')} | "
+                    f"lifecycle={getattr(period, 'lifecycle')}"
+                )
+
+    if plan.blocking_reasons:
+        lines.extend(("", "APPLY blocked"))
+        for reason in plan.blocking_reasons:
+            lines.append(f"  - {reason}")
+    else:
+        lines.extend(("", "Plan is eligible for final APPLY."))
+    lines.extend(("", "No setup changes have been made."))
+    return "\n".join(lines) + "\n"
+
+
+def _planning_time(clock: Clock) -> datetime:
+    value = clock()
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ClassroomSetupPlanningError("setup planning clock must be timezone-aware")
+    return value
+
+
+def _collect_school_year(
+    assessment: SharedSetupAssessment,
+    services: CoreClassroomPlanningServices,
+    input_fn: InputReader,
+) -> SchoolYearPlan | None:
+    active = assessment.active_school_year
+    if active is not None:
+        print(f"Using active Core school year: {active}")
+        return plan_school_year(assessment, active, services=services)
+
+    while True:
+        raw = _read("School year (YYYY-YYYY, Q to cancel): ", input_fn)
+        if raw is None or raw.upper() == "Q":
+            return None
+        if not raw:
+            print("Enter an explicit school year or Q to cancel.")
+            continue
+        try:
+            return plan_school_year(assessment, raw, services=services)
+        except ClassroomSetupPlanningError as error:
+            print(f"School year rejected: {error}")
+
+
+def _collect_roster(
+    assessment: SharedSetupAssessment,
+    class_id: str,
+    services: CoreClassroomPlanningServices,
+    input_fn: InputReader,
+) -> tuple[bool, RosterPlan | None]:
+    while True:
+        raw = _read(
+            f"Roster CSV for {class_id} (Enter to keep/skip, Q to cancel): ",
+            input_fn,
+        )
+        if raw is None or raw.upper() == "Q":
+            return False, None
+        if not raw:
+            return True, None
+        try:
+            return True, plan_roster_import(
+                assessment,
+                class_id,
+                Path(raw),
+                services=services,
+            )
+        except RosterSourcePlanningError as error:
+            print(f"Roster rejected: {error}")
+            for diagnostic in error.diagnostics:
+                print(f"  {diagnostic}")
+        except ClassroomSetupPlanningError as error:
+            print(f"Roster rejected: {error}")
+
+
+def _collect_classes(
+    assessment: SharedSetupAssessment,
+    school_year: str,
+    services: CoreClassroomPlanningServices,
+    input_fn: InputReader,
+    planning_time: datetime,
+) -> tuple[tuple[ClassPlan, ...], tuple[RosterPlan, ...]] | None:
+    classes: list[ClassPlan] = []
+    rosters: list[RosterPlan] = []
+    seen: set[str] = set()
+    print()
+    print("Classes")
+    print("Enter explicit Core class IDs one at a time. Press Enter when finished.")
+    while True:
+        raw = _read("Class ID (Enter when done, Q to cancel): ", input_fn)
+        if raw is None or raw.upper() == "Q":
+            return None
+        if not raw:
+            return tuple(classes), tuple(rosters)
+        if raw in seen:
+            print(f"Class {raw!r} is already in this proposed setup.")
+            continue
+        try:
+            class_plan = plan_class(
+                assessment,
+                raw,
+                school_year,
+                planning_time=planning_time,
+                services=services,
+            )
+        except ClassroomSetupPlanningError as error:
+            print(f"Class rejected: {error}")
+            continue
+        seen.add(class_plan.class_id)
+        classes.append(class_plan)
+        print(f"  {class_plan.class_id}: {class_plan.disposition.value}")
+        print(f"  {class_plan.reason}")
+        if class_plan.blocks_apply:
+            continue
+        keep_going, roster_plan = _collect_roster(
+            assessment,
+            class_plan.class_id,
+            services,
+            input_fn,
+        )
+        if not keep_going:
+            return None
+        if roster_plan is not None:
+            rosters.append(roster_plan)
+            print(f"  Roster action: {roster_plan.action.value}")
+
+
+def _collect_standards(
+    assessment: SharedSetupAssessment,
+    services: CoreClassroomPlanningServices,
+    input_fn: InputReader,
+) -> tuple[bool, StandardsPlan | None]:
+    print()
+    print(render_starter_standards_packs(assessment), end="")
+    if not assessment.starter_standards_packs:
+        return True, None
+    while True:
+        raw = _read(
+            "Starter pack ID (Enter to keep current library, Q to cancel): ",
+            input_fn,
+        )
+        if raw is None or raw.upper() == "Q":
+            return False, None
+        if not raw:
+            return True, None
+        try:
+            plan = plan_starter_standards(assessment, raw, services=services)
+        except ClassroomSetupPlanningError as error:
+            print(f"Standards selection rejected: {error}")
+            continue
+        print(f"Starter pack action: {plan.action.value}")
+        return True, plan
+
+
+def _period_value(
+    services: CoreClassroomPlanningServices,
+    input_fn: InputReader,
+) -> tuple[bool, Mapping[str, object] | None]:
+    print()
+    print("Allowed period types: " + ", ".join(sorted(services.academic_period_types)))
+    print(
+        "Allowed lifecycle values: "
+        + ", ".join(sorted(services.academic_period_lifecycles))
+    )
+    fields = (
+        ("period_id", "Period ID: "),
+        ("period_type", "Period type: "),
+        ("label", "Label: "),
+        ("start_date", "Start date (YYYY-MM-DD): "),
+        ("end_date", "End date (YYYY-MM-DD): "),
+        ("parent_period_id", "Parent period ID (Enter for none): "),
+        ("sequence", "Sequence (positive integer): "),
+        ("lifecycle", "Lifecycle: "),
+    )
+    values: dict[str, object] = {}
+    for name, prompt in fields:
+        while True:
+            raw = _read(prompt, input_fn)
+            if raw is None or raw.upper() == "Q":
+                return False, None
+            if name == "parent_period_id":
+                values[name] = raw or None
+                break
+            if not raw:
+                print(f"{name} is required.")
+                continue
+            if name == "sequence":
+                try:
+                    values[name] = int(raw)
+                except ValueError:
+                    print("sequence must be an integer.")
+                    continue
+                break
+            values[name] = raw
+            break
+    try:
+        services.validate_academic_period(values)
+    except Exception as error:
+        message = str(error)[:500] or error.__class__.__name__
+        print(f"Academic Period rejected by Core: {message}")
+        return True, None
+    return True, values
+
+
+def _collect_academic_periods(
+    assessment: SharedSetupAssessment,
+    school_year: str,
+    services: CoreClassroomPlanningServices,
+    input_fn: InputReader,
+    planning_time: datetime,
+) -> tuple[bool, AcademicPeriodPlan | None]:
+    baseline = plan_academic_periods(
+        assessment,
+        school_year,
+        None,
+        planning_time=planning_time,
+        services=services,
+    )
+    if baseline.action is AcademicPeriodAction.KEEP:
+        print()
+        print(baseline.reason)
+        return True, baseline
+
+    while True:
+        print()
+        print("Academic Period setup")
+        print("1. Configure an explicit initial calendar")
+        print("2. Skip Academic Period setup")
+        print("Q. Cancel")
+        choice = _read("Choose an option: ", input_fn)
+        if choice is None or choice.upper() == "Q":
+            return False, None
+        if choice == "2":
+            return True, baseline
+        if choice != "1":
+            print("Choose 1, 2, or Q.")
+            continue
+
+        period_values: list[Mapping[str, object]] = []
+        while True:
+            keep_going, value = _period_value(services, input_fn)
+            if not keep_going:
+                return False, None
+            if value is None:
+                print("Re-enter this period with Core-valid values.")
+                continue
+            period_values.append(value)
+            more = _read("Add another period? [y/N, Q to cancel]: ", input_fn)
+            if more is None or more.upper() == "Q":
+                return False, None
+            if more.lower() != "y":
+                break
+        try:
+            plan = plan_academic_periods(
+                assessment,
+                school_year,
+                period_values,
+                planning_time=planning_time,
+                services=services,
+            )
+        except ClassroomSetupPlanningError as error:
+            print(f"Academic Period calendar rejected: {error}")
+            print("Re-enter the complete calendar or choose Skip.")
+            continue
+        return True, plan
+
+
+def collect_setup_plan(
+    assessment: SharedSetupAssessment,
+    *,
+    services: CoreClassroomPlanningServices,
+    input_fn: InputReader = input,
+    clock: Clock = lambda: datetime.now(timezone.utc),
+) -> SetupCollectionResult:
+    """Collect one complete proposed setup entirely in memory."""
+    planning_time = _planning_time(clock)
+    school_year = _collect_school_year(assessment, services, input_fn)
+    if school_year is None:
+        return SetupCollectionResult(plan=None, cancelled=True)
+
+    class_result = _collect_classes(
+        assessment,
+        school_year.requested_school_year,
+        services,
+        input_fn,
+        planning_time,
+    )
+    if class_result is None:
+        return SetupCollectionResult(plan=None, cancelled=True)
+    classes, rosters = class_result
+
+    continue_setup, standards = _collect_standards(assessment, services, input_fn)
+    if not continue_setup:
+        return SetupCollectionResult(plan=None, cancelled=True)
+
+    continue_setup, academic_periods = _collect_academic_periods(
+        assessment,
+        school_year.requested_school_year,
+        services,
+        input_fn,
+        planning_time,
+    )
+    if not continue_setup:
+        return SetupCollectionResult(plan=None, cancelled=True)
+
+    plan = assemble_shared_setup_plan(
+        school_year,
+        classes=classes,
+        rosters=rosters,
+        standards=standards,
+        academic_periods=academic_periods,
+    )
+    return SetupCollectionResult(plan=plan, cancelled=False)
+
+
+def review_setup_plan(
+    assessment: SharedSetupAssessment,
+    plan: SharedSetupPlan,
+    *,
+    input_fn: InputReader = input,
+) -> SetupReviewDecision:
+    """Render the final plan and require exact APPLY for write authorization."""
+    print()
+    print(render_setup_plan(assessment, plan), end="")
+    while True:
+        print()
+        print("APPLY   apply the reviewed plan")
+        print("E       edit the plan")
+        print("Q       cancel")
+        choice = _read("Choose APPLY, E, or Q: ", input_fn)
+        if choice is None or choice.upper() == "Q":
+            return SetupReviewDecision.CANCEL
+        if choice.upper() == "E":
+            return SetupReviewDecision.EDIT
+        if choice == "APPLY":
+            if plan.can_apply:
+                return SetupReviewDecision.APPLY
+            print("APPLY is blocked until every conflict is resolved.")
+            continue
+        print("Type exact APPLY, E, or Q.")
+
+
+def _cancel_shared_setup() -> int:
+    print("Shared classroom setup cancelled. No setup changes were made.")
+    return 0
+
+
+def _print_setup_failure(error: Exception) -> None:
+    message = str(error)[:800] or error.__class__.__name__
+    print(f"Shared classroom setup failed: {message}", file=sys.stderr)
+
+
+def _render_apply_success(result: SetupApplyResult) -> None:
+    print()
+    print("Shared classroom setup complete")
+    if result.changed_actions:
+        print("Core changes applied and verified:")
+        for action in result.changed_actions:
+            print(f"  {action}")
+    else:
+        print("No persistent changes were needed; reviewed state was already current.")
+    print("Safe reruns are supported; Core remains authoritative for shared state.")
+
+
+def _render_partial_success(error: ClassroomSetupPartialSuccessError) -> None:
+    print("Shared classroom setup stopped after partial success.", file=sys.stderr)
+    if error.changed_actions:
+        print("Core writes that succeeded before the failure:", file=sys.stderr)
+        for action in error.changed_actions:
+            print(f"  {action}", file=sys.stderr)
+    print(f"Detail: {error}", file=sys.stderr)
+    print(
+        "No cross-domain rollback was attempted. Rerun 'pds setup' to reassess "
+        "the current Core state and continue safely.",
+        file=sys.stderr,
+    )
+
+
+def run_classroom_setup(
+    input_fn: InputReader = input,
+    *,
+    clock: Clock = lambda: datetime.now(timezone.utc),
+    planning_services: CoreClassroomPlanningServices | None = None,
+    apply_services_loader: Callable[[], CoreClassroomApplyServices] = (
+        load_core_classroom_apply_services
+    ),
+) -> int:
+    """Run the complete guided shared-classroom setup workflow."""
+    try:
+        active_planning = (
+            planning_services or load_core_classroom_planning_services()
+        )
+        assessment = assess_shared_setup(services=active_planning.readers)
+    except (
+        ClassroomSetupError,
+        CoreWorkspaceQualificationError,
+        CoreWorkspaceServiceError,
+    ) as error:
+        _print_setup_failure(error)
+        return 1
+
+    print(render_initial_setup_assessment(assessment), end="")
+    while True:
+        try:
+            collection = collect_setup_plan(
+                assessment,
+                services=active_planning,
+                input_fn=input_fn,
+                clock=clock,
+            )
+        except ClassroomSetupError as error:
+            _print_setup_failure(error)
+            return 1
+        if collection.cancelled or collection.plan is None:
+            return _cancel_shared_setup()
+
+        decision = review_setup_plan(
+            assessment,
+            collection.plan,
+            input_fn=input_fn,
+        )
+        if decision is SetupReviewDecision.CANCEL:
+            return _cancel_shared_setup()
+        if decision is SetupReviewDecision.EDIT:
+            print("Editing the in-memory plan. No setup changes have been made.")
+            continue
+
+        try:
+            apply_services = apply_services_loader()
+            result = execute_shared_setup_plan(
+                assessment,
+                collection.plan,
+                services=apply_services,
+                clock=clock,
+            )
+        except ClassroomSetupPartialSuccessError as error:
+            _render_partial_success(error)
+            return 1
+        except (
+            ClassroomSetupError,
+            CoreWorkspaceQualificationError,
+            CoreWorkspaceServiceError,
+        ) as error:
+            _print_setup_failure(error)
+            return 1
+
+        _render_apply_success(result)
+        return 0
+
+
+__all__ = (
+    "SetupCollectionResult",
+    "SetupReviewDecision",
+    "collect_setup_plan",
+    "render_initial_setup_assessment",
+    "render_setup_plan",
+    "render_starter_standards_packs",
+    "review_setup_plan",
+    "run_classroom_setup",
+)

--- a/paper_data_suite/cli.py
+++ b/paper_data_suite/cli.py
@@ -20,6 +20,7 @@ from paper_data_suite.applications import (
     ApplicationLaunchStatus,
     collect_application_inventory,
 )
+from paper_data_suite.classroom_setup_cli import run_classroom_setup
 from paper_data_suite.compatibility import (
     CompatibilityManifestError,
     ComponentCompatibility,
@@ -111,6 +112,16 @@ def build_parser() -> argparse.ArgumentParser:
     workspace_subparsers.add_parser(
         "reset",
         help="clear only Core's saved workspace preference",
+    )
+    subparsers.add_parser(
+        "setup",
+        help="run guided shared school-year and classroom setup",
+        description=(
+            "Guided shared setup over the currently resolved Core workspace. "
+            "Review school year, classes, rosters, standards, and an initial "
+            "Academic Period calendar before any persistent change; only exact "
+            "APPLY authorizes Core writes."
+        ),
     )
     subparsers.add_parser(
         "modules",
@@ -302,6 +313,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise AssertionError(
             f"unhandled workspace command: {arguments.workspace_command}"
         )
+    if arguments.command == "setup":
+        return run_classroom_setup()
     if arguments.command == "modules":
         return _run_modules()
     if arguments.command == "launch":

--- a/scripts/smoke_test_classroom_setup_wheel.py
+++ b/scripts/smoke_test_classroom_setup_wheel.py
@@ -1,0 +1,390 @@
+"""Smoke-test installed guided shared-classroom setup from the built wheel."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import venv
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import cast
+
+
+class ClassroomSetupSmokeTestError(RuntimeError):
+    """Raised when installed shared-classroom setup acceptance fails."""
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    input_text: str | None = None,
+    expected_returncode: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=dict(env),
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != expected_returncode:
+        raise ClassroomSetupSmokeTestError(
+            "Command returned an unexpected status "
+            f"({result.returncode}, expected {expected_returncode}): "
+            f"{' '.join(command)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _venv_python(environment: Path) -> Path:
+    if os.name == "nt":
+        return environment / "Scripts" / "python.exe"
+    return environment / "bin" / "python"
+
+
+def _scripts_directory(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> Path:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            "import sysconfig; print(sysconfig.get_path('scripts'))",
+        ],
+        cwd=cwd,
+        env=env,
+    )
+    return Path(result.stdout.strip())
+
+
+def _isolated_command_env(
+    base_env: Mapping[str, str],
+    *,
+    user_home: Path,
+) -> dict[str, str]:
+    env = dict(base_env)
+    for key in tuple(env):
+        if key.upper() in {"PYTHONPATH", "PDS_WORKSPACE_ROOT"}:
+            env.pop(key, None)
+
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONNOUSERSITE"] = "1"
+    env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    env["PIP_NO_INDEX"] = "1"
+    env["HOME"] = str(user_home)
+    env["USERPROFILE"] = str(user_home)
+    env["APPDATA"] = str(user_home / "AppData" / "Roaming")
+    env["XDG_CONFIG_HOME"] = str(user_home / ".config")
+    return env
+
+
+def _assert_installed_suite_location(
+    python: Path,
+    *,
+    environment: Path,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> None:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            (
+                "from pathlib import Path; import paper_data_suite; "
+                "print(Path(paper_data_suite.__file__).resolve())"
+            ),
+        ],
+        cwd=cwd,
+        env=env,
+    )
+    installed_path = Path(result.stdout.strip()).resolve()
+    try:
+        installed_path.relative_to(environment.resolve())
+    except ValueError as error:
+        raise ClassroomSetupSmokeTestError(
+            "Smoke test imported paper_data_suite outside the isolated environment: "
+            f"{installed_path}"
+        ) from error
+
+
+def _classroom_state(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    school_year: str = "2026-2027",
+) -> dict[str, object]:
+    code = f"""
+import json
+from pds_core.academic_period_storage import load_current_academic_period_calendar
+from pds_core.classes import list_class_folders
+from pds_core.school_years import get_active_school_year
+from pds_core.standards import load_workspace_standards_library
+from pds_core.workspace import inspect_workspace_root
+
+root = inspect_workspace_root().root
+library = load_workspace_standards_library(root)
+calendar = load_current_academic_period_calendar(root, {school_year!r})
+print(json.dumps({{
+    "root": str(root),
+    "active_school_year": get_active_school_year(root),
+    "class_count": len(list_class_folders(root)),
+    "standards_count": len(library.standards),
+    "profile_count": len(library.profiles),
+    "calendar_revision": None if calendar is None else calendar.calendar_revision,
+}}))
+""".strip()
+    result = _run([str(python), "-c", code], cwd=cwd, env=env)
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise ClassroomSetupSmokeTestError(
+            "Core classroom state was not a JSON object."
+        )
+    return cast(dict[str, object], payload)
+
+
+def _assert_state(
+    payload: Mapping[str, object],
+    *,
+    root: Path,
+    active_school_year: str | None,
+) -> None:
+    if payload.get("root") != str(root.resolve()):
+        raise ClassroomSetupSmokeTestError(
+            f"Core resolved unexpected workspace root: {payload.get('root')!r}"
+        )
+    expected = {
+        "active_school_year": active_school_year,
+        "class_count": 0,
+        "standards_count": 0,
+        "profile_count": 0,
+        "calendar_revision": None,
+    }
+    for key, value in expected.items():
+        if payload.get(key) != value:
+            raise ClassroomSetupSmokeTestError(
+                f"Unexpected Core classroom state for {key}: {payload.get(key)!r}"
+            )
+
+
+def _assert_no_setup_plan_artifacts(root: Path) -> None:
+    if not root.is_dir():
+        return
+    unexpected = [
+        path
+        for path in root.rglob("*")
+        if path.is_file()
+        and "setup" in path.name.lower()
+        and "plan" in path.name.lower()
+    ]
+    if unexpected:
+        raise ClassroomSetupSmokeTestError(
+            "Guided setup persisted a suite setup-plan artifact: "
+            + ", ".join(str(path) for path in unexpected)
+        )
+
+
+def _assert_clean_directory(path: Path) -> None:
+    contents = tuple(path.iterdir())
+    if contents:
+        raise ClassroomSetupSmokeTestError(
+            "Classroom smoke command created working-directory artifacts: "
+            + ", ".join(item.name for item in contents)
+        )
+
+
+def smoke_test_classroom_setup_wheel(
+    suite_wheel: Path,
+    core_wheel: Path,
+) -> None:
+    """Exercise installed review-before-write classroom setup beside exact Core."""
+    suite_wheel = suite_wheel.resolve()
+    core_wheel = core_wheel.resolve()
+    if not suite_wheel.is_file():
+        raise ClassroomSetupSmokeTestError(f"Suite wheel does not exist: {suite_wheel}")
+    if not core_wheel.is_file():
+        raise ClassroomSetupSmokeTestError(f"Core wheel does not exist: {core_wheel}")
+
+    with tempfile.TemporaryDirectory(prefix="pds-classroom-smoke-") as temporary:
+        temp_root = Path(temporary)
+        environment = temp_root / "venv"
+        run_directory = temp_root / "run"
+        user_home = temp_root / "user"
+        cancel_workspace = temp_root / "cancel-workspace"
+        apply_workspace = temp_root / "apply-workspace"
+        run_directory.mkdir()
+        user_home.mkdir()
+
+        venv.EnvBuilder(with_pip=True).create(environment)
+        python = _venv_python(environment)
+        command_env = _isolated_command_env(os.environ, user_home=user_home)
+
+        _run(
+            [str(python), "-m", "pip", "install", "--no-deps", str(core_wheel)],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _run(
+            [str(python), "-m", "pip", "install", "--no-deps", str(suite_wheel)],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _run(
+            [str(python), "-m", "pip", "check"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _assert_installed_suite_location(
+            python,
+            environment=environment,
+            cwd=run_directory,
+            env=command_env,
+        )
+
+        scripts = _scripts_directory(
+            python,
+            cwd=run_directory,
+            env=command_env,
+        )
+        launcher = scripts / ("pds.exe" if os.name == "nt" else "pds")
+        if not launcher.is_file():
+            raise ClassroomSetupSmokeTestError(
+                f"Installed pds launcher does not exist: {launcher}"
+            )
+
+        module_help = _run(
+            [str(python), "-m", "paper_data_suite", "setup", "--help"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        console_help = _run(
+            [str(launcher), "setup", "--help"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        for output in (module_help.stdout, console_help.stdout):
+            if "only exact APPLY authorizes Core writes" not in output:
+                raise ClassroomSetupSmokeTestError(
+                    "Installed setup help is missing the APPLY safety boundary."
+                )
+
+        _run(
+            [str(launcher), "workspace", "set", str(cancel_workspace)],
+            cwd=run_directory,
+            env=command_env,
+        )
+        cancel_input = "2026-2027\n\n\n2\napply\nQ\n"
+        cancelled = _run(
+            [str(python), "-m", "paper_data_suite", "setup"],
+            cwd=run_directory,
+            env=command_env,
+            input_text=cancel_input,
+        )
+        if "Type exact APPLY, E, or Q." not in cancelled.stdout:
+            raise ClassroomSetupSmokeTestError(
+                "Installed setup accepted or failed to reject lowercase apply."
+            )
+        if "No setup changes were made." not in cancelled.stdout:
+            raise ClassroomSetupSmokeTestError(
+                "Installed setup cancellation did not report the no-write boundary."
+            )
+        _assert_state(
+            _classroom_state(python, cwd=run_directory, env=command_env),
+            root=cancel_workspace,
+            active_school_year=None,
+        )
+        _assert_no_setup_plan_artifacts(cancel_workspace)
+
+        _run(
+            [str(launcher), "workspace", "set", str(apply_workspace)],
+            cwd=run_directory,
+            env=command_env,
+        )
+        apply_input = "2026-2027\n\n\n2\nAPPLY\n"
+        applied = _run(
+            [str(launcher), "setup"],
+            cwd=run_directory,
+            env=command_env,
+            input_text=apply_input,
+        )
+        required = (
+            "Shared setup review",
+            "2026-2027: OPEN",
+            "Plan is eligible for final APPLY.",
+            "Shared classroom setup complete",
+            "school_year:OPEN:2026-2027",
+        )
+        missing = [fragment for fragment in required if fragment not in applied.stdout]
+        if missing:
+            raise ClassroomSetupSmokeTestError(
+                "Installed setup APPLY output is missing expected content: "
+                + ", ".join(missing)
+            )
+        _assert_state(
+            _classroom_state(python, cwd=run_directory, env=command_env),
+            root=apply_workspace,
+            active_school_year="2026-2027",
+        )
+        _assert_no_setup_plan_artifacts(apply_workspace)
+
+        rerun_input = "\n\n2\nAPPLY\n"
+        rerun = _run(
+            [str(launcher), "setup"],
+            cwd=run_directory,
+            env=command_env,
+            input_text=rerun_input,
+        )
+        if "No persistent changes were needed" not in rerun.stdout:
+            raise ClassroomSetupSmokeTestError(
+                "Installed idempotent rerun did not report a no-op."
+            )
+        _assert_state(
+            _classroom_state(python, cwd=run_directory, env=command_env),
+            root=apply_workspace,
+            active_school_year="2026-2027",
+        )
+        _assert_no_setup_plan_artifacts(apply_workspace)
+        _assert_clean_directory(run_directory)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the installed classroom-setup smoke-test parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Install the built Paper Data Suite wheel beside the exact Core wheel "
+            "and exercise guided shared-classroom setup in an isolated user profile."
+        )
+    )
+    parser.add_argument("suite_wheel", type=Path)
+    parser.add_argument("core_wheel", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run installed shared-classroom setup acceptance from the command line."""
+    arguments = build_parser().parse_args(argv)
+    try:
+        smoke_test_classroom_setup_wheel(
+            arguments.suite_wheel,
+            arguments.core_wheel,
+        )
+    except ClassroomSetupSmokeTestError as error:
+        print(f"Classroom setup smoke test failed: {error}", file=sys.stderr)
+        return 1
+    print("Classroom setup wheel smoke test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_classroom_apply.py
+++ b/tests/test_classroom_apply.py
@@ -1,0 +1,719 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+import paper_data_suite.classroom_apply as classroom_apply
+from paper_data_suite.classroom_apply import (
+    ClassroomSetupPartialSuccessError,
+    ClassroomSetupPreflightError,
+    CoreClassroomApplyServices,
+    execute_shared_setup_plan,
+    load_core_classroom_apply_services,
+)
+from paper_data_suite.classroom_planning import (
+    AcademicPeriodAction,
+    AcademicPeriodPlan,
+    ClassDisposition,
+    ClassPlan,
+    CoreClassroomPlanningServices,
+    RosterAction,
+    RosterPlan,
+    SchoolYearDisposition,
+    SchoolYearPlan,
+    SharedSetupPlan,
+    StandardsAction,
+    StandardsPlan,
+)
+from paper_data_suite.classroom_setup import (
+    ClassSetupAssessment,
+    CoreClassroomServices,
+    SharedSetupAssessment,
+)
+
+
+@dataclass(frozen=True)
+class FakeState:
+    active_school_year: str
+    opened_at: datetime
+    closed_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class FakeMetadata:
+    class_id: str
+    school_year: str
+    module_details: dict[str, object]
+
+
+@dataclass(frozen=True)
+class FakeStudent:
+    class_id: str
+    student_id: str
+    last_name: str
+    first_name: str
+    period: str
+    extra_fields: dict[str, str]
+
+
+@dataclass(frozen=True)
+class FakeRoster:
+    class_id: str
+    students: tuple[FakeStudent, ...]
+    columns: tuple[str, ...]
+    source_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class FakeLibrary:
+    standards: tuple[object, ...] = ()
+    profiles: tuple[object, ...] = ()
+
+
+@dataclass(frozen=True)
+class FakePack:
+    pack_id: str = "starter"
+    title: str = "Synthetic starter"
+    source: str = "Synthetic"
+    grade_bands: tuple[str, ...] = ("9-10",)
+    courses: tuple[str, ...] = ("English",)
+    standard_count: int = 1
+    profile_count: int = 1
+
+
+@dataclass(frozen=True)
+class FakeMergeResult:
+    pack_id: str
+    target_path: Path
+    standards_added: int
+    standards_skipped: int
+    standards_overwritten: int
+    profiles_added: int
+    profiles_skipped: int
+    profiles_overwritten: int
+    standard_conflicts: tuple[str, ...] = ()
+    profile_conflicts: tuple[str, ...] = ()
+
+    @property
+    def has_conflicts(self) -> bool:
+        return bool(self.standard_conflicts or self.profile_conflicts)
+
+    @property
+    def changed_count(self) -> int:
+        return (
+            self.standards_added
+            + self.standards_overwritten
+            + self.profiles_added
+            + self.profiles_overwritten
+        )
+
+
+@dataclass(frozen=True)
+class FakeCalendar:
+    school_year: str
+    calendar_revision: int
+    periods: tuple[object, ...]
+
+
+class FakeApplyCore:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.state: FakeState | None = None
+        self.metadata: dict[str, FakeMetadata] = {}
+        self.rosters: dict[str, FakeRoster] = {}
+        self.roster_sources: dict[Path, FakeRoster] = {}
+        self.standards = FakeLibrary()
+        self.starter = FakeLibrary(("s1",), ("p1",))
+        self.calendar: FakeCalendar | None = None
+        self.events: list[str] = []
+        self.fail_class_write = False
+        self.drift_roster_on_open: str | None = None
+
+    def readers(self) -> CoreClassroomServices:
+        return cast(
+            CoreClassroomServices,
+            SimpleNamespace(
+                load_school_year_state=lambda root: self.state,
+                load_class_metadata_for_class=(
+                    lambda root, class_id: self.metadata[class_id]
+                ),
+                load_class_roster=lambda root, class_id: self.rosters[class_id],
+                load_workspace_standards_library=lambda root: self.standards,
+                load_current_academic_period_calendar=(
+                    lambda root, year: self.calendar
+                    if self.calendar is not None
+                    and self.calendar.school_year == year
+                    else None
+                ),
+                get_current_academic_period_calendar_revision=(
+                    lambda root, year: self.calendar.calendar_revision
+                    if self.calendar is not None
+                    and self.calendar.school_year == year
+                    else None
+                ),
+            ),
+        )
+
+    def planning(self) -> CoreClassroomPlanningServices:
+        return cast(
+            CoreClassroomPlanningServices,
+            SimpleNamespace(
+                readers=self.readers(),
+                create_class_metadata=self.create_metadata,
+                load_roster=lambda path: self.roster_sources[Path(path)],
+                standards_library_path=(
+                    lambda root: Path(root) / "standards" / "library.json"
+                ),
+                load_starter_standards_library=lambda pack_id: self.starter,
+                merge_standards_libraries=self.merge_standards,
+            ),
+        )
+
+    def create_metadata(
+        self,
+        class_id: str,
+        school_year: str,
+        *,
+        created_at: datetime,
+        updated_at: datetime | None = None,
+        module_details: dict[str, object] | None = None,
+    ) -> FakeMetadata:
+        assert created_at.tzinfo is not None
+        return FakeMetadata(class_id, school_year, module_details or {})
+
+    def merge_standards(
+        self,
+        pack_id: str,
+        target_path: str | Path,
+        existing_library: FakeLibrary,
+        starter_library: FakeLibrary,
+        *,
+        overwrite_conflicts: bool = False,
+    ) -> tuple[FakeLibrary, FakeMergeResult]:
+        assert pack_id == "starter"
+        assert overwrite_conflicts is False
+        assert starter_library == self.starter
+        candidate = FakeLibrary(
+            existing_library.standards + ("s1",),
+            existing_library.profiles + ("p1",),
+        )
+        result = FakeMergeResult(
+            pack_id="starter",
+            target_path=Path(target_path),
+            standards_added=1,
+            standards_skipped=0,
+            standards_overwritten=0,
+            profiles_added=1,
+            profiles_skipped=0,
+            profiles_overwritten=0,
+        )
+        return candidate, result
+
+    def open_school_year(
+        self,
+        root: str | Path,
+        school_year: str,
+        *,
+        opened_at: datetime,
+        overwrite: bool = False,
+    ) -> FakeState:
+        assert Path(root) == self.root
+        assert overwrite is False
+        self.events.append("school")
+        self.state = FakeState(school_year, opened_at)
+        if self.drift_roster_on_open is not None:
+            class_id = self.drift_roster_on_open
+            current = self.rosters[class_id]
+            student = current.students[0]
+            self.rosters[class_id] = FakeRoster(
+                class_id,
+                (
+                    FakeStudent(
+                        class_id,
+                        student.student_id,
+                        "Changed",
+                        student.first_name,
+                        student.period,
+                        student.extra_fields,
+                    ),
+                ),
+                current.columns,
+            )
+        return self.state
+
+    def write_metadata(
+        self,
+        root: str | Path,
+        metadata_value: FakeMetadata,
+        *,
+        overwrite: bool = False,
+    ) -> Path:
+        assert overwrite is False
+        self.events.append(f"class:{metadata_value.class_id}")
+        if self.fail_class_write:
+            raise ValueError("synthetic class write failure")
+        self.metadata[metadata_value.class_id] = metadata_value
+        return self.root / "classes" / metadata_value.class_id / "class.json"
+
+    def write_roster(
+        self,
+        root: str | Path,
+        roster: FakeRoster,
+        *,
+        overwrite: bool = False,
+    ) -> Path:
+        self.events.append(
+            f"roster:{'replace' if overwrite else 'create'}:{roster.class_id}"
+        )
+        self.rosters[roster.class_id] = roster
+        return self.root / "classes" / roster.class_id / "roster.csv"
+
+    def install_standards(
+        self,
+        root: str | Path,
+        pack_id: str,
+        existing_library: FakeLibrary,
+        *,
+        overwrite_conflicts: bool = False,
+    ) -> FakeMergeResult:
+        assert overwrite_conflicts is False
+        self.events.append("standards")
+        candidate, result = self.merge_standards(
+            pack_id,
+            self.root / "standards" / "library.json",
+            existing_library,
+            self.starter,
+            overwrite_conflicts=False,
+        )
+        self.standards = candidate
+        return result
+
+    def write_calendar(
+        self,
+        root: str | Path,
+        calendar: FakeCalendar,
+        *,
+        expected_current_revision: int | None,
+    ) -> Path:
+        assert expected_current_revision is None
+        self.events.append("periods")
+        self.calendar = calendar
+        return self.root / "settings" / "academic_periods" / "1.json"
+
+    def services(self) -> CoreClassroomApplyServices:
+        return CoreClassroomApplyServices(
+            planning=self.planning(),
+            open_school_year=self.open_school_year,
+            write_class_metadata_for_class=cast(object, self.write_metadata),
+            write_class_roster=cast(object, self.write_roster),
+            install_starter_standards_library=cast(
+                object,
+                self.install_standards,
+            ),
+            write_academic_period_calendar=cast(object, self.write_calendar),
+        )
+
+
+def assessment(
+    core: FakeApplyCore,
+    *,
+    classes: tuple[ClassSetupAssessment, ...] = (),
+) -> SharedSetupAssessment:
+    return SharedSetupAssessment(
+        workspace_root=core.root,
+        workspace_source="saved_config",
+        school_year_state=core.state,
+        classes=classes,
+        standards_library=core.standards,
+        starter_standards_packs=(FakePack(),),
+        academic_period_calendar=core.calendar,
+        academic_period_revision=(
+            None if core.calendar is None else core.calendar.calendar_revision
+        ),
+    )
+
+
+def school_plan(
+    disposition: SchoolYearDisposition = SchoolYearDisposition.NEW,
+) -> SchoolYearPlan:
+    return SchoolYearPlan("2026-2027", disposition, "school")
+
+
+def test_apply_services_load_writers_from_actual_public_owner_modules(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    planning = cast(CoreClassroomPlanningServices, SimpleNamespace())
+    monkeypatch.setattr(
+        classroom_apply,
+        "load_core_classroom_planning_services",
+        lambda *args, **kwargs: planning,
+    )
+    modules = {
+        "pds_core.school_years": SimpleNamespace(open_school_year=lambda *a, **k: None),
+        "pds_core.classes": SimpleNamespace(write_class_roster=lambda *a, **k: None),
+        "pds_core.class_metadata": SimpleNamespace(
+            write_class_metadata_for_class=lambda *a, **k: None
+        ),
+        "pds_core.starter_standards": SimpleNamespace(
+            install_starter_standards_library=lambda *a, **k: None
+        ),
+        "pds_core.academic_period_storage": SimpleNamespace(
+            write_academic_period_calendar=lambda *a, **k: None
+        ),
+    }
+    events: list[str] = []
+
+    def importer(name: str) -> object:
+        events.append(name)
+        return modules[name]
+
+    services = load_core_classroom_apply_services(module_importer=importer)
+
+    assert services.planning is planning
+    assert events == [
+        "pds_core.school_years",
+        "pds_core.classes",
+        "pds_core.class_metadata",
+        "pds_core.starter_standards",
+        "pds_core.academic_period_storage",
+    ]
+
+
+def test_preflight_state_drift_refuses_every_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core = FakeApplyCore(tmp_path)
+    reviewed = assessment(core)
+    changed = SharedSetupAssessment(
+        workspace_root=tmp_path,
+        workspace_source="saved_config",
+        school_year_state=None,
+        classes=(),
+        standards_library=FakeLibrary(("external",), ()),
+        starter_standards_packs=(FakePack(),),
+        academic_period_calendar=None,
+        academic_period_revision=None,
+    )
+    monkeypatch.setattr(classroom_apply, "assess_shared_setup", lambda **kw: changed)
+
+    with pytest.raises(ClassroomSetupPreflightError, match="changed after review"):
+        execute_shared_setup_plan(
+            reviewed,
+            SharedSetupPlan(school_plan(), (), (), None, None),
+            services=core.services(),
+            clock=lambda: datetime(2026, 8, 20, tzinfo=UTC),
+        )
+
+    assert core.events == []
+    assert core.state is None
+
+
+def test_apply_executes_core_writes_in_required_order_and_verifies(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core = FakeApplyCore(tmp_path)
+    incoming = FakeRoster(
+        "eng10",
+        (FakeStudent("eng10", "s1", "Last", "First", "2", {}),),
+        ("class_id", "student_id", "last_name", "first_name", "period"),
+        tmp_path / "incoming.csv",
+    )
+    core.roster_sources[incoming.source_path] = incoming  # type: ignore[index]
+    reviewed = assessment(core)
+    monkeypatch.setattr(classroom_apply, "assess_shared_setup", lambda **kw: reviewed)
+
+    class_plan = ClassPlan(
+        "eng10",
+        "2026-2027",
+        ClassDisposition.NEW,
+        FakeMetadata("eng10", "2026-2027", {}),
+        None,
+        "new class",
+    )
+    roster_plan = RosterPlan(
+        "eng10",
+        cast(Path, incoming.source_path),
+        incoming,
+        None,
+        RosterAction.CREATE,
+        1,
+        None,
+        1,
+        0,
+        0,
+        0,
+        "create roster",
+    )
+    standards = StandardsPlan(
+        "starter",
+        StandardsAction.INSTALL,
+        FakeLibrary(("s1",), ("p1",)),
+        tmp_path / "standards" / "library.json",
+        1,
+        0,
+        (),
+        1,
+        0,
+        (),
+        "install",
+    )
+    calendar = FakeCalendar("2026-2027", 1, ("q1",))
+    periods = AcademicPeriodPlan(
+        "2026-2027",
+        AcademicPeriodAction.CREATE,
+        calendar,
+        1,
+        "create calendar",
+    )
+    plan = SharedSetupPlan(
+        school_plan(),
+        (class_plan,),
+        (roster_plan,),
+        standards,
+        periods,
+    )
+
+    result = execute_shared_setup_plan(
+        reviewed,
+        plan,
+        services=core.services(),
+        clock=lambda: datetime(2026, 8, 20, 12, tzinfo=UTC),
+    )
+
+    assert core.events == [
+        "school",
+        "class:eng10",
+        "roster:create:eng10",
+        "standards",
+        "periods",
+    ]
+    assert result.changed_actions == (
+        "school_year:OPEN:2026-2027",
+        "class:CREATE:eng10",
+        "roster:CREATE:eng10",
+        "standards:INSTALL:starter",
+        "academic_periods:CREATE:2026-2027:revision-1",
+    )
+
+
+def test_roster_source_change_after_review_fails_before_first_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core = FakeApplyCore(tmp_path)
+    source = tmp_path / "incoming.csv"
+    reviewed_roster = FakeRoster(
+        "eng10",
+        (FakeStudent("eng10", "s1", "Last", "First", "2", {}),),
+        ("class_id", "student_id", "last_name", "first_name", "period"),
+        source,
+    )
+    core.roster_sources[source] = FakeRoster(
+        "eng10",
+        (FakeStudent("eng10", "s1", "Changed", "First", "2", {}),),
+        reviewed_roster.columns,
+        source,
+    )
+    reviewed = assessment(core)
+    monkeypatch.setattr(classroom_apply, "assess_shared_setup", lambda **kw: reviewed)
+    plan = SharedSetupPlan(
+        school_plan(),
+        (
+            ClassPlan(
+                "eng10",
+                "2026-2027",
+                ClassDisposition.NEW,
+                FakeMetadata("eng10", "2026-2027", {}),
+                None,
+                "new",
+            ),
+        ),
+        (
+            RosterPlan(
+                "eng10",
+                source,
+                reviewed_roster,
+                None,
+                RosterAction.CREATE,
+                1,
+                None,
+                1,
+                0,
+                0,
+                0,
+                "create",
+            ),
+        ),
+        None,
+        None,
+    )
+
+    with pytest.raises(ClassroomSetupPreflightError, match="source.*changed"):
+        execute_shared_setup_plan(
+            reviewed,
+            plan,
+            services=core.services(),
+            clock=lambda: datetime(2026, 8, 20, tzinfo=UTC),
+        )
+
+    assert core.events == []
+
+
+def test_late_roster_drift_reports_partial_success_without_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core = FakeApplyCore(tmp_path)
+    existing = FakeRoster(
+        "eng10",
+        (FakeStudent("eng10", "s1", "Old", "First", "2", {}),),
+        ("class_id", "student_id", "last_name", "first_name", "period"),
+    )
+    incoming = FakeRoster(
+        "eng10",
+        (FakeStudent("eng10", "s1", "New", "First", "2", {}),),
+        existing.columns,
+        tmp_path / "incoming.csv",
+    )
+    metadata_value = FakeMetadata("eng10", "2026-2027", {})
+    core.metadata["eng10"] = metadata_value
+    core.rosters["eng10"] = existing
+    core.roster_sources[cast(Path, incoming.source_path)] = incoming
+    current_class = ClassSetupAssessment("eng10", metadata_value, existing)
+    reviewed = assessment(core, classes=(current_class,))
+    monkeypatch.setattr(classroom_apply, "assess_shared_setup", lambda **kw: reviewed)
+    core.drift_roster_on_open = "eng10"
+    plan = SharedSetupPlan(
+        school_plan(),
+        (
+            ClassPlan(
+                "eng10",
+                "2026-2027",
+                ClassDisposition.EXISTING_MATCH,
+                metadata_value,
+                current_class,
+                "match",
+            ),
+        ),
+        (
+            RosterPlan(
+                "eng10",
+                cast(Path, incoming.source_path),
+                incoming,
+                existing,
+                RosterAction.REPLACE,
+                1,
+                1,
+                0,
+                0,
+                1,
+                0,
+                "replace",
+            ),
+        ),
+        None,
+        None,
+    )
+
+    with pytest.raises(ClassroomSetupPartialSuccessError) as raised:
+        execute_shared_setup_plan(
+            reviewed,
+            plan,
+            services=core.services(),
+            clock=lambda: datetime(2026, 8, 20, tzinfo=UTC),
+        )
+
+    assert raised.value.changed_actions == ("school_year:OPEN:2026-2027",)
+    assert not any(event.startswith("roster:replace") for event in core.events)
+    assert "no rollback" in str(raised.value).lower()
+
+
+def test_later_writer_failure_reports_earlier_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core = FakeApplyCore(tmp_path)
+    reviewed = assessment(core)
+    monkeypatch.setattr(classroom_apply, "assess_shared_setup", lambda **kw: reviewed)
+    core.fail_class_write = True
+    plan = SharedSetupPlan(
+        school_plan(),
+        (
+            ClassPlan(
+                "eng10",
+                "2026-2027",
+                ClassDisposition.NEW,
+                FakeMetadata("eng10", "2026-2027", {}),
+                None,
+                "new",
+            ),
+        ),
+        (),
+        None,
+        None,
+    )
+
+    with pytest.raises(ClassroomSetupPartialSuccessError) as raised:
+        execute_shared_setup_plan(
+            reviewed,
+            plan,
+            services=core.services(),
+            clock=lambda: datetime(2026, 8, 20, tzinfo=UTC),
+        )
+
+    assert raised.value.changed_actions == ("school_year:OPEN:2026-2027",)
+    assert core.state is not None
+    assert "eng10" not in core.metadata
+
+
+def test_idempotent_reviewed_keep_plan_performs_no_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core = FakeApplyCore(tmp_path)
+    core.state = FakeState(
+        "2026-2027",
+        datetime(2026, 8, 1, tzinfo=UTC),
+    )
+    reviewed = assessment(core)
+    monkeypatch.setattr(classroom_apply, "assess_shared_setup", lambda **kw: reviewed)
+    plan = SharedSetupPlan(
+        school_plan(SchoolYearDisposition.EXISTING_MATCH),
+        (),
+        (),
+        None,
+        AcademicPeriodPlan(
+            "2026-2027",
+            AcademicPeriodAction.SKIP,
+            None,
+            0,
+            "skip",
+        ),
+    )
+
+    result = execute_shared_setup_plan(
+        reviewed,
+        plan,
+        services=core.services(),
+        clock=lambda: datetime(2026, 8, 20, tzinfo=UTC),
+    )
+
+    assert result.changed_actions == ()
+    assert core.events == []
+
+
+def test_apply_services_match_installed_qualified_core_public_contract() -> None:
+    services = load_core_classroom_apply_services()
+
+    assert callable(services.open_school_year)
+    assert callable(services.write_class_metadata_for_class)
+    assert callable(services.write_class_roster)
+    assert callable(services.install_starter_standards_library)
+    assert callable(services.write_academic_period_calendar)

--- a/tests/test_classroom_import_safety.py
+++ b/tests/test_classroom_import_safety.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+TRACKED_MODULES = (
+    "pds_core",
+    "scoreform",
+    "quillan",
+    "concord",
+    "meridian",
+    "vitrine",
+)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "paper_data_suite.classroom_setup",
+        "paper_data_suite.classroom_planning",
+        "paper_data_suite.classroom_apply",
+        "paper_data_suite.classroom_setup_cli",
+    ],
+)
+def test_classroom_setup_imports_are_side_effect_free(
+    tmp_path: Path,
+    module_name: str,
+) -> None:
+    code = f"""
+import importlib
+import json
+import sys
+
+importlib.import_module({module_name!r})
+tracked = {TRACKED_MODULES!r}
+print(json.dumps({{name: name in sys.modules for name in tracked}}))
+""".strip()
+
+    before = tuple(tmp_path.iterdir())
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=tmp_path,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    assert tuple(tmp_path.iterdir()) == before
+
+    loaded = cast(dict[str, bool], json.loads(result.stdout))
+    assert loaded == {name: False for name in TRACKED_MODULES}

--- a/tests/test_classroom_planning.py
+++ b/tests/test_classroom_planning.py
@@ -1,0 +1,923 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from paper_data_suite.classroom_planning import (
+    AcademicPeriodAction,
+    ClassDisposition,
+    ClassroomSetupPlanningError,
+    CoreClassroomPlanningServices,
+    RosterAction,
+    RosterSourcePlanningError,
+    SchoolYearDisposition,
+    StandardsAction,
+    assemble_shared_setup_plan,
+    load_core_classroom_planning_services,
+    plan_academic_periods,
+    plan_class,
+    plan_roster_import,
+    plan_school_year,
+    plan_starter_standards,
+)
+from paper_data_suite.classroom_setup import (
+    ClassSetupAssessment,
+    CoreClassroomServices,
+    SharedSetupAssessment,
+)
+from paper_data_suite.compatibility import load_release_compatibility_manifest
+
+
+@dataclass(frozen=True)
+class FakeSchoolYearState:
+    active_school_year: str
+    opened_at: datetime
+    closed_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class FakeMetadata:
+    class_id: str
+    school_year: str
+    module_details: dict[str, object]
+
+
+@dataclass(frozen=True)
+class FakeStudent:
+    class_id: str
+    student_id: str
+    last_name: str
+    first_name: str
+    period: str
+    extra_fields: dict[str, str]
+
+
+@dataclass(frozen=True)
+class FakeRoster:
+    class_id: str
+    students: tuple[FakeStudent, ...]
+    columns: tuple[str, ...]
+    source_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class FakeLibrary:
+    standards: tuple[object, ...]
+    profiles: tuple[object, ...]
+
+
+@dataclass(frozen=True)
+class FakeStarterPack:
+    pack_id: str
+    title: str = "Synthetic pack"
+    source: str = "Synthetic"
+    grade_bands: tuple[str, ...] = ("9-10",)
+    courses: tuple[str, ...] = ("English 10",)
+    standard_count: int = 2
+    profile_count: int = 1
+
+
+@dataclass(frozen=True)
+class FakeMergeResult:
+    pack_id: str
+    target_path: Path
+    standards_added: int
+    standards_skipped: int
+    standards_overwritten: int
+    profiles_added: int
+    profiles_skipped: int
+    profiles_overwritten: int
+    standard_conflicts: tuple[str, ...] = ()
+    profile_conflicts: tuple[str, ...] = ()
+
+    @property
+    def has_conflicts(self) -> bool:
+        return bool(self.standard_conflicts or self.profile_conflicts)
+
+    @property
+    def changed_count(self) -> int:
+        return (
+            self.standards_added
+            + self.standards_overwritten
+            + self.profiles_added
+            + self.profiles_overwritten
+        )
+
+
+@dataclass(frozen=True)
+class FakePeriod:
+    period_id: str
+    period_type: str
+    label: str
+    start_date: date
+    end_date: date
+    parent_period_id: str | None
+    sequence: int
+    lifecycle: str
+
+
+@dataclass(frozen=True)
+class FakeCalendar:
+    school_year: str
+    calendar_revision: int
+    periods: tuple[object, ...]
+
+
+class FakeRosterValidationError(ValueError):
+    def __init__(self) -> None:
+        self.issues = (
+            SimpleNamespace(
+                code="missing_required_column",
+                message="Required column 'student_id' is missing.",
+                row_number=1,
+                column="student_id",
+                value="secret-student-id",
+            ),
+        )
+        super().__init__("invalid roster")
+
+
+class FakePlanningCore:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.rosters: dict[Path, FakeRoster] = {}
+        self.starter = FakeLibrary(standards=("s1", "s2"), profiles=("p1",))
+        self.merge_result = FakeMergeResult(
+            pack_id="starter",
+            target_path=root / "standards" / "library.json",
+            standards_added=2,
+            standards_skipped=0,
+            standards_overwritten=0,
+            profiles_added=1,
+            profiles_skipped=0,
+            profiles_overwritten=0,
+        )
+        self.merged = FakeLibrary(standards=("s1", "s2"), profiles=("p1",))
+        self.calendar_validation_error: Exception | None = None
+        self.current_calendars: dict[str, FakeCalendar] = {}
+
+    def validate_identifier(self, value: object, field_name: str = "identifier") -> str:
+        if not isinstance(value, str) or not value or " " in value:
+            raise ValueError(f"{field_name} is invalid")
+        return value
+
+    def validate_school_year(self, value: object) -> str:
+        if not isinstance(value, str) or len(value) != 9 or value[4] != "-":
+            raise ValueError("school_year must use YYYY-YYYY")
+        start = int(value[:4])
+        end = int(value[5:])
+        if end != start + 1:
+            raise ValueError("school_year must be consecutive")
+        return value
+
+    def create_class_metadata(
+        self,
+        class_id: str,
+        school_year: str,
+        *,
+        created_at: datetime,
+        updated_at: datetime | None = None,
+        module_details: dict[str, object] | None = None,
+    ) -> FakeMetadata:
+        if created_at.tzinfo is None:
+            raise ValueError("created_at must be timezone-aware")
+        return FakeMetadata(class_id, school_year, module_details or {})
+
+    def load_roster(self, path: str | Path) -> FakeRoster:
+        source = Path(path)
+        if source.name == "invalid.csv":
+            raise FakeRosterValidationError()
+        return self.rosters[source]
+
+    def standards_library_path(self, workspace_root: str | Path) -> Path:
+        return Path(workspace_root) / "standards" / "library.json"
+
+    def load_starter(self, pack_id: str) -> FakeLibrary:
+        assert pack_id == "starter"
+        return self.starter
+
+    def merge_standards(
+        self,
+        pack_id: str,
+        target_path: str | Path,
+        existing_library: FakeLibrary,
+        starter_library: FakeLibrary,
+        *,
+        overwrite_conflicts: bool = False,
+    ) -> tuple[FakeLibrary, FakeMergeResult]:
+        assert pack_id == "starter"
+        assert Path(target_path) == self.merge_result.target_path
+        assert overwrite_conflicts is False
+        assert starter_library is self.starter
+        assert isinstance(existing_library, FakeLibrary)
+        return self.merged, self.merge_result
+
+    def validate_period(self, value: object) -> FakePeriod:
+        assert isinstance(value, dict)
+        return FakePeriod(
+            period_id=cast(str, value["period_id"]),
+            period_type=cast(str, value["period_type"]),
+            label=cast(str, value["label"]),
+            start_date=date.fromisoformat(cast(str, value["start_date"])),
+            end_date=date.fromisoformat(cast(str, value["end_date"])),
+            parent_period_id=cast(str | None, value["parent_period_id"]),
+            sequence=cast(int, value["sequence"]),
+            lifecycle=cast(str, value["lifecycle"]),
+        )
+
+    def make_calendar(self, **kwargs: object) -> FakeCalendar:
+        created_at = cast(datetime, kwargs["created_at"])
+        if created_at.tzinfo is None:
+            raise ValueError("created_at must be timezone-aware")
+        return FakeCalendar(
+            school_year=cast(str, kwargs["school_year"]),
+            calendar_revision=cast(int, kwargs["calendar_revision"]),
+            periods=tuple(cast(tuple[object, ...], kwargs["periods"])),
+        )
+
+    def validate_calendar(self, value: object) -> FakeCalendar:
+        if self.calendar_validation_error is not None:
+            raise self.calendar_validation_error
+        return cast(FakeCalendar, value)
+
+    def load_current_calendar(
+        self, workspace_root: str | Path, school_year: str
+    ) -> FakeCalendar | None:
+        assert Path(workspace_root) == self.root
+        return self.current_calendars.get(school_year)
+
+    def get_current_revision(
+        self, workspace_root: str | Path, school_year: str
+    ) -> int | None:
+        assert Path(workspace_root) == self.root
+        calendar = self.current_calendars.get(school_year)
+        return None if calendar is None else calendar.calendar_revision
+
+    def services(self) -> CoreClassroomPlanningServices:
+        readers = cast(
+            CoreClassroomServices,
+            SimpleNamespace(
+                load_current_academic_period_calendar=self.load_current_calendar,
+                get_current_academic_period_calendar_revision=(
+                    self.get_current_revision
+                ),
+            ),
+        )
+        return CoreClassroomPlanningServices(
+            readers=readers,
+            validate_identifier=self.validate_identifier,
+            validate_school_year=self.validate_school_year,
+            create_class_metadata=self.create_class_metadata,
+            load_roster=self.load_roster,
+            standards_library_path=self.standards_library_path,
+            load_starter_standards_library=self.load_starter,
+            merge_standards_libraries=self.merge_standards,
+            validate_academic_period=self.validate_period,
+            academic_period_calendar_factory=self.make_calendar,
+            validate_academic_period_calendar=self.validate_calendar,
+            academic_period_calendar_schema_version="1",
+            academic_period_calendar_record_type="academic_period_calendar",
+            academic_period_types=frozenset({"quarter", "semester"}),
+            academic_period_lifecycles=frozenset({"planned", "active", "closed"}),
+        )
+
+
+def assessment(
+    root: Path,
+    *,
+    state: FakeSchoolYearState | None = None,
+    classes: tuple[ClassSetupAssessment, ...] = (),
+    library: FakeLibrary | None = None,
+    packs: tuple[FakeStarterPack, ...] = (FakeStarterPack("starter"),),
+    calendar: FakeCalendar | None = None,
+) -> SharedSetupAssessment:
+    return SharedSetupAssessment(
+        workspace_root=root,
+        workspace_source="saved_config",
+        school_year_state=state,
+        classes=classes,
+        standards_library=library or FakeLibrary(standards=(), profiles=()),
+        starter_standards_packs=packs,
+        academic_period_calendar=calendar,
+        academic_period_revision=(
+            None if calendar is None else calendar.calendar_revision
+        ),
+    )
+
+
+def student(student_id: str, *, first_name: str = "Alex") -> FakeStudent:
+    return FakeStudent(
+        class_id="eng10",
+        student_id=student_id,
+        last_name="Student",
+        first_name=first_name,
+        period="2",
+        extra_fields={"email": f"{student_id}@example.invalid"},
+    )
+
+
+def roster(
+    *students: FakeStudent,
+    source: Path | None = None,
+    class_id: str = "eng10",
+) -> FakeRoster:
+    return FakeRoster(
+        class_id=class_id,
+        students=tuple(students),
+        columns=(
+            "class_id",
+            "student_id",
+            "last_name",
+            "first_name",
+            "period",
+            "email",
+        ),
+        source_path=source,
+    )
+
+
+def class_assessment(
+    root: Path,
+    *,
+    metadata: FakeMetadata | None,
+    existing_roster: FakeRoster | None = None,
+) -> ClassSetupAssessment:
+    return ClassSetupAssessment(
+        class_id="eng10",
+        metadata=metadata,
+        roster=existing_roster,
+    )
+
+
+def period_input(period_id: str = "q1") -> dict[str, object]:
+    return {
+        "period_id": period_id,
+        "period_type": "quarter",
+        "label": "Quarter 1",
+        "start_date": "2026-09-01",
+        "end_date": "2026-11-01",
+        "parent_period_id": None,
+        "sequence": 1,
+        "lifecycle": "planned",
+    }
+
+
+def test_planning_service_loader_keeps_writers_out_of_pre_apply_surface() -> None:
+    manifest = load_release_compatibility_manifest()
+    core = next(
+        component
+        for component in manifest.components
+        if "shared_core" in component.capabilities
+    )
+    modules = {
+        "pds_core.workspace": SimpleNamespace(
+            inspect_workspace_root=lambda explicit_root=None: None,
+            ensure_workspace_root=lambda path, create=True: Path(path),
+            save_workspace_root=lambda path: Path(path),
+            clear_saved_workspace_root=lambda: False,
+        ),
+        "pds_core.school_years": SimpleNamespace(
+            load_school_year_state=lambda root: None,
+            validate_school_year=lambda value: value,
+            open_school_year=lambda *args, **kwargs: None,
+        ),
+        "pds_core.classes": SimpleNamespace(
+            list_class_folders=lambda root, **kwargs: (),
+            load_class_roster=lambda root, class_id: None,
+        ),
+        "pds_core.class_metadata": SimpleNamespace(
+            load_class_metadata_for_class=lambda root, class_id: None,
+            create_class_metadata=lambda class_id, school_year, **kwargs: object(),
+            write_class_metadata_for_class=lambda *args, **kwargs: None,
+        ),
+        "pds_core.rosters": SimpleNamespace(
+            load_roster=lambda path: None,
+            write_class_roster=lambda *args, **kwargs: None,
+        ),
+        "pds_core.standards": SimpleNamespace(
+            load_workspace_standards_library=lambda root: None,
+            standards_library_path=(
+                lambda root: Path(root) / "standards" / "library.json"
+            ),
+        ),
+        "pds_core.starter_standards": SimpleNamespace(
+            list_starter_standards_packs=lambda: (),
+            load_starter_standards_library=lambda pack_id: None,
+            merge_standards_libraries=lambda *args, **kwargs: (None, None),
+            install_starter_standards_library=lambda *args, **kwargs: None,
+        ),
+        "pds_core.academic_period_storage": SimpleNamespace(
+            load_current_academic_period_calendar=lambda root, year: None,
+            get_current_academic_period_calendar_revision=lambda root, year: None,
+            write_academic_period_calendar=lambda *args, **kwargs: None,
+        ),
+        "pds_core.identifiers": SimpleNamespace(
+            validate_identifier=lambda value, field_name="identifier": value,
+        ),
+        "pds_core.academic_periods": SimpleNamespace(
+            validate_academic_period=lambda value: value,
+            AcademicPeriodCalendar=lambda **kwargs: SimpleNamespace(**kwargs),
+            validate_academic_period_calendar=lambda value: value,
+            ACADEMIC_PERIOD_CALENDAR_SCHEMA_VERSION="1",
+            ACADEMIC_PERIOD_CALENDAR_RECORD_TYPE="academic_period_calendar",
+            ACADEMIC_PERIOD_TYPES=frozenset({"quarter"}),
+            ACADEMIC_PERIOD_LIFECYCLES=frozenset({"planned"}),
+        ),
+    }
+
+    services = load_core_classroom_planning_services(
+        manifest,
+        version_lookup=lambda _distribution: core.version,
+        module_importer=lambda name: modules[name],
+    )
+
+    assert services.academic_period_types == frozenset({"quarter"})
+    assert not hasattr(services, "open_school_year")
+    assert not hasattr(services, "write_class_metadata_for_class")
+    assert not hasattr(services, "write_class_roster")
+    assert not hasattr(services, "install_starter_standards_library")
+    assert not hasattr(services, "write_academic_period_calendar")
+
+
+def test_school_year_plan_new_match_and_conflict(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+    empty = assessment(tmp_path)
+    current = assessment(
+        tmp_path,
+        state=FakeSchoolYearState(
+            "2026-2027",
+            datetime(2026, 8, 20, tzinfo=UTC),
+        ),
+    )
+
+    new = plan_school_year(empty, "2026-2027", services=core.services())
+    match = plan_school_year(current, "2026-2027", services=core.services())
+    conflict = plan_school_year(current, "2027-2028", services=core.services())
+
+    assert new.disposition is SchoolYearDisposition.NEW
+    assert match.disposition is SchoolYearDisposition.EXISTING_MATCH
+    assert conflict.disposition is SchoolYearDisposition.CONFLICT
+    assert conflict.blocks_apply is True
+
+
+def test_school_year_plan_uses_core_validation(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+    with pytest.raises(ClassroomSetupPlanningError, match="Core rejected"):
+        plan_school_year(assessment(tmp_path), "2026-2028", services=core.services())
+
+
+def test_class_plan_new_and_existing_match(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+    now = datetime(2026, 8, 20, tzinfo=UTC)
+    empty = assessment(tmp_path)
+    current = assessment(
+        tmp_path,
+        classes=(
+            class_assessment(
+                tmp_path,
+                metadata=FakeMetadata("eng10", "2026-2027", {"keep": True}),
+            ),
+        ),
+    )
+
+    new = plan_class(
+        empty,
+        "eng10",
+        "2026-2027",
+        planning_time=now,
+        services=core.services(),
+    )
+    match = plan_class(
+        current,
+        "eng10",
+        "2026-2027",
+        planning_time=now,
+        services=core.services(),
+    )
+
+    assert new.disposition is ClassDisposition.NEW
+    assert new.candidate_metadata.module_details == {}
+    assert match.disposition is ClassDisposition.EXISTING_MATCH
+    assert match.candidate_metadata.module_details == {"keep": True}
+
+
+def test_class_plan_allows_empty_folder_but_refuses_roster_without_metadata(
+    tmp_path: Path,
+) -> None:
+    core = FakePlanningCore(tmp_path)
+    now = datetime(2026, 8, 20, tzinfo=UTC)
+    folder_only = assessment(
+        tmp_path,
+        classes=(class_assessment(tmp_path, metadata=None),),
+    )
+    orphan_roster = assessment(
+        tmp_path,
+        classes=(
+            class_assessment(
+                tmp_path,
+                metadata=None,
+                existing_roster=roster(student("s1")),
+            ),
+        ),
+    )
+
+    finish = plan_class(
+        folder_only,
+        "eng10",
+        "2026-2027",
+        planning_time=now,
+        services=core.services(),
+    )
+    refuse = plan_class(
+        orphan_roster,
+        "eng10",
+        "2026-2027",
+        planning_time=now,
+        services=core.services(),
+    )
+
+    assert finish.disposition is ClassDisposition.NEW
+    assert refuse.disposition is ClassDisposition.CONFLICT
+
+
+def test_class_plan_refuses_existing_metadata_for_other_year(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+    current = assessment(
+        tmp_path,
+        classes=(
+            class_assessment(
+                tmp_path,
+                metadata=FakeMetadata("eng10", "2025-2026", {}),
+            ),
+        ),
+    )
+
+    plan = plan_class(
+        current,
+        "eng10",
+        "2026-2027",
+        planning_time=datetime(2026, 8, 20, tzinfo=UTC),
+        services=core.services(),
+    )
+
+    assert plan.disposition is ClassDisposition.CONFLICT
+    assert plan.blocks_apply is True
+
+
+def test_roster_plan_reports_core_validation_diagnostics(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+
+    with pytest.raises(RosterSourcePlanningError) as caught:
+        plan_roster_import(
+            assessment(tmp_path),
+            "eng10",
+            tmp_path / "invalid.csv",
+            services=core.services(),
+        )
+
+    assert caught.value.diagnostics == (
+        "row 1 / column student_id: A required roster column is missing.",
+    )
+    assert "secret-student-id" not in str(caught.value)
+    assert "secret-student-id" not in "\n".join(caught.value.diagnostics)
+
+
+def test_roster_plan_refuses_source_for_different_class(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+    source = tmp_path / "other.csv"
+    core.rosters[source] = roster(student("s1"), source=source, class_id="eng11")
+
+    plan = plan_roster_import(
+        assessment(tmp_path),
+        "eng10",
+        source,
+        services=core.services(),
+    )
+
+    assert plan.action is RosterAction.REFUSE
+    assert plan.blocks_apply is True
+
+
+def test_roster_plan_create_when_no_existing_roster(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+    source = tmp_path / "new.csv"
+    core.rosters[source] = roster(student("s1"), student("s2"), source=source)
+
+    plan = plan_roster_import(
+        assessment(tmp_path),
+        "eng10",
+        source,
+        services=core.services(),
+    )
+
+    assert plan.action is RosterAction.CREATE
+    assert plan.incoming_student_count == 2
+    assert plan.existing_student_count is None
+    assert plan.new_count == 2
+
+
+def test_roster_plan_keep_ignores_only_source_path(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+    source = tmp_path / "incoming.csv"
+    incoming = roster(student("s1"), source=source)
+    existing = roster(
+        student("s1"),
+        source=tmp_path / "classes" / "eng10" / "roster.csv",
+    )
+    core.rosters[source] = incoming
+    current = assessment(
+        tmp_path,
+        classes=(
+            class_assessment(
+                tmp_path,
+                metadata=FakeMetadata("eng10", "2026-2027", {}),
+                existing_roster=existing,
+            ),
+        ),
+    )
+
+    plan = plan_roster_import(current, "eng10", source, services=core.services())
+
+    assert plan.action is RosterAction.KEEP
+    assert plan.unchanged_count == 1
+    assert plan.conflicting_existing_count == 0
+
+
+def test_roster_plan_replace_uses_student_id_and_reports_counts(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+    source = tmp_path / "incoming.csv"
+    core.rosters[source] = roster(
+        student("s1"),
+        student("s2", first_name="Changed"),
+        student("s3"),
+        source=source,
+    )
+    existing = roster(
+        student("s1"),
+        student("s2"),
+        student("s4"),
+        source=tmp_path / "canonical.csv",
+    )
+    current = assessment(
+        tmp_path,
+        classes=(
+            class_assessment(
+                tmp_path,
+                metadata=FakeMetadata("eng10", "2026-2027", {}),
+                existing_roster=existing,
+            ),
+        ),
+    )
+
+    plan = plan_roster_import(current, "eng10", source, services=core.services())
+
+    assert plan.action is RosterAction.REPLACE
+    assert plan.new_count == 1
+    assert plan.unchanged_count == 1
+    assert plan.conflicting_existing_count == 1
+    assert plan.removed_existing_count == 1
+
+
+def test_standards_plan_requires_explicit_advertised_pack(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+    with pytest.raises(ClassroomSetupPlanningError, match="not advertised"):
+        plan_starter_standards(
+            assessment(tmp_path),
+            "not-a-pack",
+            services=core.services(),
+        )
+
+
+def test_standards_plan_install_keep_and_refuse(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+    current = assessment(tmp_path)
+
+    install = plan_starter_standards(current, "starter", services=core.services())
+    assert install.action is StandardsAction.INSTALL
+    assert install.standards_to_add == 2
+    assert install.profiles_to_add == 1
+
+    core.merge_result = FakeMergeResult(
+        pack_id="starter",
+        target_path=tmp_path / "standards" / "library.json",
+        standards_added=0,
+        standards_skipped=2,
+        standards_overwritten=0,
+        profiles_added=0,
+        profiles_skipped=1,
+        profiles_overwritten=0,
+    )
+    keep = plan_starter_standards(current, "starter", services=core.services())
+    assert keep.action is StandardsAction.KEEP
+    assert keep.standards_identical == 2
+
+    core.merge_result = FakeMergeResult(
+        pack_id="starter",
+        target_path=tmp_path / "standards" / "library.json",
+        standards_added=0,
+        standards_skipped=1,
+        standards_overwritten=0,
+        profiles_added=0,
+        profiles_skipped=0,
+        profiles_overwritten=0,
+        standard_conflicts=("std.conflict",),
+        profile_conflicts=("profile.conflict",),
+    )
+    refuse = plan_starter_standards(current, "starter", services=core.services())
+    assert refuse.action is StandardsAction.REFUSE
+    assert refuse.standard_conflicts == ("std.conflict",)
+    assert refuse.profile_conflicts == ("profile.conflict",)
+
+
+def test_academic_period_plan_skip_and_existing_keep(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+    skipped = plan_academic_periods(
+        assessment(tmp_path),
+        "2026-2027",
+        None,
+        planning_time=datetime(2026, 8, 20, tzinfo=UTC),
+        services=core.services(),
+    )
+    existing_calendar = FakeCalendar("2026-2027", 1, (object(), object()))
+    kept = plan_academic_periods(
+        assessment(tmp_path, calendar=existing_calendar),
+        "2026-2027",
+        None,
+        planning_time=datetime(2026, 8, 20, tzinfo=UTC),
+        services=core.services(),
+    )
+
+    assert skipped.action is AcademicPeriodAction.SKIP
+    assert kept.action is AcademicPeriodAction.KEEP
+    assert kept.period_count == 2
+
+
+def test_academic_period_plan_refuses_revision_of_existing_calendar(
+    tmp_path: Path,
+) -> None:
+    core = FakePlanningCore(tmp_path)
+    existing_calendar = FakeCalendar("2026-2027", 1, (object(),))
+
+    plan = plan_academic_periods(
+        assessment(tmp_path, calendar=existing_calendar),
+        "2026-2027",
+        (period_input(),),
+        planning_time=datetime(2026, 8, 20, tzinfo=UTC),
+        services=core.services(),
+    )
+
+    assert plan.action is AcademicPeriodAction.REFUSE
+    assert plan.blocks_apply is True
+
+
+def test_academic_period_plan_builds_revision_one_and_uses_full_core_validation(
+    tmp_path: Path,
+) -> None:
+    core = FakePlanningCore(tmp_path)
+    now = datetime(2026, 8, 20, tzinfo=UTC)
+
+    plan = plan_academic_periods(
+        assessment(tmp_path),
+        "2026-2027",
+        (period_input(),),
+        planning_time=now,
+        services=core.services(),
+    )
+
+    assert plan.action is AcademicPeriodAction.CREATE
+    assert plan.candidate_calendar is not None
+    assert plan.candidate_calendar.calendar_revision == 1
+    assert plan.period_count == 1
+
+    core.calendar_validation_error = ValueError("duplicate sibling sequence")
+    with pytest.raises(ClassroomSetupPlanningError, match="duplicate sibling sequence"):
+        plan_academic_periods(
+            assessment(tmp_path),
+            "2026-2027",
+            (period_input(),),
+            planning_time=now,
+            services=core.services(),
+        )
+
+
+def test_assembled_plan_blocks_any_unresolved_domain_conflict(tmp_path: Path) -> None:
+    core = FakePlanningCore(tmp_path)
+    now = datetime(2026, 8, 20, tzinfo=UTC)
+    current = assessment(
+        tmp_path,
+        state=FakeSchoolYearState("2025-2026", now),
+    )
+    school = plan_school_year(current, "2026-2027", services=core.services())
+    class_plan = plan_class(
+        current,
+        "eng10",
+        "2026-2027",
+        planning_time=now,
+        services=core.services(),
+    )
+
+    plan = assemble_shared_setup_plan(school, classes=(class_plan,))
+
+    assert plan.can_apply is False
+    assert plan.blocking_reasons
+
+
+def test_assembled_plan_rejects_roster_without_corresponding_class_plan(
+    tmp_path: Path,
+) -> None:
+    core = FakePlanningCore(tmp_path)
+    source = tmp_path / "incoming.csv"
+    core.rosters[source] = roster(student("s1"), source=source)
+    school = plan_school_year(
+        assessment(tmp_path),
+        "2026-2027",
+        services=core.services(),
+    )
+    roster_plan = plan_roster_import(
+        assessment(tmp_path),
+        "eng10",
+        source,
+        services=core.services(),
+    )
+
+    with pytest.raises(ClassroomSetupPlanningError, match="no corresponding class"):
+        assemble_shared_setup_plan(school, rosters=(roster_plan,))
+
+
+def test_academic_period_plan_checks_proposed_year_when_not_active(
+    tmp_path: Path,
+) -> None:
+    core = FakePlanningCore(tmp_path)
+    existing = FakeCalendar("2026-2027", 1, (object(),))
+    core.current_calendars["2026-2027"] = existing
+
+    plan = plan_academic_periods(
+        assessment(tmp_path),
+        "2026-2027",
+        None,
+        planning_time=datetime(2026, 8, 20, tzinfo=UTC),
+        services=core.services(),
+    )
+
+    assert plan.action is AcademicPeriodAction.KEEP
+    assert plan.candidate_calendar is existing
+
+
+def test_academic_period_plan_fails_closed_on_pointer_mismatch(
+    tmp_path: Path,
+) -> None:
+    core = FakePlanningCore(tmp_path)
+    existing = FakeCalendar("2026-2027", 2, (object(),))
+    core.current_calendars["2026-2027"] = existing
+
+    services = core.services()
+    readers = cast(
+        CoreClassroomServices,
+        SimpleNamespace(
+            load_current_academic_period_calendar=core.load_current_calendar,
+            get_current_academic_period_calendar_revision=(
+                lambda root, year: 1
+            ),
+        ),
+    )
+    mismatched_services = CoreClassroomPlanningServices(
+        readers=readers,
+        validate_identifier=services.validate_identifier,
+        validate_school_year=services.validate_school_year,
+        create_class_metadata=services.create_class_metadata,
+        load_roster=services.load_roster,
+        standards_library_path=services.standards_library_path,
+        load_starter_standards_library=(
+            services.load_starter_standards_library
+        ),
+        merge_standards_libraries=services.merge_standards_libraries,
+        validate_academic_period=services.validate_academic_period,
+        academic_period_calendar_factory=(
+            services.academic_period_calendar_factory
+        ),
+        validate_academic_period_calendar=(
+            services.validate_academic_period_calendar
+        ),
+        academic_period_calendar_schema_version=(
+            services.academic_period_calendar_schema_version
+        ),
+        academic_period_calendar_record_type=(
+            services.academic_period_calendar_record_type
+        ),
+        academic_period_types=services.academic_period_types,
+        academic_period_lifecycles=services.academic_period_lifecycles,
+    )
+
+    with pytest.raises(ClassroomSetupPlanningError, match="pointer disagree"):
+        plan_academic_periods(
+            assessment(tmp_path),
+            "2026-2027",
+            None,
+            planning_time=datetime(2026, 8, 20, tzinfo=UTC),
+            services=mismatched_services,
+        )

--- a/tests/test_classroom_setup.py
+++ b/tests/test_classroom_setup.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from paper_data_suite.classroom_setup import (
+    ClassroomSetupAssessmentError,
+    ClassroomWorkspaceError,
+    CoreClassroomServiceError,
+    CoreClassroomServices,
+    assess_shared_setup,
+    load_core_classroom_services,
+)
+from paper_data_suite.compatibility import load_release_compatibility_manifest
+
+
+@dataclass(frozen=True)
+class FakeWorkspaceStatus:
+    root: Path
+    source: str = "saved_config"
+    exists: bool = True
+    is_dir: bool = True
+    is_writable: bool = True
+
+
+@dataclass(frozen=True)
+class FakeSchoolYearState:
+    active_school_year: str
+    opened_at: datetime
+    closed_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class FakeClassFolder:
+    class_id: str
+    class_dir: Path
+    roster_path: Path
+    metadata_path: Path
+
+
+@dataclass(frozen=True)
+class FakeClassMetadata:
+    class_id: str
+    school_year: str
+    module_details: dict[str, object]
+
+
+@dataclass(frozen=True)
+class FakeStudent:
+    student_id: str
+
+
+@dataclass(frozen=True)
+class FakeRoster:
+    class_id: str
+    students: tuple[FakeStudent, ...]
+    columns: tuple[str, ...] = (
+        "class_id",
+        "student_id",
+        "last_name",
+        "first_name",
+        "period",
+    )
+
+
+@dataclass(frozen=True)
+class FakeStandardsLibrary:
+    standards: tuple[object, ...]
+    profiles: tuple[object, ...]
+
+
+@dataclass(frozen=True)
+class FakeStarterPack:
+    pack_id: str
+    title: str
+    source: str
+    grade_bands: tuple[str, ...]
+    courses: tuple[str, ...]
+    standard_count: int
+    profile_count: int
+
+
+@dataclass(frozen=True)
+class FakeCalendar:
+    school_year: str
+    calendar_revision: int
+    periods: tuple[object, ...]
+
+
+class FakeCore:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.workspace = FakeWorkspaceStatus(root=root)
+        self.school_year: FakeSchoolYearState | None = None
+        self.folders: tuple[FakeClassFolder, ...] = ()
+        self.metadata_by_class: dict[str, FakeClassMetadata] = {}
+        self.roster_by_class: dict[str, FakeRoster] = {}
+        self.standards = FakeStandardsLibrary(standards=(), profiles=())
+        self.starter_packs: tuple[FakeStarterPack, ...] = ()
+        self.calendar: FakeCalendar | None = None
+        self.revision: int | None = None
+        self.calls: list[str] = []
+        self.fail_area: str | None = None
+
+    def inspect_workspace(
+        self, explicit_root: str | Path | None = None
+    ) -> FakeWorkspaceStatus:
+        assert explicit_root is None
+        self.calls.append("workspace.inspect")
+        return self.workspace
+
+    def load_school_year(
+        self, workspace_root: str | Path
+    ) -> FakeSchoolYearState | None:
+        assert Path(workspace_root) == self.root
+        self.calls.append("school_year.load")
+        if self.fail_area == "school_year":
+            raise ValueError("bad school year")
+        return self.school_year
+
+    def list_classes(
+        self,
+        workspace_root: str | Path,
+        *,
+        require_roster: bool = False,
+        load_rosters: bool = False,
+        require_metadata: bool = False,
+        load_metadata: bool = False,
+    ) -> tuple[FakeClassFolder, ...]:
+        assert Path(workspace_root) == self.root
+        assert not require_roster
+        assert not load_rosters
+        assert not require_metadata
+        assert not load_metadata
+        self.calls.append("classes.list")
+        return self.folders
+
+    def load_metadata(
+        self, workspace_root: str | Path, class_id: str
+    ) -> FakeClassMetadata:
+        assert Path(workspace_root) == self.root
+        self.calls.append(f"class.metadata:{class_id}")
+        if self.fail_area == f"metadata:{class_id}":
+            raise ValueError("invalid class.json")
+        return self.metadata_by_class[class_id]
+
+    def load_roster(self, workspace_root: str | Path, class_id: str) -> FakeRoster:
+        assert Path(workspace_root) == self.root
+        self.calls.append(f"class.roster:{class_id}")
+        if self.fail_area == f"roster:{class_id}":
+            raise ValueError("invalid roster.csv")
+        return self.roster_by_class[class_id]
+
+    def load_standards(self, workspace_root: str | Path) -> FakeStandardsLibrary:
+        assert Path(workspace_root) == self.root
+        self.calls.append("standards.load")
+        if self.fail_area == "standards":
+            raise ValueError("invalid standards library")
+        return self.standards
+
+    def list_starter_packs(self) -> tuple[FakeStarterPack, ...]:
+        self.calls.append("standards.starters")
+        return self.starter_packs
+
+    def load_calendar(
+        self,
+        workspace_root: str | Path,
+        school_year: str,
+    ) -> FakeCalendar | None:
+        assert Path(workspace_root) == self.root
+        self.calls.append(f"periods.load:{school_year}")
+        if self.fail_area == "periods":
+            raise ValueError("bad calendar")
+        return self.calendar
+
+    def get_revision(self, workspace_root: str | Path, school_year: str) -> int | None:
+        assert Path(workspace_root) == self.root
+        self.calls.append(f"periods.revision:{school_year}")
+        return self.revision
+
+    def services(self) -> CoreClassroomServices:
+        return CoreClassroomServices(
+            inspect_workspace_root=self.inspect_workspace,
+            load_school_year_state=self.load_school_year,
+            list_class_folders=self.list_classes,
+            load_class_metadata_for_class=self.load_metadata,
+            load_class_roster=self.load_roster,
+            load_workspace_standards_library=self.load_standards,
+            list_starter_standards_packs=self.list_starter_packs,
+            load_current_academic_period_calendar=self.load_calendar,
+            get_current_academic_period_calendar_revision=self.get_revision,
+        )
+
+
+def test_load_services_qualifies_core_before_other_core_imports() -> None:
+    manifest = load_release_compatibility_manifest()
+    core = next(
+        component
+        for component in manifest.components
+        if "shared_core" in component.capabilities
+    )
+    events: list[str] = []
+
+    modules = {
+        "pds_core.workspace": SimpleNamespace(
+            inspect_workspace_root=lambda explicit_root=None: None,
+            ensure_workspace_root=lambda path, create=True: Path(path),
+            save_workspace_root=lambda path: Path(path),
+            clear_saved_workspace_root=lambda: False,
+        ),
+        "pds_core.school_years": SimpleNamespace(
+            load_school_year_state=lambda root: None,
+        ),
+        "pds_core.classes": SimpleNamespace(
+            list_class_folders=lambda root, **kwargs: (),
+            load_class_roster=lambda root, class_id: None,
+        ),
+        "pds_core.class_metadata": SimpleNamespace(
+            load_class_metadata_for_class=lambda root, class_id: None,
+        ),
+        "pds_core.standards": SimpleNamespace(
+            load_workspace_standards_library=lambda root: None,
+        ),
+        "pds_core.starter_standards": SimpleNamespace(
+            list_starter_standards_packs=lambda: (),
+        ),
+        "pds_core.academic_period_storage": SimpleNamespace(
+            load_current_academic_period_calendar=lambda root, school_year: None,
+            get_current_academic_period_calendar_revision=(
+                lambda root, school_year: None
+            ),
+        ),
+    }
+
+    def version_lookup(distribution: str) -> str:
+        events.append(f"version:{distribution}")
+        return core.version
+
+    def importer(name: str) -> object:
+        events.append(f"import:{name}")
+        return modules[name]
+
+    load_core_classroom_services(
+        manifest,
+        version_lookup=version_lookup,
+        module_importer=importer,
+    )
+
+    assert events[0] == f"version:{core.distribution}"
+    assert events[1] == "import:pds_core.workspace"
+    assert events[2:] == [
+        "import:pds_core.school_years",
+        "import:pds_core.classes",
+        "import:pds_core.class_metadata",
+        "import:pds_core.standards",
+        "import:pds_core.starter_standards",
+        "import:pds_core.academic_period_storage",
+    ]
+
+
+def test_load_services_requires_exact_public_callable() -> None:
+    manifest = load_release_compatibility_manifest()
+    core = next(
+        component
+        for component in manifest.components
+        if "shared_core" in component.capabilities
+    )
+    modules = {
+        "pds_core.workspace": SimpleNamespace(
+            inspect_workspace_root=lambda explicit_root=None: None,
+            ensure_workspace_root=lambda path, create=True: Path(path),
+            save_workspace_root=lambda path: Path(path),
+            clear_saved_workspace_root=lambda: False,
+        ),
+        "pds_core.school_years": SimpleNamespace(
+            load_school_year_state=lambda root: None
+        ),
+        "pds_core.classes": SimpleNamespace(
+            list_class_folders=lambda root, **kwargs: (),
+            load_class_roster=lambda root, class_id: None,
+        ),
+        "pds_core.class_metadata": SimpleNamespace(
+            load_class_metadata_for_class=lambda root, class_id: None
+        ),
+        "pds_core.standards": SimpleNamespace(
+            load_workspace_standards_library=lambda root: None
+        ),
+        "pds_core.starter_standards": SimpleNamespace(),
+        "pds_core.academic_period_storage": SimpleNamespace(
+            load_current_academic_period_calendar=lambda root, school_year: None,
+            get_current_academic_period_calendar_revision=(
+                lambda root, school_year: None
+            ),
+        ),
+    }
+
+    with pytest.raises(CoreClassroomServiceError, match="list_starter_standards_packs"):
+        load_core_classroom_services(
+            manifest,
+            version_lookup=lambda _distribution: core.version,
+            module_importer=lambda name: modules[name],
+        )
+
+
+def test_assessment_rejects_missing_workspace_without_other_reads(
+    tmp_path: Path,
+) -> None:
+    fake = FakeCore(tmp_path / "missing")
+    fake.workspace = FakeWorkspaceStatus(root=fake.root, exists=False, is_dir=False)
+
+    with pytest.raises(ClassroomWorkspaceError, match="pds workspace setup"):
+        assess_shared_setup(services=fake.services())
+
+    assert fake.calls == ["workspace.inspect"]
+    assert not fake.root.exists()
+
+
+def test_assessment_accepts_empty_existing_workspace(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    fake = FakeCore(root)
+
+    assessment = assess_shared_setup(services=fake.services())
+
+    assert assessment.workspace_root == root
+    assert assessment.active_school_year is None
+    assert assessment.classes == ()
+    assert assessment.standards_count == 0
+    assert assessment.standards_profile_count == 0
+    assert assessment.academic_period_calendar is None
+    assert assessment.academic_period_revision is None
+    assert not any(call.startswith("periods.") for call in fake.calls)
+
+
+def test_assessment_loads_valid_existing_shared_state(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    class_dir = root / "classes" / "eng10-p2"
+    class_dir.mkdir(parents=True)
+    metadata_path = class_dir / "class.json"
+    roster_path = class_dir / "roster.csv"
+    metadata_path.write_text("{}", encoding="utf-8")
+    roster_path.write_text("synthetic", encoding="utf-8")
+
+    fake = FakeCore(root)
+    fake.school_year = FakeSchoolYearState(
+        active_school_year="2026-2027",
+        opened_at=datetime(2026, 8, 20, tzinfo=UTC),
+    )
+    fake.folders = (
+        FakeClassFolder(
+            class_id="eng10-p2",
+            class_dir=class_dir,
+            roster_path=roster_path,
+            metadata_path=metadata_path,
+        ),
+    )
+    fake.metadata_by_class["eng10-p2"] = FakeClassMetadata(
+        class_id="eng10-p2",
+        school_year="2026-2027",
+        module_details={},
+    )
+    fake.roster_by_class["eng10-p2"] = FakeRoster(
+        class_id="eng10-p2",
+        students=(FakeStudent("s001"), FakeStudent("s002")),
+    )
+    fake.standards = FakeStandardsLibrary(
+        standards=(object(), object(), object()),
+        profiles=(object(),),
+    )
+    fake.starter_packs = (
+        FakeStarterPack(
+            pack_id="example",
+            title="Example",
+            source="Synthetic",
+            grade_bands=("9-10",),
+            courses=("English 10",),
+            standard_count=3,
+            profile_count=1,
+        ),
+    )
+    fake.calendar = FakeCalendar(
+        school_year="2026-2027",
+        calendar_revision=1,
+        periods=(object(), object()),
+    )
+    fake.revision = 1
+
+    assessment = assess_shared_setup(services=fake.services())
+
+    assert assessment.active_school_year == "2026-2027"
+    assert len(assessment.classes) == 1
+    assert assessment.classes[0].has_metadata is True
+    assert assessment.classes[0].has_roster is True
+    assert assessment.classes[0].student_count == 2
+    assert assessment.standards_count == 3
+    assert assessment.standards_profile_count == 1
+    assert assessment.starter_standards_packs[0].pack_id == "example"
+    assert assessment.academic_period_revision == 1
+
+
+def test_assessment_does_not_load_calendar_for_closed_school_year(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    fake = FakeCore(root)
+    fake.school_year = FakeSchoolYearState(
+        active_school_year="2025-2026",
+        opened_at=datetime(2025, 8, 20, tzinfo=UTC),
+        closed_at=datetime(2026, 6, 30, tzinfo=UTC),
+    )
+
+    assessment = assess_shared_setup(services=fake.services())
+
+    assert assessment.active_school_year is None
+    assert not any(call.startswith("periods.") for call in fake.calls)
+
+
+def test_assessment_refuses_malformed_class_metadata(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    class_dir = root / "classes" / "eng10"
+    class_dir.mkdir(parents=True)
+    metadata_path = class_dir / "class.json"
+    metadata_path.write_text("malformed", encoding="utf-8")
+    fake = FakeCore(root)
+    fake.folders = (
+        FakeClassFolder(
+            class_id="eng10",
+            class_dir=class_dir,
+            roster_path=class_dir / "roster.csv",
+            metadata_path=metadata_path,
+        ),
+    )
+    fake.fail_area = "metadata:eng10"
+
+    with pytest.raises(ClassroomSetupAssessmentError, match="class metadata"):
+        assess_shared_setup(services=fake.services())
+
+
+def test_assessment_refuses_malformed_roster(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    class_dir = root / "classes" / "eng10"
+    class_dir.mkdir(parents=True)
+    roster_path = class_dir / "roster.csv"
+    roster_path.write_text("malformed", encoding="utf-8")
+    fake = FakeCore(root)
+    fake.folders = (
+        FakeClassFolder(
+            class_id="eng10",
+            class_dir=class_dir,
+            roster_path=roster_path,
+            metadata_path=class_dir / "class.json",
+        ),
+    )
+    fake.fail_area = "roster:eng10"
+
+    with pytest.raises(ClassroomSetupAssessmentError, match="roster"):
+        assess_shared_setup(services=fake.services())
+
+
+def test_assessment_refuses_malformed_standards_library(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    fake = FakeCore(root)
+    fake.fail_area = "standards"
+
+    with pytest.raises(ClassroomSetupAssessmentError, match="standards-library"):
+        assess_shared_setup(services=fake.services())
+
+
+def test_assessment_refuses_academic_period_pointer_mismatch(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    fake = FakeCore(root)
+    fake.school_year = FakeSchoolYearState(
+        active_school_year="2026-2027",
+        opened_at=datetime(2026, 8, 20, tzinfo=UTC),
+    )
+    fake.calendar = FakeCalendar(
+        school_year="2026-2027",
+        calendar_revision=2,
+        periods=(),
+    )
+    fake.revision = 1
+
+    with pytest.raises(
+        ClassroomSetupAssessmentError,
+        match="revision pointer disagree",
+    ):
+        assess_shared_setup(services=fake.services())
+
+
+def test_assessment_preserves_core_objects_without_copying_sensitive_rows(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    class_dir = root / "classes" / "eng10"
+    class_dir.mkdir(parents=True)
+    roster_path = class_dir / "roster.csv"
+    roster_path.touch()
+    fake = FakeCore(root)
+    roster = FakeRoster(
+        class_id="eng10",
+        students=(FakeStudent("opaque-student-id"),),
+    )
+    fake.folders = (
+        FakeClassFolder(
+            class_id="eng10",
+            class_dir=class_dir,
+            roster_path=roster_path,
+            metadata_path=class_dir / "class.json",
+        ),
+    )
+    fake.roster_by_class["eng10"] = roster
+
+    assessment = assess_shared_setup(services=fake.services())
+
+    assert assessment.classes[0].roster is roster
+    assert assessment.classes[0].student_count == 1
+
+
+def test_service_dataclass_rejects_no_fake_writes_by_construction(
+    tmp_path: Path,
+) -> None:
+    """The slice-1 service surface intentionally contains readers only."""
+    fake = FakeCore(tmp_path)
+    services = fake.services()
+
+    assert not hasattr(services, "open_school_year")
+    assert not hasattr(services, "ensure_class_folder")
+    assert not hasattr(services, "write_class_roster")
+    assert not hasattr(services, "install_starter_standards_library")
+    assert not hasattr(services, "write_academic_period_calendar")
+
+    cast(object, services)
+
+
+def test_load_services_matches_installed_qualified_core_public_contract() -> None:
+    services = load_core_classroom_services()
+
+    assert callable(services.load_school_year_state)
+    assert callable(services.list_class_folders)
+    assert callable(services.load_class_metadata_for_class)
+    assert callable(services.load_class_roster)
+    assert callable(services.load_workspace_standards_library)
+    assert callable(services.list_starter_standards_packs)
+    assert callable(services.load_current_academic_period_calendar)
+    assert callable(services.get_current_academic_period_calendar_revision)

--- a/tests/test_classroom_setup_cli.py
+++ b/tests/test_classroom_setup_cli.py
@@ -1,0 +1,685 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+import paper_data_suite.classroom_setup_cli as setup_cli
+from paper_data_suite.classroom_planning import (
+    AcademicPeriodAction,
+    AcademicPeriodPlan,
+    ClassDisposition,
+    ClassPlan,
+    CoreClassroomPlanningServices,
+    RosterAction,
+    RosterPlan,
+    SchoolYearDisposition,
+    SchoolYearPlan,
+    SharedSetupPlan,
+    StandardsAction,
+    StandardsPlan,
+)
+from paper_data_suite.classroom_setup import (
+    ClassSetupAssessment,
+    SharedSetupAssessment,
+)
+
+
+@dataclass(frozen=True)
+class FakeState:
+    active_school_year: str
+    opened_at: datetime
+    closed_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class FakeLibrary:
+    standards: tuple[object, ...] = ()
+    profiles: tuple[object, ...] = ()
+
+
+@dataclass(frozen=True)
+class FakePack:
+    pack_id: str = "starter"
+    title: str = "Synthetic standards"
+    source: str = "Core synthetic fixture"
+    grade_bands: tuple[str, ...] = ("9-10",)
+    courses: tuple[str, ...] = ("English",)
+    standard_count: int = 3
+    profile_count: int = 1
+
+
+@dataclass(frozen=True)
+class FakeMetadata:
+    class_id: str
+    school_year: str
+    module_details: dict[str, object]
+
+
+@dataclass(frozen=True)
+class FakeStudent:
+    class_id: str
+    student_id: str
+    last_name: str
+    first_name: str
+    period: str
+    extra_fields: dict[str, str]
+
+
+@dataclass(frozen=True)
+class FakeRoster:
+    class_id: str
+    students: tuple[FakeStudent, ...]
+    columns: tuple[str, ...]
+    source_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class FakeCalendar:
+    school_year: str
+    calendar_revision: int
+    periods: tuple[object, ...]
+
+
+@dataclass(frozen=True)
+class FakePeriod:
+    period_id: str
+    period_type: str
+    label: str
+    start_date: str
+    end_date: str
+    parent_period_id: str | None
+    sequence: int
+    lifecycle: str
+
+
+def fake_assessment(
+    tmp_path: Path,
+    *,
+    active_year: str | None = None,
+    classes: tuple[ClassSetupAssessment, ...] = (),
+    calendar: FakeCalendar | None = None,
+) -> SharedSetupAssessment:
+    state = None
+    if active_year is not None:
+        state = FakeState(
+            active_school_year=active_year,
+            opened_at=datetime(2026, 8, 20, tzinfo=UTC),
+        )
+    return SharedSetupAssessment(
+        workspace_root=tmp_path,
+        workspace_source="saved_config",
+        school_year_state=state,
+        classes=classes,
+        standards_library=FakeLibrary((object(), object()), (object(),)),
+        starter_standards_packs=(FakePack(),),
+        academic_period_calendar=calendar,
+        academic_period_revision=(
+            None if calendar is None else calendar.calendar_revision
+        ),
+    )
+
+
+def fake_services() -> CoreClassroomPlanningServices:
+    return cast(
+        CoreClassroomPlanningServices,
+        SimpleNamespace(
+            academic_period_types=frozenset({"quarter", "semester"}),
+            academic_period_lifecycles=frozenset(
+                {"planned", "active", "closed", "cancelled"}
+            ),
+            validate_academic_period=lambda value: value,
+        ),
+    )
+
+
+def input_reader(values: list[str]):
+    iterator = iter(values)
+    return lambda _prompt: next(iterator)
+
+
+def school_plan(
+    year: str = "2026-2027",
+    disposition: SchoolYearDisposition = SchoolYearDisposition.NEW,
+) -> SchoolYearPlan:
+    return SchoolYearPlan(year, disposition, "school year reason")
+
+
+def class_plan(
+    assessment: SharedSetupAssessment,
+    *,
+    disposition: ClassDisposition = ClassDisposition.NEW,
+) -> ClassPlan:
+    existing = next(
+        (item for item in assessment.classes if item.class_id == "eng10"),
+        None,
+    )
+    return ClassPlan(
+        class_id="eng10",
+        school_year="2026-2027",
+        disposition=disposition,
+        candidate_metadata=FakeMetadata("eng10", "2026-2027", {}),
+        existing=existing,
+        reason="class reason",
+    )
+
+
+def test_initial_assessment_is_bounded_and_does_not_dump_roster(
+    tmp_path: Path,
+) -> None:
+    roster = FakeRoster(
+        class_id="eng10",
+        students=(
+            FakeStudent(
+                "eng10",
+                "secret-student-id",
+                "SensitiveLast",
+                "SensitiveFirst",
+                "2",
+                {},
+            ),
+        ),
+        columns=("class_id", "student_id", "last_name", "first_name", "period"),
+    )
+    current = fake_assessment(
+        tmp_path,
+        active_year="2026-2027",
+        classes=(
+            ClassSetupAssessment(
+                "eng10",
+                FakeMetadata("eng10", "2026-2027", {}),
+                roster,
+            ),
+        ),
+    )
+
+    rendered = setup_cli.render_initial_setup_assessment(current)
+
+    assert str(tmp_path) in rendered
+    assert "saved workspace selection" in rendered
+    assert "eng10: metadata; roster with 1 students" in rendered
+    assert "secret-student-id" not in rendered
+    assert "SensitiveFirst" not in rendered
+    assert "SensitiveLast" not in rendered
+
+
+def test_starter_pack_rendering_uses_only_core_metadata(tmp_path: Path) -> None:
+    rendered = setup_cli.render_starter_standards_packs(fake_assessment(tmp_path))
+
+    assert "starter — Synthetic standards" in rendered
+    assert "Core synthetic fixture" in rendered
+    assert "Grade bands: 9-10" in rendered
+    assert "Courses: English" in rendered
+    assert "Standards: 3" in rendered
+    assert "Profiles: 1" in rendered
+
+
+def test_final_review_shows_whole_roster_counts_without_rows(tmp_path: Path) -> None:
+    current = fake_assessment(tmp_path)
+    incoming = FakeRoster(
+        "eng10",
+        (
+            FakeStudent("eng10", "s1", "One", "Student", "2", {}),
+            FakeStudent("eng10", "s2", "Two", "Student", "2", {}),
+        ),
+        ("class_id", "student_id", "last_name", "first_name", "period"),
+        Path("teacher-private-roster.csv"),
+    )
+    roster_plan = RosterPlan(
+        class_id="eng10",
+        source_path=Path("teacher-private-roster.csv"),
+        incoming_roster=incoming,
+        existing_roster=None,
+        action=RosterAction.REPLACE,
+        incoming_student_count=2,
+        existing_student_count=2,
+        new_count=1,
+        unchanged_count=0,
+        conflicting_existing_count=1,
+        removed_existing_count=1,
+        reason="whole-roster replacement required",
+    )
+    standards = StandardsPlan(
+        pack_id="starter",
+        action=StandardsAction.INSTALL,
+        candidate_library=FakeLibrary(),
+        target_path=tmp_path / "standards" / "library.json",
+        standards_to_add=3,
+        standards_identical=1,
+        standard_conflicts=(),
+        profiles_to_add=1,
+        profiles_identical=0,
+        profile_conflicts=(),
+        reason="standards reason",
+    )
+    periods = AcademicPeriodPlan(
+        "2026-2027",
+        AcademicPeriodAction.CREATE,
+        FakeCalendar(
+            "2026-2027",
+            1,
+            (
+                FakePeriod(
+                    "q1",
+                    "quarter",
+                    "Quarter 1",
+                    "2026-09-01",
+                    "2026-11-01",
+                    None,
+                    1,
+                    "planned",
+                ),
+                FakePeriod(
+                    "q2",
+                    "quarter",
+                    "Quarter 2",
+                    "2026-11-02",
+                    "2027-01-31",
+                    None,
+                    2,
+                    "planned",
+                ),
+            ),
+        ),
+        2,
+        "period reason",
+    )
+    plan = SharedSetupPlan(
+        school_plan(),
+        (class_plan(current),),
+        (roster_plan,),
+        standards,
+        periods,
+    )
+
+    rendered = setup_cli.render_setup_plan(current, plan)
+
+    assert "eng10: REPLACE" in rendered
+    assert "Incoming students: 2" in rendered
+    assert "Conflicting existing: 1" in rendered
+    assert "Existing absent from import: 1" in rendered
+    assert "teacher-private-roster.csv" not in rendered
+    assert "Student" not in rendered
+    assert "s1" not in rendered
+    assert "q1 | quarter | Quarter 1" in rendered
+    assert "2026-09-01..2026-11-01" in rendered
+    assert "parent=none | sequence=1 | lifecycle=planned" in rendered
+    assert "q2 | quarter | Quarter 2" in rendered
+    assert "Plan is eligible for final APPLY." in rendered
+
+
+def test_review_requires_exact_apply(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    current = fake_assessment(tmp_path)
+    plan = SharedSetupPlan(school_plan(), (), (), None, None)
+
+    decision = setup_cli.review_setup_plan(
+        current,
+        plan,
+        input_fn=input_reader(["apply", "APPLY"]),
+    )
+
+    assert decision is setup_cli.SetupReviewDecision.APPLY
+    assert "Type exact APPLY, E, or Q." in capsys.readouterr().out
+
+
+def test_review_refuses_apply_while_conflict_remains(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    current = fake_assessment(tmp_path, active_year="2025-2026")
+    conflict = school_plan(
+        disposition=SchoolYearDisposition.CONFLICT,
+    )
+    plan = SharedSetupPlan(conflict, (), (), None, None)
+
+    decision = setup_cli.review_setup_plan(
+        current,
+        plan,
+        input_fn=input_reader(["APPLY", "Q"]),
+    )
+
+    assert decision is setup_cli.SetupReviewDecision.CANCEL
+    assert "APPLY is blocked" in capsys.readouterr().out
+
+
+def test_collect_requires_explicit_school_year_when_none_is_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = fake_assessment(tmp_path)
+    observed_years: list[str] = []
+
+    def fake_school(_assessment: object, year: str, **_kwargs: object):
+        observed_years.append(year)
+        return school_plan(year)
+
+    monkeypatch.setattr(setup_cli, "plan_school_year", fake_school)
+    monkeypatch.setattr(
+        setup_cli,
+        "plan_academic_periods",
+        lambda *args, **kwargs: AcademicPeriodPlan(
+            "2026-2027",
+            AcademicPeriodAction.SKIP,
+            None,
+            0,
+            "skipped",
+        ),
+    )
+
+    result = setup_cli.collect_setup_plan(
+        current,
+        services=fake_services(),
+        input_fn=input_reader(["2026-2027", "", "", "2"]),
+        clock=lambda: datetime(2026, 8, 20, tzinfo=UTC),
+    )
+
+    assert result.cancelled is False
+    assert result.plan is not None
+    assert observed_years == ["2026-2027"]
+    assert result.plan.school_year.requested_school_year == "2026-2027"
+    assert result.plan.classes == ()
+
+
+def test_collect_uses_existing_active_year_without_inventing_another(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = fake_assessment(tmp_path, active_year="2026-2027")
+    observed_years: list[str] = []
+
+    def fake_school(_assessment: object, year: str, **_kwargs: object):
+        observed_years.append(year)
+        return school_plan(year, SchoolYearDisposition.EXISTING_MATCH)
+
+    monkeypatch.setattr(setup_cli, "plan_school_year", fake_school)
+    monkeypatch.setattr(
+        setup_cli,
+        "plan_academic_periods",
+        lambda *args, **kwargs: AcademicPeriodPlan(
+            "2026-2027",
+            AcademicPeriodAction.SKIP,
+            None,
+            0,
+            "skipped",
+        ),
+    )
+
+    result = setup_cli.collect_setup_plan(
+        current,
+        services=fake_services(),
+        input_fn=input_reader(["", "", "2"]),
+        clock=lambda: datetime(2026, 8, 20, tzinfo=UTC),
+    )
+
+    assert result.plan is not None
+    assert observed_years == ["2026-2027"]
+
+
+def test_collect_class_and_roster_preserves_replace_action(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = fake_assessment(tmp_path, active_year="2026-2027")
+    incoming = FakeRoster(
+        "eng10",
+        (),
+        ("class_id", "student_id", "last_name", "first_name", "period"),
+        tmp_path / "roster.csv",
+    )
+    replacement = RosterPlan(
+        "eng10",
+        tmp_path / "roster.csv",
+        incoming,
+        None,
+        RosterAction.REPLACE,
+        2,
+        2,
+        1,
+        0,
+        1,
+        1,
+        "replacement",
+    )
+    monkeypatch.setattr(
+        setup_cli,
+        "plan_school_year",
+        lambda *args, **kwargs: school_plan(
+            disposition=SchoolYearDisposition.EXISTING_MATCH
+        ),
+    )
+    monkeypatch.setattr(
+        setup_cli,
+        "plan_class",
+        lambda *args, **kwargs: class_plan(current),
+    )
+    monkeypatch.setattr(
+        setup_cli,
+        "plan_roster_import",
+        lambda *args, **kwargs: replacement,
+    )
+    monkeypatch.setattr(
+        setup_cli,
+        "plan_academic_periods",
+        lambda *args, **kwargs: AcademicPeriodPlan(
+            "2026-2027",
+            AcademicPeriodAction.SKIP,
+            None,
+            0,
+            "skipped",
+        ),
+    )
+
+    result = setup_cli.collect_setup_plan(
+        current,
+        services=fake_services(),
+        input_fn=input_reader(
+            ["eng10", str(tmp_path / "roster.csv"), "", "", "2"]
+        ),
+        clock=lambda: datetime(2026, 8, 20, tzinfo=UTC),
+    )
+
+    assert result.plan is not None
+    assert result.plan.rosters[0].action is RosterAction.REPLACE
+
+
+def test_collect_academic_periods_requires_all_explicit_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    current = fake_assessment(tmp_path, active_year="2026-2027")
+    observed_periods: list[object] = []
+
+    monkeypatch.setattr(
+        setup_cli,
+        "plan_school_year",
+        lambda *args, **kwargs: school_plan(
+            disposition=SchoolYearDisposition.EXISTING_MATCH
+        ),
+    )
+
+    def fake_period_plan(
+        _assessment: object,
+        year: str,
+        period_values: object,
+        **_kwargs: object,
+    ) -> AcademicPeriodPlan:
+        if period_values is None:
+            return AcademicPeriodPlan(
+                year,
+                AcademicPeriodAction.SKIP,
+                None,
+                0,
+                "skipped",
+            )
+        observed_periods.extend(cast(list[object], period_values))
+        return AcademicPeriodPlan(
+            year,
+            AcademicPeriodAction.CREATE,
+            FakeCalendar(year, 1, (object(),)),
+            1,
+            "valid",
+        )
+
+    monkeypatch.setattr(setup_cli, "plan_academic_periods", fake_period_plan)
+
+    result = setup_cli.collect_setup_plan(
+        current,
+        services=fake_services(),
+        input_fn=input_reader(
+            [
+                "",
+                "",
+                "1",
+                "q1",
+                "quarter",
+                "Quarter 1",
+                "2026-09-01",
+                "2026-11-01",
+                "",
+                "not-an-int",
+                "1",
+                "planned",
+                "n",
+            ]
+        ),
+        clock=lambda: datetime(2026, 8, 20, tzinfo=UTC),
+    )
+
+    assert result.plan is not None
+    assert result.plan.academic_periods is not None
+    assert result.plan.academic_periods.action is AcademicPeriodAction.CREATE
+    assert observed_periods == [
+        {
+            "period_id": "q1",
+            "period_type": "quarter",
+            "label": "Quarter 1",
+            "start_date": "2026-09-01",
+            "end_date": "2026-11-01",
+            "parent_period_id": None,
+            "sequence": 1,
+            "lifecycle": "planned",
+        }
+    ]
+    output = capsys.readouterr().out
+    assert "Allowed period types: quarter, semester" in output
+    assert "sequence must be an integer" in output
+
+
+def test_collect_cancellation_returns_no_plan(
+    tmp_path: Path,
+) -> None:
+    result = setup_cli.collect_setup_plan(
+        fake_assessment(tmp_path),
+        services=fake_services(),
+        input_fn=input_reader(["Q"]),
+        clock=lambda: datetime(2026, 8, 20, tzinfo=UTC),
+    )
+
+    assert result.cancelled is True
+    assert result.plan is None
+
+
+def test_run_setup_cancel_never_loads_apply_writer_services(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    current = fake_assessment(tmp_path, active_year="2026-2027")
+    planning = cast(
+        CoreClassroomPlanningServices,
+        SimpleNamespace(readers=object()),
+    )
+    plan = SharedSetupPlan(
+        school_plan(disposition=SchoolYearDisposition.EXISTING_MATCH),
+        (),
+        (),
+        None,
+        None,
+    )
+    monkeypatch.setattr(setup_cli, "assess_shared_setup", lambda **kwargs: current)
+    monkeypatch.setattr(
+        setup_cli,
+        "collect_setup_plan",
+        lambda *args, **kwargs: setup_cli.SetupCollectionResult(plan, False),
+    )
+    monkeypatch.setattr(
+        setup_cli,
+        "review_setup_plan",
+        lambda *args, **kwargs: setup_cli.SetupReviewDecision.CANCEL,
+    )
+    apply_loads: list[str] = []
+
+    def load_apply():
+        apply_loads.append("loaded")
+        return object()
+
+    result = setup_cli.run_classroom_setup(
+        planning_services=planning,
+        apply_services_loader=load_apply,  # type: ignore[arg-type]
+    )
+
+    assert result == 0
+    assert apply_loads == []
+    assert "No setup changes were made" in capsys.readouterr().out
+
+
+def test_run_setup_loads_apply_services_only_after_apply_decision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from paper_data_suite.classroom_apply import SetupApplyResult
+
+    current = fake_assessment(tmp_path, active_year="2026-2027")
+    planning = cast(
+        CoreClassroomPlanningServices,
+        SimpleNamespace(readers=object()),
+    )
+    plan = SharedSetupPlan(
+        school_plan(disposition=SchoolYearDisposition.EXISTING_MATCH),
+        (),
+        (),
+        None,
+        None,
+    )
+    apply_services = object()
+    events: list[str] = []
+    monkeypatch.setattr(setup_cli, "assess_shared_setup", lambda **kwargs: current)
+    monkeypatch.setattr(
+        setup_cli,
+        "collect_setup_plan",
+        lambda *args, **kwargs: setup_cli.SetupCollectionResult(plan, False),
+    )
+    monkeypatch.setattr(
+        setup_cli,
+        "review_setup_plan",
+        lambda *args, **kwargs: setup_cli.SetupReviewDecision.APPLY,
+    )
+
+    def load_apply():
+        events.append("load-writers")
+        return apply_services
+
+    def execute(*args: object, **kwargs: object) -> SetupApplyResult:
+        assert kwargs["services"] is apply_services
+        events.append("execute")
+        return SetupApplyResult((), ())
+
+    monkeypatch.setattr(setup_cli, "execute_shared_setup_plan", execute)
+
+    result = setup_cli.run_classroom_setup(
+        planning_services=planning,
+        apply_services_loader=load_apply,  # type: ignore[arg-type]
+    )
+
+    assert result == 0
+    assert events == ["load-writers", "execute"]
+    assert "No persistent changes were needed" in capsys.readouterr().out

--- a/tests/test_classroom_setup_dispatch.py
+++ b/tests/test_classroom_setup_dispatch.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from paper_data_suite.cli import main
+
+
+def test_setup_help_describes_current_core_workspace_and_review_boundary(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as raised:
+        main(("setup", "--help"))
+
+    assert raised.value.code == 0
+    output = capsys.readouterr().out
+    assert "usage: pds setup" in output
+    assert "currently resolved Core workspace" in output
+    assert "exact APPLY" in output
+
+
+def test_setup_dispatches_complete_guided_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.cli as cli
+
+    calls: list[str] = []
+
+    def run_setup() -> int:
+        calls.append("setup")
+        return 7
+
+    monkeypatch.setattr(cli, "run_classroom_setup", run_setup)
+
+    assert main(("setup",)) == 7
+    assert calls == ["setup"]

--- a/tests/test_smoke_test_classroom_setup_wheel.py
+++ b/tests/test_smoke_test_classroom_setup_wheel.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import smoke_test_classroom_setup_wheel
+
+
+def test_main_invokes_classroom_smoke_with_cli_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "suite.whl"
+    core = tmp_path / "core.whl"
+    observed: list[tuple[Path, Path]] = []
+
+    def fake_smoke(suite_wheel: Path, core_wheel: Path) -> None:
+        observed.append((suite_wheel, core_wheel))
+
+    monkeypatch.setattr(
+        smoke_test_classroom_setup_wheel,
+        "smoke_test_classroom_setup_wheel",
+        fake_smoke,
+    )
+
+    assert smoke_test_classroom_setup_wheel.main((str(suite), str(core))) == 0
+    assert observed == [(suite, core)]
+    assert capsys.readouterr().out.strip() == (
+        "Classroom setup wheel smoke test passed."
+    )
+
+
+def test_main_returns_failure_when_classroom_smoke_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "suite.whl"
+    core = tmp_path / "core.whl"
+
+    def fail_smoke(suite_wheel: Path, core_wheel: Path) -> None:
+        del suite_wheel, core_wheel
+        raise smoke_test_classroom_setup_wheel.ClassroomSetupSmokeTestError(
+            "synthetic failure"
+        )
+
+    monkeypatch.setattr(
+        smoke_test_classroom_setup_wheel,
+        "smoke_test_classroom_setup_wheel",
+        fail_smoke,
+    )
+
+    assert smoke_test_classroom_setup_wheel.main((str(suite), str(core))) == 1
+    assert "synthetic failure" in capsys.readouterr().err
+
+
+def test_isolated_command_env_removes_workspace_and_pythonpath_variants(
+    tmp_path: Path,
+) -> None:
+    result = smoke_test_classroom_setup_wheel._isolated_command_env(
+        {
+            "PATH": "synthetic",
+            "PYTHONPATH": "source-a",
+            "PythonPath": "source-b",
+            "PDS_WORKSPACE_ROOT": "real-workspace",
+        },
+        user_home=tmp_path / "user",
+    )
+
+    assert result["PATH"] == "synthetic"
+    assert all(key.upper() != "PYTHONPATH" for key in result)
+    assert all(key.upper() != "PDS_WORKSPACE_ROOT" for key in result)
+    assert result["PYTHONNOUSERSITE"] == "1"
+    assert result["HOME"] == str(tmp_path / "user")
+    assert result["USERPROFILE"] == str(tmp_path / "user")
+
+
+def test_state_assertion_accepts_minimal_cancelled_setup(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    payload = {
+        "root": str(root.resolve()),
+        "active_school_year": None,
+        "class_count": 0,
+        "standards_count": 0,
+        "profile_count": 0,
+        "calendar_revision": None,
+    }
+
+    smoke_test_classroom_setup_wheel._assert_state(
+        payload,
+        root=root,
+        active_school_year=None,
+    )
+
+
+def test_setup_plan_artifact_assertion_rejects_persisted_plan(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "suite-setup-plan.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(
+        smoke_test_classroom_setup_wheel.ClassroomSetupSmokeTestError,
+        match="setup-plan artifact",
+    ):
+        smoke_test_classroom_setup_wheel._assert_no_setup_plan_artifacts(root)


### PR DESCRIPTION
## Summary

Implements #9 by adding the suite-level guided shared classroom setup workflow:

```text
pds setup
```

with equivalent module invocation:

```text
python -m paper_data_suite setup
```

The workflow coordinates the exact suite-qualified public PDS Core APIs for:

- active school-year setup;
- class creation and shared class metadata;
- roster import;
- shared standards setup; and
- initial Academic Period calendar configuration.

The suite remains an orchestration/presentation layer. Core continues to own canonical models, validation, identifiers, paths, and persistence.

Closes #9.

## What this adds

- read-only assessment of the currently resolved Core workspace and existing shared classroom state;
- exact Core qualification through the suite compatibility manifest before setup operations;
- in-memory setup planning with domain-specific NEW / KEEP / REPLACE / CONFLICT / REFUSE behavior;
- guided teacher-facing collection and review;
- stable final `APPLY` / `E` / `Q` interaction;
- persistent writes only after exact uppercase `APPLY`;
- fresh preflight validation immediately before the first mutation;
- drift detection for reviewed workspace/shared state and roster sources;
- post-write verification through Core after each setup domain;
- truthful partial-success reporting without synthetic rollback;
- safe/idempotent rerun behavior;
- `pds setup --help` and module-form CLI dispatch;
- dedicated operational documentation and README first-time pilot guidance;
- dedicated installed-wheel classroom-setup acceptance coverage.

## School year

- requires an explicit consecutive `YYYY-YYYY` value;
- delegates validation to Core;
- treats the same active year as idempotent;
- refuses a conflicting open school year rather than replacing or closing it implicitly;
- generates operational timestamps only at the write boundary.

No school year is inferred from the date, workspace, roster, calendar, locale, or other context.

## Classes

- requires explicit Core-valid `class_id` values;
- binds metadata to the explicitly selected school year;
- uses Core class metadata factories and writers;
- preserves legitimate existing `module_details`;
- distinguishes new, matching, and conflicting existing class state;
- refuses silent `class.json` replacement.

No course, period, room, teacher, section, or module configuration is invented.

## Rosters

- loads teacher-selected CSV files through Core's canonical roster parser;
- preserves Core's required identity and validation rules;
- does not rewrite headers, infer IDs, split mixed-class files, or deduplicate by name;
- verifies imported `class_id` rather than replacing it with the selected target;
- compares students by `student_id` within the class;
- reports new, unchanged, conflicting-existing, and removed-existing counts;
- treats materially identical imports as KEEP;
- presents differing existing rosters as explicit whole-roster REPLACE actions;
- keeps Core overwrite protection enabled unless that reviewed replacement is actually applied;
- avoids printing roster contents or sensitive offending values in validation diagnostics.

## Standards

- exposes only Core-provided starter standards packs;
- displays Core-provided pack metadata and counts;
- never auto-selects NJSLS or any other jurisdiction/course pack;
- performs the preview with Core's in-memory merge using `overwrite_conflicts=False`;
- treats no-change installs as idempotent;
- refuses conflicting existing standards/profile replacement.

## Academic Periods

- requires explicit values for every Core-required period field;
- does not infer structure, dates, lifecycle, parent relationships, IDs, or labels;
- validates each period and the complete hierarchy through Core;
- shows the complete proposed calendar during final review;
- allows setup to be skipped;
- keeps an existing current calendar unchanged rather than acting as a general revision editor;
- creates a new calendar as revision `1` using Core expected-current-revision protection.

## APPLY safety

No persistent setup state is written before exact final `APPLY`.

Writer-capable Core services are loaded only at the APPLY boundary.

Before the first write, the executor performs a fresh read-only preflight and refuses execution if reviewed state has drifted.

Writes are then sequenced in the required order:

1. school year;
2. class folders/metadata;
3. rosters;
4. standards;
5. Academic Period calendar.

Each successful step is re-read and verified through Core.

The workflow is deliberately not represented as one cross-domain transaction. If a later operation fails, the command reports what actually completed and what failed, does not claim rollback, and supports a safe rerun.

## Core integration

All canonical shared-state persistence uses public Core services.

The suite does not directly author:

- school-year state;
- `class.json`;
- `roster.csv`;
- `standards/library.json`;
- Academic Period JSON.

This work also corrects the integration boundary for `load_class_roster`, using its actual public Core v0.6.0 owner:

```text
pds_core.classes
```

rather than `pds_core.rosters`.

## Documentation

Adds:

```text
docs/operations/shared-classroom-setup.md
```

and updates the README with:

- `pds setup`;
- module-form invocation;
- setup safety semantics;
- first-time pilot workflow;
- installed-wheel validation instructions.

## Validation

Source-tree validation:

```text
393 passed, 4 skipped
```

Additional checks passed:

```text
python -m ruff check .
python -m mypy
git diff --check
python -m pip check
python .\scripts\validate_compatibility_manifest.py
```

Packaging succeeded:

```text
python -m build
python -m twine check .\dist\*
```

Built-wheel acceptance passed:

```text
python .\scripts\check_package.py <suite-wheel>
python .\scripts\smoke_test_wheel.py <suite-wheel> <core-wheel>
python .\scripts\smoke_test_workspace_wheel.py <suite-wheel> <core-wheel>
python .\scripts\smoke_test_classroom_setup_wheel.py <suite-wheel> <core-wheel>
```

The dedicated classroom-setup wheel smoke verifies the installed distribution outside the source tree, including cancellation/no-write behavior, exact `APPLY`, Core-owned persisted state, absence of suite-owned setup-plan artifacts, and idempotent rerun behavior.

## Notes

- Tests use synthetic classroom data only.
- No sibling PDS application is required for repository-local or installed-wheel classroom setup acceptance.
- Merge should remain contingent on the repository's supported CI jobs, including the dedicated installed-wheel setup acceptance, passing.