### PR TITLE
feat: add protected workspace backup creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ There is **no supported public v0.1.0 release yet**. The package foundation is
 installable. The shell now provides read-only environment diagnostics through
 `pds doctor`, suite-qualified application inventory through `pds modules`,
 verified out-of-process application launching through `pds launch <component-id>`,
-Core-backed workspace selection/validation through `pds workspace`, and guided
-shared classroom setup through `pds setup`. Additional teacher-facing workflows
-are added by later v0.1.0 issues.
+Core-backed workspace selection/validation through `pds workspace`, guided shared
+classroom setup through `pds setup`, and verified whole-workspace backup creation
+through `pds backup create`. Additional teacher-facing workflows are added by
+later v0.1.0 issues.
 
 The package metadata requires Python 3.11 or newer and
 `pds-core>=0.6,<0.7`. Those broad package requirements do **not** by themselves
@@ -225,6 +226,7 @@ pds doctor
 pds workspace setup
 pds doctor
 pds setup
+pds backup create --destination <protected-backup-location>
 pds modules
 ```
 
@@ -238,6 +240,49 @@ The operational contract, duplicate/conflict rules, APPLY ordering, privacy
 boundaries, partial-success behavior, and installed-wheel acceptance are documented
 in
 [`docs/operations/shared-classroom-setup.md`](docs/operations/shared-classroom-setup.md).
+
+## Workspace backup creation
+
+Create a timestamped, non-overwriting whole-workspace backup with:
+
+```powershell
+pds backup create --destination "D:\PDS Backups"
+```
+
+Equivalent module invocation:
+
+```powershell
+python -m paper_data_suite backup create --destination "D:\PDS Backups"
+```
+
+The source is always the workspace currently resolved by Core. The suite treats
+backup as opaque byte custody: it inventories ordinary files and empty directories,
+streams file bytes without parsing owner records, calculates SHA-256 hashes, checks
+destination containment and free space, detects observed source drift, verifies the
+staged payload, and only then publishes a completed timestamped backup.
+
+Interactive creation requires exact uppercase `BACKUP`. `--yes` is available for
+deliberate noninteractive use with the required explicit destination; it bypasses
+the prompt only, not safety or verification checks. Cancellation creates no backup.
+
+Backup v1 has no module-aware or user-configurable source exclusions. Links,
+junction-like redirection, unsupported special entries, unsafe source/destination
+relationships, insufficient free space, collisions, and verification failures are
+refused rather than silently ignored.
+
+A backup is another complete copy of potentially sensitive classroom data. PDS does
+not encrypt, upload, or cloud-sync it. SHA-256 provides integrity evidence, not
+confidentiality or digital-signature authenticity. External synchronization of a
+chosen OneDrive or other managed folder remains behavior of that storage system,
+not PDS.
+
+Issue #10 implements creation-time self-verification only. Standalone backup
+verification and restore-to-an-explicit-alternate-location belong to the following
+backup/restore issue.
+
+The manifest/layout contract, privacy boundary, staging/publication model, source
+consistency limits, and installed-wheel acceptance are documented in
+[`docs/operations/workspace-backup.md`](docs/operations/workspace-backup.md).
 
 ## Architecture direction
 
@@ -283,6 +328,8 @@ pds --help
 pds --version
 pds doctor
 pds doctor --workspace <path>
+pds backup
+pds backup create --destination <path> [--yes]
 pds modules
 pds launch <component-id>
 pds setup
@@ -296,6 +343,8 @@ python -m paper_data_suite
 python -m paper_data_suite --help
 python -m paper_data_suite --version
 python -m paper_data_suite doctor
+python -m paper_data_suite backup
+python -m paper_data_suite backup create --destination <path> [--yes]
 python -m paper_data_suite modules
 python -m paper_data_suite launch <component-id>
 python -m paper_data_suite setup
@@ -306,15 +355,16 @@ python -m paper_data_suite workspace set <path>
 python -m paper_data_suite workspace reset
 ```
 
-The help/version commands, `doctor`, `modules`, and `workspace show` do not
-create or select a workspace or perform classroom-data mutation.
+The help/version commands, `doctor`, `modules`, `workspace show`, and `backup`
+help do not create or select a workspace or perform classroom-data mutation.
 `doctor --workspace` is an invocation-scoped inspection override only.
 `workspace validate` validates an existing candidate without initializing or
 saving it; `workspace setup`, `set`, and `reset` are the explicit workspace
 mutation surfaces. `pds setup` is the explicit shared-classroom mutation surface
-and remains read-only until exact final `APPLY`. `launch` crosses only the verified
-public application boundary; module-owned behavior remains owned by the launched
-application.
+and remains read-only until exact final `APPLY`. `pds backup create` leaves the
+source workspace read-only and creates an external copy only after exact `BACKUP`
+or explicit `--yes`. `launch` crosses only the verified public application boundary;
+module-owned behavior remains owned by the launched application.
 
 ## Development validation
 
@@ -339,6 +389,7 @@ python .\scripts\check_package.py <suite-wheel>
 python .\scripts\smoke_test_wheel.py <suite-wheel> <core-wheel>
 python .\scripts\smoke_test_workspace_wheel.py <suite-wheel> <core-wheel>
 python .\scripts\smoke_test_classroom_setup_wheel.py <suite-wheel> <core-wheel>
+python .\scripts\smoke_test_workspace_backup_wheel.py <suite-wheel> <core-wheel>
 ```
 
 The Core-only smoke proves legitimate partial installation behavior. The dedicated
@@ -347,9 +398,13 @@ workspace show/validate/setup/set/reset behavior without touching the developer'
 real Core configuration or workspace. The dedicated classroom setup smoke uses a
 separate isolated profile to prove exact-`APPLY` authorization, cancellation with
 no classroom mutation, Core-owned school-year application, absence of persisted
-suite setup-plan artifacts, and idempotent reruns. To exercise the complete
-suite-qualified application composition, place every exact component
-wheel declared by the manifest in one artifact directory and run:
+suite setup-plan artifacts, and idempotent reruns. The dedicated workspace-backup
+smoke uses another isolated profile to prove module/console command installation,
+mutation-free cancellation, inside-workspace refusal, source immutability, complete
+opaque payload/hash inventory, manifest privacy, non-overwrite collision behavior,
+and absence of sibling-module requirements. To exercise the complete
+suite-qualified application composition, place every exact component wheel declared
+by the manifest in one artifact directory and run:
 
 ```powershell
 python .\scripts\smoke_test_application_wheels.py `
@@ -396,6 +451,9 @@ Do not place a real classroom PDS workspace inside this repository.
   — Core-backed workspace selection, validation, guided setup, and reset.
 - [`docs/operations/shared-classroom-setup.md`](docs/operations/shared-classroom-setup.md)
   — guided school-year, class, roster, standards, and Academic Period setup.
+- [`docs/operations/workspace-backup.md`](docs/operations/workspace-backup.md)
+  — whole-workspace opaque backup creation, deterministic manifest, safety, and
+  acceptance.
 - [`docs/development-plan.md`](docs/development-plan.md) — suite-wide
   pilot-readiness and development program.
 - [`docs/pds-viz-identity.md`](docs/pds-viz-identity.md) — shared Paper Data

--- a/docs/operations/workspace-backup.md
+++ b/docs/operations/workspace-backup.md
@@ -1,0 +1,417 @@
+# Workspace backup creation
+
+## Purpose
+
+`pds backup create` creates one complete, timestamped copy of the currently
+resolved Paper Data Suite workspace in an explicit external directory.
+
+The backup feature is a suite-shell **opaque-custody** operation. It may enumerate,
+copy, hash, and inventory workspace bytes, but it does not acquire semantic
+ownership of Core- or module-owned records.
+
+The controlling architecture rule is:
+
+```text
+opaque byte custody != semantic record ownership
+```
+
+Backup creation does not parse, normalize, repair, merge, or reinterpret records.
+Unknown future module directories are backed up the same way as known ones.
+
+## Commands
+
+Interactive creation:
+
+```powershell
+pds backup create --destination "D:\PDS Backups"
+```
+
+Equivalent module invocation:
+
+```powershell
+python -m paper_data_suite backup create --destination "D:\PDS Backups"
+```
+
+For deliberate noninteractive use:
+
+```powershell
+pds backup create --destination "D:\PDS Backups" --yes
+```
+
+`--destination` is always required and names the **parent directory** under which
+PDS creates a new timestamped backup. There is no `--source` option. The source is
+always the workspace currently resolved by Core.
+
+Running:
+
+```powershell
+pds backup
+```
+
+shows the available backup subcommands.
+
+## Core qualification and source resolution
+
+The suite first loads its bundled release-compatibility manifest and requires the
+exact Core version qualified by that suite release. For the current development
+manifest, that is `pds-core==0.6.0`; the broader package dependency
+`pds-core>=0.6,<0.7` does not independently qualify other Core versions.
+
+The suite then uses public `pds_core.workspace.inspect_workspace_root` behavior to
+obtain the current workspace and its resolution source. Backup creation does not:
+
+- initialize a missing workspace;
+- select a different workspace;
+- save another workspace preference;
+- invoke Core's write-probing workspace validator merely to prove source
+  writability; or
+- require the source workspace to be writable.
+
+The source must exist and be a directory. Actual readability is proven by the
+inventory/copy operation itself.
+
+## Review-before-copy boundary
+
+Before creating any destination directory, the command performs a read-only
+preflight and shows a bounded summary containing:
+
+- resolved workspace;
+- Core resolution source;
+- destination parent;
+- proposed final backup path;
+- directory count;
+- file count;
+- total payload bytes;
+- destination free bytes;
+- minimum required free bytes; and
+- backup format version.
+
+The preview does not list individual files, student names, student IDs, grades,
+roster rows, per-file hashes, or record contents.
+
+Interactive creation requires exact uppercase:
+
+```text
+BACKUP
+```
+
+`Q`, end-of-input, or keyboard interruption cancels without creating a backup.
+Other input is rejected and the confirmation prompt is repeated.
+
+`--yes` bypasses only the prompt. It does not bypass compatibility, containment,
+space, collision, filesystem-entry, source-drift, hashing, or verification checks.
+
+## Sensitive-data warning
+
+A whole-workspace backup contains the same potentially sensitive classroom data as
+the source workspace.
+
+PDS does **not** encrypt the backup. SHA-256 hashes provide integrity evidence;
+they do not provide confidentiality and are not digital signatures.
+
+PDS also does not upload or cloud-sync backups. If the explicit destination is
+inside a OneDrive, Google Drive, Dropbox, network-sync, removable-media, or other
+externally managed location, synchronization and access behavior belong to that
+external storage system. Use only a teacher-controlled or institutionally approved
+location appropriate for the data being copied.
+
+No telemetry or remote backup service is used.
+
+## Backup naming and layout
+
+Completed backups use a UTC timestamp with microseconds:
+
+```text
+pds-workspace-backup-YYYYMMDDTHHMMSSffffffZ
+```
+
+For example:
+
+```text
+pds-workspace-backup-20260820T174812123456Z
+```
+
+A completed backup has this layout:
+
+```text
+<destination-parent>/
+  pds-workspace-backup-<timestamp>/
+    manifest.json
+    workspace/
+      <opaque workspace copy>
+```
+
+`manifest.json` is suite-owned backup metadata. It is deliberately outside the
+`workspace/` payload so the payload remains the copied workspace tree rather than a
+workspace modified by backup metadata.
+
+If the exact timestamped final path already exists, creation fails. PDS never
+chooses overwrite as a collision policy.
+
+## Manifest v1 contract
+
+The v1 manifest declares:
+
+```text
+record_type = "pds_workspace_backup_manifest"
+schema_version = "1"
+payload_root = "workspace"
+hash_algorithm = "sha256"
+```
+
+Its fields are:
+
+```text
+record_type
+schema_version
+backup_id
+created_at
+suite_version
+core_version
+payload_root
+hash_algorithm
+directory_count
+file_count
+total_bytes
+directories
+files
+exclusions
+```
+
+Each file entry contains only:
+
+```text
+path
+size
+sha256
+```
+
+The manifest does not store file contents or parsed academic/student data. It does
+not record the absolute source workspace path.
+
+### Deterministic serialization
+
+For the same source byte tree, creation timestamp, suite/Core versions, and schema
+version, manifest serialization is deterministic:
+
+- directories are sorted;
+- file entries are sorted by canonical relative path;
+- paths use `/` separators;
+- JSON keys are sorted;
+- UTF-8 is used;
+- SHA-256 digests use lowercase hexadecimal;
+- serialization ends with one newline; and
+- no process ID, random staging value, access time, or enumeration order enters the
+  portable manifest.
+
+`backup_id` derives from the timestamped backup name. Randomness is used only for
+temporary `.incomplete-*` staging identity and is never persisted in the manifest.
+
+### Portable path grammar
+
+Manifest v1 paths are relative POSIX-style path strings. They may not contain:
+
+- absolute/rooted syntax;
+- `.` or `..` path segments;
+- repeated or trailing `/` separators;
+- backslashes;
+- colons; or
+- ASCII control characters.
+
+Backslashes and colons are rejected even on platforms where they could be ordinary
+filename characters. This prevents a backup created on one platform from producing
+an ambiguous or traversal-capable path when a later restore is evaluated on
+Windows. A workspace containing a path that cannot be represented safely in the v1
+portable grammar is refused rather than silently omitting that entry.
+
+## Whole-workspace inclusion policy
+
+Manifest v1 has no user-configurable or module-specific source exclusions.
+`exclusions` is therefore an explicit empty array.
+
+Ordinary files are included regardless of extension, producer, hidden status, or
+whether the shell recognizes their domain. Empty directories are preserved.
+
+The shell does not omit paths such as `.pds/`, `classes/`, `settings/`, scans, or
+module-owned work trees because it believes they are unimportant or derived.
+
+## Links, junctions, reparse points, and special files
+
+Backup v1 supports ordinary directories and regular files.
+
+Traversal does not intentionally follow:
+
+- symbolic links;
+- Windows junction/mount-point redirection; or
+- other recognized redirecting reparse entries.
+
+Such source entries are refused rather than dereferenced or silently skipped.
+Unsupported special filesystem entries are also refused.
+
+Windows cloud-provider reparse metadata is not categorically treated as a junction:
+the safety rule targets filesystem redirection rather than all reparse-backed local
+files. Ordinary locally readable file bytes may therefore be hydrated by the host
+filesystem when read.
+
+## Source/destination containment
+
+The destination is canonicalized and checked against the canonical Core workspace.
+The backup destination and final backup root must remain outside the workspace.
+PDS refuses equivalent/aliased paths, a destination inside the source, and a final
+backup path that would contain the source.
+
+For a destination that does not yet exist, preflight resolves its nearest existing
+directory for free-space inspection without creating the requested destination.
+After confirmation, PDS creates/re-resolves the destination and repeats containment
+checks before creating staging state. This protects against a destination path that
+resolves differently after review.
+
+Containment is based on path semantics, not string-prefix comparison.
+
+## Free-space preflight
+
+V1 copies ordinary bytes without assuming compression. The conservative threshold
+is:
+
+```text
+required_free_bytes =
+    total_payload_bytes
+    + max(64 MiB, ceil(total_payload_bytes * 0.02))
+```
+
+Creation is refused when reported destination free space is below this threshold.
+The check is repeated after confirmation because free space may have changed.
+
+The check is a safeguard, not a reservation. A later disk-full error still fails the
+backup safely.
+
+## Staging, verification, and publication
+
+The final timestamped name is not used as a work directory. After confirmation,
+PDS creates an exclusive sibling staging directory with a name conceptually like:
+
+```text
+.<backup-id>.incomplete-<nonce>
+```
+
+The nonce is temporary and not part of backup identity.
+
+Within staging, PDS:
+
+1. recreates the inventoried directory tree;
+2. streams each regular source file into `workspace/` in bounded chunks;
+3. calculates SHA-256 from the bytes written;
+4. flushes/fsyncs each copied file;
+5. re-inventories and re-hashes the source to detect observed drift;
+6. independently inventories and re-hashes the staged payload;
+7. builds and validates the deterministic manifest;
+8. writes the manifest and reads it back for validation; and
+9. only then promotes verified staging to the final timestamped backup name.
+
+An existing completed backup is never deliberately replaced. A competing completed
+PDS backup is non-empty, so a same-name publication race also fails rather than
+replacing that completed tree on supported platforms.
+
+On a handled failure, PDS removes the staging tree best-effort. If cleanup fails,
+the command reports the remaining `.incomplete-*` location. An interrupted process
+may likewise leave incomplete staging. That directory is **not** a completed backup
+and must not be treated as one.
+
+PDS does not automatically remove unrelated or older incomplete staging directories.
+
+## Source consistency limits
+
+Paper Data Suite currently has no suite-wide snapshot transaction or global lock
+honored by every Core/module writer. Backup therefore does not claim to be an
+operating-system point-in-time snapshot.
+
+The implementation instead detects observed change through inventory and SHA-256
+rechecks. If the workspace changes during creation, completion is refused and the
+teacher is instructed to close active PDS workflows and retry.
+
+For the strongest practical result, close active PDS application workflows before
+starting a backup.
+
+This drift-detection model is not a substitute for adversarial filesystem isolation
+against another process with permission to rewrite paths during every individual
+system call.
+
+## Completion output
+
+A successful command reports only bounded operational facts:
+
+- source workspace;
+- final backup path;
+- directory/file counts;
+- payload byte count;
+- creation time; and
+- SHA-256 of the serialized manifest.
+
+It does not dump the manifest inventory or student-bearing file names.
+
+Exit behavior is:
+
+```text
+0  completed backup or explicit cancellation
+1  safely refused or failed backup
+2  argparse/usage error
+```
+
+`Workspace backup complete` is printed only after verified staging has been
+published at the final backup path.
+
+## Restore boundary
+
+Issue #10 implements **creation-time self-verification only**. It does not claim that
+a backup can yet be restored.
+
+The following backup/restore issue owns:
+
+```text
+pds backup verify
+pds backup restore
+```
+
+That work must independently validate this manifest/inventory/hashes and restore only
+to an explicit alternate safe location. A restored workspace must not become the
+selected Core workspace automatically.
+
+## Installed-wheel acceptance
+
+`scripts/smoke_test_workspace_backup_wheel.py` validates backup creation from built
+suite/Core wheels in an isolated virtual environment and user profile. It proves,
+with synthetic data only, that:
+
+- both console and module command surfaces are installed;
+- no sibling PDS application is required;
+- cancellation creates no backup;
+- an inside-workspace destination is refused;
+- an external backup leaves the source byte tree unchanged;
+- hidden, binary, zero-byte, unknown-module, and empty-directory content is copied;
+- the manifest independently matches the source inventory and hashes;
+- no unlisted payload entry appears;
+- the serialized manifest does not contain the source absolute path;
+- a pre-existing deterministic backup identity is not overwritten; and
+- the smoke working directory remains clean.
+
+## Non-goals
+
+Backup creation does not provide:
+
+- restore;
+- a standalone verification command;
+- in-place active-workspace replacement;
+- automatic selection of restored workspaces;
+- ZIP/TAR archives;
+- compression;
+- encryption or password management;
+- cloud-provider APIs;
+- scheduled backups;
+- retention/pruning;
+- incremental/differential backups;
+- deduplication;
+- module-aware selective backup;
+- user-defined exclusion globs;
+- domain-record validation or repair;
+- VSS or other operating-system snapshots; or
+- a global cross-module write lock.

--- a/paper_data_suite/cli.py
+++ b/paper_data_suite/cli.py
@@ -28,6 +28,7 @@ from paper_data_suite.compatibility import (
     load_release_compatibility_manifest,
 )
 from paper_data_suite.doctor import collect_doctor_diagnostics, render_doctor_report
+from paper_data_suite.workspace_backup_cli import run_workspace_backup_create
 from paper_data_suite.workspace_cli import (
     run_workspace_reset,
     run_workspace_set,
@@ -112,6 +113,38 @@ def build_parser() -> argparse.ArgumentParser:
     workspace_subparsers.add_parser(
         "reset",
         help="clear only Core's saved workspace preference",
+    )
+    backup = subparsers.add_parser(
+        "backup",
+        help="create protected whole-workspace backups",
+        description=(
+            "Create protected whole-workspace backups of the currently resolved "
+            "Core workspace. Backup copies are opaque byte custody: PDS does not "
+            "rewrite owner records, encrypt, upload, or cloud-sync them."
+        ),
+    )
+    backup.set_defaults(backup_parser=backup)
+    backup_subparsers = backup.add_subparsers(dest="backup_command")
+    backup_create = backup_subparsers.add_parser(
+        "create",
+        help="create one timestamped non-overwriting workspace backup",
+        description=(
+            "Create a timestamped, non-overwriting backup of the currently resolved "
+            "Core workspace. --destination is the explicit parent directory for the "
+            "new backup. The backup contains the same potentially sensitive data as "
+            "the workspace. PDS does not encrypt, upload, or cloud-sync the backup."
+        ),
+    )
+    backup_create.add_argument(
+        "--destination",
+        required=True,
+        type=Path,
+        help="explicit parent directory under which the timestamped backup is created",
+    )
+    backup_create.add_argument(
+        "--yes",
+        action="store_true",
+        help="create after preflight without the interactive BACKUP confirmation",
     )
     subparsers.add_parser(
         "setup",
@@ -313,6 +346,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise AssertionError(
             f"unhandled workspace command: {arguments.workspace_command}"
         )
+    if arguments.command == "backup":
+        if arguments.backup_command is None:
+            arguments.backup_parser.print_help()
+            return 0
+        if arguments.backup_command == "create":
+            return run_workspace_backup_create(
+                arguments.destination,
+                assume_yes=arguments.yes,
+            )
+        raise AssertionError(f"unhandled backup command: {arguments.backup_command}")
     if arguments.command == "setup":
         return run_classroom_setup()
     if arguments.command == "modules":

--- a/paper_data_suite/workspace_backup.py
+++ b/paper_data_suite/workspace_backup.py
@@ -1,0 +1,1378 @@
+"""Planning, manifest, and safe creation for whole-workspace backups.
+
+Backup is the suite architecture's opaque-custody exception: this module may
+enumerate and copy workspace files as bytes, but it never parses or rewrites
+Core- or module-owned records.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import shutil
+import stat
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib import import_module, metadata
+from pathlib import Path, PurePosixPath
+from typing import Final, Protocol, cast
+
+from paper_data_suite._version import __version__
+from paper_data_suite.compatibility import (
+    ReleaseCompatibilityManifest,
+    load_release_compatibility_manifest,
+)
+from paper_data_suite.component_inspection import DistributionVersionLookup
+from paper_data_suite.workspace_setup import (
+    CoreWorkspaceQualificationError,
+    WorkspaceInspector,
+    load_core_workspace_services,
+)
+
+BACKUP_MANIFEST_RECORD_TYPE: Final[str] = "pds_workspace_backup_manifest"
+BACKUP_MANIFEST_SCHEMA_VERSION: Final[str] = "1"
+BACKUP_PAYLOAD_ROOT: Final[str] = "workspace"
+BACKUP_HASH_ALGORITHM: Final[str] = "sha256"
+BACKUP_NAME_PREFIX: Final[str] = "pds-workspace-backup-"
+BACKUP_MINIMUM_RESERVE_BYTES: Final[int] = 64 * 1024 * 1024
+BACKUP_RESERVE_PERCENT: Final[int] = 2
+BACKUP_MANIFEST_FILENAME: Final[str] = "manifest.json"
+BACKUP_COPY_CHUNK_BYTES: Final[int] = 1024 * 1024
+
+_SHA256_RE: Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{64}$")
+_BACKUP_NAME_RE: Final[re.Pattern[str]] = re.compile(
+    r"^pds-workspace-backup-\d{8}T\d{12}Z$"
+)
+_MANIFEST_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "record_type",
+        "schema_version",
+        "backup_id",
+        "created_at",
+        "suite_version",
+        "core_version",
+        "payload_root",
+        "hash_algorithm",
+        "directory_count",
+        "file_count",
+        "total_bytes",
+        "directories",
+        "files",
+        "exclusions",
+    }
+)
+_FILE_ENTRY_KEYS: Final[frozenset[str]] = frozenset({"path", "size", "sha256"})
+
+Clock = Callable[[], datetime]
+ModuleImporter = Callable[[str], object]
+
+
+class WorkspaceBackupError(RuntimeError):
+    """Base class for bounded workspace-backup failures."""
+
+
+class WorkspaceBackupManifestError(WorkspaceBackupError, ValueError):
+    """Raised when a backup manifest violates the v1 contract."""
+
+
+class WorkspaceBackupSourceError(WorkspaceBackupError):
+    """Raised when the currently resolved source workspace cannot be backed up."""
+
+
+class WorkspaceBackupDestinationError(WorkspaceBackupError):
+    """Raised when the requested backup destination is unsafe or unusable."""
+
+
+class WorkspaceBackupUnsupportedEntryError(WorkspaceBackupSourceError):
+    """Raised when source traversal encounters a link or special entry."""
+
+
+class WorkspaceBackupSpaceError(WorkspaceBackupDestinationError):
+    """Raised when destination free space is below the conservative threshold."""
+
+
+class WorkspaceBackupCollisionError(WorkspaceBackupDestinationError):
+    """Raised when the deterministic final backup path already exists."""
+
+
+class WorkspaceBackupDriftError(WorkspaceBackupSourceError):
+    """Raised when the source workspace changes during backup creation."""
+
+
+class WorkspaceBackupCopyError(WorkspaceBackupError):
+    """Raised when opaque payload copying cannot complete safely."""
+
+
+class WorkspaceBackupVerificationError(WorkspaceBackupError):
+    """Raised when copied payload or persisted manifest verification fails."""
+
+
+class WorkspaceBackupPublicationError(WorkspaceBackupError):
+    """Raised when a verified staging backup cannot be published safely."""
+
+
+class DiskUsageLike(Protocol):
+    """Read-only free-space field consumed from a disk-usage provider."""
+
+    @property
+    def free(self) -> int: ...
+
+
+DiskUsageReader = Callable[[str | os.PathLike[str]], DiskUsageLike]
+
+
+def _read_disk_usage(path: str | os.PathLike[str]) -> DiskUsageLike:
+    """Read filesystem usage through the project-owned injectable signature."""
+    return shutil.disk_usage(path)
+
+
+class WorkspaceStatusLike(Protocol):
+    """Public Core workspace status fields consumed by backup planning."""
+
+    root: Path
+    source: str
+    exists: bool
+    is_dir: bool
+
+
+@dataclass(frozen=True, slots=True)
+class CoreBackupServices:
+    """Qualified public Core services/facts required for backup planning."""
+
+    inspect_workspace_root: WorkspaceInspector
+    core_version: str
+
+
+@dataclass(frozen=True, slots=True)
+class BackupSourceFile:
+    """One regular source file discovered during read-only preflight."""
+
+    path: str
+    size: int
+
+    def __post_init__(self) -> None:
+        _validate_relative_manifest_path(self.path, "source file path")
+        if (
+            not isinstance(self.size, int)
+            or isinstance(self.size, bool)
+            or self.size < 0
+        ):
+            raise WorkspaceBackupManifestError("source file size must be >= 0")
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceBackupInventory:
+    """Deterministic read-only source tree inventory before confirmation."""
+
+    directories: tuple[str, ...]
+    files: tuple[BackupSourceFile, ...]
+    total_bytes: int
+
+    def __post_init__(self) -> None:
+        _validate_sorted_unique_paths(self.directories, "directories")
+        file_paths = tuple(entry.path for entry in self.files)
+        _validate_sorted_unique_paths(file_paths, "files")
+        if tuple(sorted(self.files, key=lambda item: item.path)) != self.files:
+            raise WorkspaceBackupManifestError("files must be sorted by relative path")
+        expected_total = sum(entry.size for entry in self.files)
+        if self.total_bytes != expected_total:
+            raise WorkspaceBackupManifestError(
+                "inventory total_bytes does not match file sizes"
+            )
+
+    @property
+    def directory_count(self) -> int:
+        return len(self.directories)
+
+    @property
+    def file_count(self) -> int:
+        return len(self.files)
+
+
+@dataclass(frozen=True, slots=True)
+class BackupFileEntry:
+    """Portable integrity facts for one copied regular payload file."""
+
+    path: str
+    size: int
+    sha256: str
+
+    def __post_init__(self) -> None:
+        _validate_relative_manifest_path(self.path, "file path")
+        if (
+            not isinstance(self.size, int)
+            or isinstance(self.size, bool)
+            or self.size < 0
+        ):
+            raise WorkspaceBackupManifestError("file size must be >= 0")
+        if (
+            not isinstance(self.sha256, str)
+            or _SHA256_RE.fullmatch(self.sha256) is None
+        ):
+            raise WorkspaceBackupManifestError(
+                "file sha256 must be 64 lowercase hexadecimal characters"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceBackupManifest:
+    """Versioned deterministic manifest for one completed workspace backup."""
+
+    record_type: str
+    schema_version: str
+    backup_id: str
+    created_at: datetime
+    suite_version: str
+    core_version: str
+    payload_root: str
+    hash_algorithm: str
+    directory_count: int
+    file_count: int
+    total_bytes: int
+    directories: tuple[str, ...]
+    files: tuple[BackupFileEntry, ...]
+    exclusions: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.record_type != BACKUP_MANIFEST_RECORD_TYPE:
+            raise WorkspaceBackupManifestError(
+                "unsupported backup manifest record_type"
+            )
+        if self.schema_version != BACKUP_MANIFEST_SCHEMA_VERSION:
+            raise WorkspaceBackupManifestError(
+                "unsupported backup manifest schema_version"
+            )
+        if not isinstance(self.backup_id, str) or _BACKUP_NAME_RE.fullmatch(
+            self.backup_id
+        ) is None:
+            raise WorkspaceBackupManifestError(
+                "backup_id is not a canonical backup name"
+            )
+        normalized_created_at = _utc_datetime(self.created_at, "created_at")
+        object.__setattr__(self, "created_at", normalized_created_at)
+        if self.backup_id != backup_name(normalized_created_at):
+            raise WorkspaceBackupManifestError(
+                "backup_id does not match created_at timestamp identity"
+            )
+        for value, field_name in (
+            (self.suite_version, "suite_version"),
+            (self.core_version, "core_version"),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise WorkspaceBackupManifestError(f"{field_name} must not be blank")
+        if self.payload_root != BACKUP_PAYLOAD_ROOT:
+            raise WorkspaceBackupManifestError("payload_root must be 'workspace'")
+        if self.hash_algorithm != BACKUP_HASH_ALGORITHM:
+            raise WorkspaceBackupManifestError("hash_algorithm must be 'sha256'")
+        _validate_sorted_unique_paths(self.directories, "directories")
+        file_paths = tuple(entry.path for entry in self.files)
+        _validate_sorted_unique_paths(file_paths, "files")
+        if tuple(sorted(self.files, key=lambda item: item.path)) != self.files:
+            raise WorkspaceBackupManifestError("files must be sorted by relative path")
+        if self.directory_count != len(self.directories):
+            raise WorkspaceBackupManifestError(
+                "directory_count does not match directories inventory"
+            )
+        if self.file_count != len(self.files):
+            raise WorkspaceBackupManifestError(
+                "file_count does not match files inventory"
+            )
+        if self.total_bytes != sum(entry.size for entry in self.files):
+            raise WorkspaceBackupManifestError("total_bytes does not match file sizes")
+        if self.exclusions != ():
+            raise WorkspaceBackupManifestError(
+                "backup manifest v1 requires an empty source-content exclusions set"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceBackupPlan:
+    """Read-only backup proposal shown before any destination mutation."""
+
+    workspace_root: Path
+    workspace_source: str
+    destination_parent: Path
+    final_backup_root: Path
+    backup_id: str
+    created_at: datetime
+    suite_version: str
+    core_version: str
+    inventory: WorkspaceBackupInventory
+    destination_free_bytes: int
+    required_free_bytes: int
+    destination_parent_exists: bool
+
+    @property
+    def payload_root(self) -> Path:
+        return self.final_backup_root / BACKUP_PAYLOAD_ROOT
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceBackupResult:
+    """Verified completed backup after non-overwriting publication."""
+
+    final_backup_root: Path
+    manifest: WorkspaceBackupManifest
+    manifest_sha256: str
+
+    @property
+    def payload_root(self) -> Path:
+        return self.final_backup_root / BACKUP_PAYLOAD_ROOT
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.final_backup_root / BACKUP_MANIFEST_FILENAME
+
+
+def _utc_datetime(value: datetime, field_name: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise WorkspaceBackupManifestError(f"{field_name} must be a datetime")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise WorkspaceBackupManifestError(f"{field_name} must be timezone-aware")
+    return value.astimezone(timezone.utc)
+
+
+def _format_created_at(value: datetime) -> str:
+    normalized = _utc_datetime(value, "created_at")
+    return normalized.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _parse_created_at(value: object) -> datetime:
+    if not isinstance(value, str):
+        raise WorkspaceBackupManifestError("created_at must be a UTC timestamp string")
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError as error:
+        raise WorkspaceBackupManifestError(
+            "created_at must use YYYY-MM-DDTHH:MM:SS.ffffffZ"
+        ) from error
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def backup_name(created_at: datetime) -> str:
+    """Return the deterministic Windows-safe backup directory identity."""
+    normalized = _utc_datetime(created_at, "created_at")
+    return BACKUP_NAME_PREFIX + normalized.strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def required_backup_free_bytes(total_payload_bytes: int) -> int:
+    """Return the conservative destination free-space threshold."""
+    if (
+        not isinstance(total_payload_bytes, int)
+        or isinstance(total_payload_bytes, bool)
+        or total_payload_bytes < 0
+    ):
+        raise WorkspaceBackupDestinationError("total payload bytes must be >= 0")
+    percent_reserve = (
+        total_payload_bytes * BACKUP_RESERVE_PERCENT + 99
+    ) // 100
+    reserve = max(BACKUP_MINIMUM_RESERVE_BYTES, percent_reserve)
+    return total_payload_bytes + reserve
+
+
+def _validate_relative_manifest_path(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise WorkspaceBackupManifestError(f"{label} must be a non-empty string")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise WorkspaceBackupManifestError(
+            f"{label} must not contain control characters"
+        )
+    if "\\" in value or ":" in value:
+        raise WorkspaceBackupManifestError(
+            f"{label} contains non-portable path syntax"
+        )
+    path = PurePosixPath(value)
+    if path.is_absolute() or value.startswith("/"):
+        raise WorkspaceBackupManifestError(f"{label} must be relative")
+    if value.endswith("/") or "//" in value:
+        raise WorkspaceBackupManifestError(f"{label} is not canonical")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise WorkspaceBackupManifestError(f"{label} must not contain dot segments")
+    if path.as_posix() != value:
+        raise WorkspaceBackupManifestError(f"{label} must use canonical '/' separators")
+    return value
+
+
+def _validate_sorted_unique_paths(values: Sequence[str], label: str) -> None:
+    for value in values:
+        _validate_relative_manifest_path(value, f"{label} path")
+    if tuple(values) != tuple(sorted(values)):
+        raise WorkspaceBackupManifestError(f"{label} must be sorted")
+    if len(values) != len(set(values)):
+        raise WorkspaceBackupManifestError(f"{label} must not contain duplicates")
+
+
+def _duplicate_rejecting_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise WorkspaceBackupManifestError(f"duplicate JSON object key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _mapping(value: object, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or any(not isinstance(key, str) for key in value):
+        raise WorkspaceBackupManifestError(f"{label} must be a JSON object")
+    return cast(Mapping[str, object], value)
+
+
+def _exact_keys(
+    value: Mapping[str, object],
+    expected: frozenset[str],
+    label: str,
+) -> None:
+    actual = frozenset(value)
+    missing = sorted(expected - actual)
+    unknown = sorted(actual - expected)
+    if missing:
+        raise WorkspaceBackupManifestError(
+            f"{label} is missing field(s): {', '.join(missing)}"
+        )
+    if unknown:
+        raise WorkspaceBackupManifestError(
+            f"{label} has unknown field(s): {', '.join(unknown)}"
+        )
+
+
+def _string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise WorkspaceBackupManifestError(f"{label} must be a non-empty string")
+    return value
+
+
+def _integer(value: object, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise WorkspaceBackupManifestError(f"{label} must be an integer >= 0")
+    return value
+
+
+def workspace_backup_manifest_to_dict(
+    manifest: WorkspaceBackupManifest,
+) -> dict[str, object]:
+    """Return the canonical JSON-compatible v1 manifest mapping."""
+    return {
+        "record_type": manifest.record_type,
+        "schema_version": manifest.schema_version,
+        "backup_id": manifest.backup_id,
+        "created_at": _format_created_at(manifest.created_at),
+        "suite_version": manifest.suite_version,
+        "core_version": manifest.core_version,
+        "payload_root": manifest.payload_root,
+        "hash_algorithm": manifest.hash_algorithm,
+        "directory_count": manifest.directory_count,
+        "file_count": manifest.file_count,
+        "total_bytes": manifest.total_bytes,
+        "directories": list(manifest.directories),
+        "files": [
+            {"path": entry.path, "size": entry.size, "sha256": entry.sha256}
+            for entry in manifest.files
+        ],
+        "exclusions": list(manifest.exclusions),
+    }
+
+
+def serialize_workspace_backup_manifest(manifest: WorkspaceBackupManifest) -> bytes:
+    """Serialize a manifest deterministically as UTF-8 JSON plus one newline."""
+    payload = json.dumps(
+        workspace_backup_manifest_to_dict(manifest),
+        ensure_ascii=False,
+        allow_nan=False,
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+    return payload.encode("utf-8")
+
+
+def workspace_backup_manifest_sha256(manifest: WorkspaceBackupManifest) -> str:
+    """Return SHA-256 of the canonical serialized manifest bytes."""
+    return hashlib.sha256(serialize_workspace_backup_manifest(manifest)).hexdigest()
+
+
+def parse_workspace_backup_manifest(data: bytes | str) -> WorkspaceBackupManifest:
+    """Parse and strictly validate one v1 backup manifest."""
+    try:
+        text = data.decode("utf-8") if isinstance(data, bytes) else data
+    except UnicodeDecodeError as error:
+        raise WorkspaceBackupManifestError("manifest must be UTF-8") from error
+    if not isinstance(text, str):
+        raise WorkspaceBackupManifestError("manifest input must be bytes or text")
+    try:
+        raw = json.loads(text, object_pairs_hook=_duplicate_rejecting_object)
+    except json.JSONDecodeError as error:
+        raise WorkspaceBackupManifestError(
+            f"manifest is invalid JSON: {error}"
+        ) from error
+    mapping = _mapping(raw, "manifest")
+    _exact_keys(mapping, _MANIFEST_KEYS, "manifest")
+
+    raw_directories = mapping["directories"]
+    raw_files = mapping["files"]
+    raw_exclusions = mapping["exclusions"]
+    if not isinstance(raw_directories, list):
+        raise WorkspaceBackupManifestError("directories must be an array")
+    if not isinstance(raw_files, list):
+        raise WorkspaceBackupManifestError("files must be an array")
+    if not isinstance(raw_exclusions, list):
+        raise WorkspaceBackupManifestError("exclusions must be an array")
+
+    directories = tuple(
+        _string(value, f"directories[{index}]")
+        for index, value in enumerate(raw_directories)
+    )
+    files: list[BackupFileEntry] = []
+    for index, raw_entry in enumerate(raw_files):
+        entry = _mapping(raw_entry, f"files[{index}]")
+        _exact_keys(entry, _FILE_ENTRY_KEYS, f"files[{index}]")
+        files.append(
+            BackupFileEntry(
+                path=_string(entry["path"], f"files[{index}].path"),
+                size=_integer(entry["size"], f"files[{index}].size"),
+                sha256=_string(entry["sha256"], f"files[{index}].sha256"),
+            )
+        )
+    exclusions = tuple(
+        _string(value, f"exclusions[{index}]")
+        for index, value in enumerate(raw_exclusions)
+    )
+
+    return WorkspaceBackupManifest(
+        record_type=_string(mapping["record_type"], "record_type"),
+        schema_version=_string(mapping["schema_version"], "schema_version"),
+        backup_id=_string(mapping["backup_id"], "backup_id"),
+        created_at=_parse_created_at(mapping["created_at"]),
+        suite_version=_string(mapping["suite_version"], "suite_version"),
+        core_version=_string(mapping["core_version"], "core_version"),
+        payload_root=_string(mapping["payload_root"], "payload_root"),
+        hash_algorithm=_string(mapping["hash_algorithm"], "hash_algorithm"),
+        directory_count=_integer(mapping["directory_count"], "directory_count"),
+        file_count=_integer(mapping["file_count"], "file_count"),
+        total_bytes=_integer(mapping["total_bytes"], "total_bytes"),
+        directories=directories,
+        files=tuple(files),
+        exclusions=exclusions,
+    )
+
+
+def create_workspace_backup_manifest(
+    plan: WorkspaceBackupPlan,
+    files: Sequence[BackupFileEntry],
+) -> WorkspaceBackupManifest:
+    """Build the final manifest only from a reviewed plan and verified file hashes."""
+    sorted_files = tuple(sorted(files, key=lambda item: item.path))
+    expected = {entry.path: entry.size for entry in plan.inventory.files}
+    observed = {entry.path: entry.size for entry in sorted_files}
+    if observed != expected or len(sorted_files) != len(expected):
+        raise WorkspaceBackupManifestError(
+            "verified file entries do not match the reviewed source inventory"
+        )
+    return WorkspaceBackupManifest(
+        record_type=BACKUP_MANIFEST_RECORD_TYPE,
+        schema_version=BACKUP_MANIFEST_SCHEMA_VERSION,
+        backup_id=plan.backup_id,
+        created_at=plan.created_at,
+        suite_version=plan.suite_version,
+        core_version=plan.core_version,
+        payload_root=BACKUP_PAYLOAD_ROOT,
+        hash_algorithm=BACKUP_HASH_ALGORITHM,
+        directory_count=plan.inventory.directory_count,
+        file_count=plan.inventory.file_count,
+        total_bytes=plan.inventory.total_bytes,
+        directories=plan.inventory.directories,
+        files=sorted_files,
+        exclusions=(),
+    )
+
+
+def _shared_core_version(manifest: ReleaseCompatibilityManifest) -> str:
+    candidates = tuple(
+        component
+        for component in manifest.components
+        if "shared_core" in component.capabilities
+    )
+    if len(candidates) != 1:
+        raise CoreWorkspaceQualificationError(
+            "The suite manifest does not identify exactly one shared Core component."
+        )
+    return candidates[0].version
+
+
+def load_core_backup_services(
+    manifest: ReleaseCompatibilityManifest | None = None,
+    *,
+    version_lookup: DistributionVersionLookup = metadata.version,
+    module_importer: ModuleImporter = import_module,
+) -> CoreBackupServices:
+    """Qualify Core exactly, then expose only its read-only workspace inspector."""
+    active_manifest = manifest or load_release_compatibility_manifest()
+    workspace_services = load_core_workspace_services(
+        active_manifest,
+        version_lookup=version_lookup,
+        module_importer=module_importer,
+    )
+    return CoreBackupServices(
+        inspect_workspace_root=workspace_services.inspect_workspace_root,
+        core_version=_shared_core_version(active_manifest),
+    )
+
+
+def _workspace_source(services: CoreBackupServices) -> tuple[Path, str]:
+    try:
+        status = services.inspect_workspace_root()
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise WorkspaceBackupSourceError(
+            f"Core could not inspect the currently resolved workspace: {message}"
+        ) from error
+    try:
+        root = Path(status.root)
+        source = status.source
+        exists = status.exists
+        is_dir = status.is_dir
+    except (AttributeError, TypeError, ValueError) as error:
+        raise WorkspaceBackupSourceError(
+            "Core returned an invalid workspace status result."
+        ) from error
+    if not isinstance(source, str) or not source.strip():
+        raise WorkspaceBackupSourceError(
+            "Core returned an invalid workspace resolution source."
+        )
+    if not isinstance(exists, bool) or not isinstance(is_dir, bool):
+        raise WorkspaceBackupSourceError(
+            "Core returned invalid workspace status flags."
+        )
+    if not exists:
+        raise WorkspaceBackupSourceError(
+            f"The currently resolved workspace does not exist: {root}. "
+            "Run 'pds workspace setup' first."
+        )
+    if not is_dir:
+        raise WorkspaceBackupSourceError(
+            f"The currently resolved workspace is not a directory: {root}. "
+            "Run 'pds workspace setup' to select a usable workspace."
+        )
+    try:
+        canonical = root.resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise WorkspaceBackupSourceError(
+            f"Could not resolve the current workspace: {root}."
+        ) from error
+    if not canonical.is_dir():
+        raise WorkspaceBackupSourceError(
+            f"The currently resolved workspace is not a directory: {canonical}."
+        )
+    return canonical, source
+
+
+def _manifest_relative(root: Path, path: Path) -> str:
+    try:
+        relative = path.relative_to(root)
+    except ValueError as error:
+        raise WorkspaceBackupSourceError(
+            f"Workspace entry escaped the source root: {path}"
+        ) from error
+    value = "/".join(relative.parts)
+    try:
+        return _validate_relative_manifest_path(value, "workspace entry path")
+    except WorkspaceBackupManifestError as error:
+        raise WorkspaceBackupUnsupportedEntryError(
+            "Workspace backup path is not portable in manifest v1: "
+            f"{value!r}"
+        ) from error
+
+
+def _redirecting_reparse(stat_result: os.stat_result) -> bool:
+    attributes = getattr(stat_result, "st_file_attributes", 0)
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    if not reparse_flag or not attributes & reparse_flag:
+        return False
+    tag = getattr(stat_result, "st_reparse_tag", None)
+    redirect_tags = {
+        value
+        for value in (
+            getattr(stat, "IO_REPARSE_TAG_SYMLINK", None),
+            getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", None),
+        )
+        if value is not None
+    }
+    return tag in redirect_tags
+
+
+def inventory_workspace(workspace_root: Path) -> WorkspaceBackupInventory:
+    """Enumerate ordinary files/directories without following filesystem links."""
+    directories: list[str] = []
+    files: list[BackupSourceFile] = []
+
+    def walk(directory: Path) -> None:
+        try:
+            with os.scandir(directory) as scan:
+                entries = sorted(tuple(scan), key=lambda item: item.name)
+        except OSError as error:
+            raise WorkspaceBackupSourceError(
+                f"Could not enumerate workspace directory: "
+                f"{_display_relative(workspace_root, directory)}"
+            ) from error
+
+        for entry in entries:
+            entry_path = Path(entry.path)
+            relative = _manifest_relative(workspace_root, entry_path)
+            try:
+                status = entry.stat(follow_symlinks=False)
+                is_symlink = entry.is_symlink()
+            except OSError as error:
+                raise WorkspaceBackupSourceError(
+                    f"Could not inspect workspace entry: {relative}"
+                ) from error
+            if (
+                is_symlink
+                or stat.S_ISLNK(status.st_mode)
+                or _redirecting_reparse(status)
+            ):
+                raise WorkspaceBackupUnsupportedEntryError(
+                    "Workspace backup does not follow linked filesystem entry: "
+                    f"{relative}"
+                )
+            if stat.S_ISDIR(status.st_mode):
+                directories.append(relative)
+                walk(entry_path)
+                continue
+            if stat.S_ISREG(status.st_mode):
+                files.append(BackupSourceFile(path=relative, size=status.st_size))
+                continue
+            raise WorkspaceBackupUnsupportedEntryError(
+                "Workspace backup does not support special filesystem entry: "
+                f"{relative}"
+            )
+
+    walk(workspace_root)
+    sorted_directories = tuple(sorted(directories))
+    sorted_files = tuple(sorted(files, key=lambda item: item.path))
+    return WorkspaceBackupInventory(
+        directories=sorted_directories,
+        files=sorted_files,
+        total_bytes=sum(entry.size for entry in sorted_files),
+    )
+
+
+def _display_relative(root: Path, path: Path) -> str:
+    if path == root:
+        return "."
+    try:
+        return "/".join(path.relative_to(root).parts)
+    except ValueError:
+        return "<outside workspace>"
+
+
+def _expanded_path(path: str | Path, label: str) -> Path:
+    raw = os.fspath(path)
+    if not raw.strip():
+        raise WorkspaceBackupDestinationError(f"{label} cannot be empty")
+    expanded = os.path.expandvars(os.path.expanduser(raw))
+    try:
+        return Path(expanded).resolve(strict=False)
+    except (OSError, RuntimeError) as error:
+        raise WorkspaceBackupDestinationError(
+            f"Could not resolve {label.lower()}."
+        ) from error
+
+
+def _contains(parent: Path, child: Path) -> bool:
+    try:
+        child.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _assert_safe_destination(
+    workspace_root: Path,
+    destination_parent: Path,
+    final_backup_root: Path,
+) -> None:
+    if destination_parent == workspace_root or _contains(
+        workspace_root, destination_parent
+    ):
+        raise WorkspaceBackupDestinationError(
+            "Backup destination must be outside the active workspace."
+        )
+    if final_backup_root == workspace_root or _contains(
+        workspace_root, final_backup_root
+    ):
+        raise WorkspaceBackupDestinationError(
+            "Final backup path must be outside the active workspace."
+        )
+    if _contains(final_backup_root, workspace_root):
+        raise WorkspaceBackupDestinationError(
+            "Final backup path must not contain the active workspace."
+        )
+
+
+def _nearest_existing_directory(path: Path) -> Path:
+    candidate = path
+    while not candidate.exists():
+        parent = candidate.parent
+        if parent == candidate:
+            break
+        candidate = parent
+    if not candidate.exists() or not candidate.is_dir():
+        raise WorkspaceBackupDestinationError(
+            "Backup destination has no usable existing directory ancestor."
+        )
+    return candidate
+
+
+def _destination_free_bytes(
+    destination_parent: Path,
+    disk_usage_reader: DiskUsageReader,
+) -> int:
+    anchor = _nearest_existing_directory(destination_parent)
+    try:
+        usage = disk_usage_reader(anchor)
+        free = usage.free
+    except (OSError, TypeError, ValueError, AttributeError) as error:
+        raise WorkspaceBackupDestinationError(
+            f"Could not inspect free space for backup destination: {anchor}"
+        ) from error
+    if not isinstance(free, int) or isinstance(free, bool) or free < 0:
+        raise WorkspaceBackupDestinationError(
+            "Destination free-space provider returned an invalid value."
+        )
+    return free
+
+
+def plan_workspace_backup(
+    destination_parent: str | Path,
+    *,
+    services: CoreBackupServices | None = None,
+    clock: Clock | None = None,
+    disk_usage_reader: DiskUsageReader = _read_disk_usage,
+) -> WorkspaceBackupPlan:
+    """Build a complete read-only backup proposal without creating destination state."""
+    active_services = services or load_core_backup_services()
+    workspace_root, workspace_source = _workspace_source(active_services)
+    created_at = _utc_datetime(
+        (clock or (lambda: datetime.now(timezone.utc)))(),
+        "created_at",
+    )
+    backup_id = backup_name(created_at)
+    destination = _expanded_path(destination_parent, "Backup destination")
+    if destination.exists() and not destination.is_dir():
+        raise WorkspaceBackupDestinationError(
+            f"Backup destination exists but is not a directory: {destination}"
+        )
+    final_root = destination / backup_id
+    _assert_safe_destination(workspace_root, destination, final_root)
+    if final_root.exists():
+        raise WorkspaceBackupCollisionError(
+            f"Backup already exists and will not be overwritten: {final_root}"
+        )
+
+    inventory = inventory_workspace(workspace_root)
+    free_bytes = _destination_free_bytes(destination, disk_usage_reader)
+    required_bytes = required_backup_free_bytes(inventory.total_bytes)
+    if free_bytes < required_bytes:
+        raise WorkspaceBackupSpaceError(
+            "Insufficient destination free space for backup: "
+            f"required {required_bytes} bytes, available {free_bytes} bytes."
+        )
+
+    return WorkspaceBackupPlan(
+        workspace_root=workspace_root,
+        workspace_source=workspace_source,
+        destination_parent=destination,
+        final_backup_root=final_root,
+        backup_id=backup_id,
+        created_at=created_at,
+        suite_version=__version__,
+        core_version=active_services.core_version,
+        inventory=inventory,
+        destination_free_bytes=free_bytes,
+        required_free_bytes=required_bytes,
+        destination_parent_exists=destination.exists(),
+    )
+
+
+def _payload_path(root: Path, relative: str) -> Path:
+    """Return a native path for one already-validated manifest relative path."""
+    canonical = _validate_relative_manifest_path(relative, "payload path")
+    return root.joinpath(*PurePosixPath(canonical).parts)
+
+
+def _regular_file_status(path: Path, *, relative: str, area: str) -> os.stat_result:
+    """Inspect one regular file without following the leaf entry."""
+    try:
+        status = path.lstat()
+    except OSError as error:
+        if area == "source":
+            raise WorkspaceBackupSourceError(
+                f"Could not inspect source backup file: {relative}"
+            ) from error
+        raise WorkspaceBackupVerificationError(
+            f"Could not inspect staged backup file: {relative}"
+        ) from error
+    if stat.S_ISLNK(status.st_mode) or _redirecting_reparse(status):
+        if area == "source":
+            raise WorkspaceBackupUnsupportedEntryError(
+                f"Backup source contains linked filesystem entry: {relative}"
+            )
+        raise WorkspaceBackupVerificationError(
+            f"Backup staged contains linked filesystem entry: {relative}"
+        )
+    if not stat.S_ISREG(status.st_mode):
+        if area == "source":
+            raise WorkspaceBackupUnsupportedEntryError(
+                f"Backup source contains non-regular file entry: {relative}"
+            )
+        raise WorkspaceBackupVerificationError(
+            f"Backup staged contains non-regular file entry: {relative}"
+        )
+    return status
+
+
+def _hash_file(
+    path: Path,
+    *,
+    relative: str,
+    area: str,
+    chunk_size: int,
+) -> BackupFileEntry:
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be greater than zero")
+    before = _regular_file_status(path, relative=relative, area=area)
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with path.open("rb") as stream:
+            opened = os.fstat(stream.fileno())
+            if not stat.S_ISREG(opened.st_mode):
+                raise WorkspaceBackupVerificationError(
+                    f"Backup {area} file changed type while opening: {relative}"
+                )
+            while True:
+                chunk = stream.read(chunk_size)
+                if not chunk:
+                    break
+                total += len(chunk)
+                digest.update(chunk)
+    except WorkspaceBackupError:
+        raise
+    except OSError as error:
+        if area == "source":
+            raise WorkspaceBackupSourceError(
+                f"Could not read source backup file: {relative}"
+            ) from error
+        raise WorkspaceBackupVerificationError(
+            f"Could not read staged backup file: {relative}"
+        ) from error
+    after = _regular_file_status(path, relative=relative, area=area)
+    if total != before.st_size or total != after.st_size:
+        if area == "source":
+            raise WorkspaceBackupDriftError(
+                f"Backup source file changed while being read: {relative}"
+            )
+        raise WorkspaceBackupVerificationError(
+            f"Backup staged file changed while being read: {relative}"
+        )
+    return BackupFileEntry(path=relative, size=total, sha256=digest.hexdigest())
+
+
+def _copy_regular_file(
+    source_root: Path,
+    payload_root: Path,
+    relative: str,
+    chunk_size: int,
+) -> BackupFileEntry:
+    """Copy one regular source file exclusively while hashing written bytes."""
+    source = _payload_path(source_root, relative)
+    destination = _payload_path(payload_root, relative)
+    before = _regular_file_status(source, relative=relative, area="source")
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with source.open("rb") as input_stream, destination.open("xb") as output_stream:
+            opened = os.fstat(input_stream.fileno())
+            if not stat.S_ISREG(opened.st_mode):
+                raise WorkspaceBackupUnsupportedEntryError(
+                    f"Workspace file changed type while opening: {relative}"
+                )
+            while True:
+                chunk = input_stream.read(chunk_size)
+                if not chunk:
+                    break
+                output_stream.write(chunk)
+                digest.update(chunk)
+                total += len(chunk)
+            output_stream.flush()
+            os.fsync(output_stream.fileno())
+    except WorkspaceBackupError:
+        raise
+    except FileExistsError as error:
+        raise WorkspaceBackupCopyError(
+            f"Staging payload unexpectedly already contains file: {relative}"
+        ) from error
+    except OSError as error:
+        raise WorkspaceBackupCopyError(
+            f"Could not copy workspace file into backup staging: {relative}"
+        ) from error
+    after = _regular_file_status(source, relative=relative, area="source")
+    if total != before.st_size or total != after.st_size:
+        raise WorkspaceBackupDriftError(
+            f"Workspace file changed while being copied: {relative}"
+        )
+    return BackupFileEntry(path=relative, size=total, sha256=digest.hexdigest())
+
+
+FileCopier = Callable[[Path, Path, str, int], BackupFileEntry]
+StagingNonceFactory = Callable[[], str]
+AfterCopyHook = Callable[[Path, Path], None]
+BeforePublishHook = Callable[[Path, Path], None]
+
+
+def _default_staging_nonce() -> str:
+    return secrets.token_hex(8)
+
+
+def _staging_root(plan: WorkspaceBackupPlan, nonce: str) -> Path:
+    if not isinstance(nonce, str) or not nonce or any(
+        character not in (
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+        )
+        for character in nonce
+    ):
+        raise WorkspaceBackupDestinationError("Backup staging nonce is invalid.")
+    return plan.destination_parent / f".{plan.backup_id}.incomplete-{nonce}"
+
+
+def _same_inventory(
+    expected: WorkspaceBackupInventory,
+    observed: WorkspaceBackupInventory,
+) -> bool:
+    return expected == observed
+
+
+def _recheck_plan_source(
+    plan: WorkspaceBackupPlan,
+    services: CoreBackupServices,
+) -> None:
+    current_root, _current_source = _workspace_source(services)
+    if current_root != plan.workspace_root:
+        raise WorkspaceBackupDriftError(
+            "The currently resolved workspace changed after backup preview."
+        )
+    current_inventory = inventory_workspace(current_root)
+    if not _same_inventory(plan.inventory, current_inventory):
+        raise WorkspaceBackupDriftError(
+            "The workspace changed after backup preview; create a new backup plan."
+        )
+
+
+def _prepare_destination_for_execution(
+    plan: WorkspaceBackupPlan,
+    *,
+    disk_usage_reader: DiskUsageReader,
+) -> Path:
+    """Create/re-resolve the destination parent only at the execution boundary."""
+    precreate = _expanded_path(plan.destination_parent, "Backup destination")
+    proposed_final = precreate / plan.backup_id
+    _assert_safe_destination(plan.workspace_root, precreate, proposed_final)
+    if proposed_final.exists():
+        raise WorkspaceBackupCollisionError(
+            f"Backup already exists and will not be overwritten: {proposed_final}"
+        )
+    try:
+        precreate.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise WorkspaceBackupDestinationError(
+            f"Could not create backup destination: {precreate}"
+        ) from error
+    try:
+        destination = precreate.resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise WorkspaceBackupDestinationError(
+            f"Could not resolve created backup destination: {precreate}"
+        ) from error
+    if not destination.is_dir():
+        raise WorkspaceBackupDestinationError(
+            f"Backup destination is not a directory: {destination}"
+        )
+    final_root = destination / plan.backup_id
+    _assert_safe_destination(plan.workspace_root, destination, final_root)
+    if destination != plan.destination_parent:
+        raise WorkspaceBackupDestinationError(
+            "Backup destination resolved differently after confirmation; rerun preview."
+        )
+    if final_root != plan.final_backup_root:
+        raise WorkspaceBackupDestinationError(
+            "Final backup path changed after confirmation; rerun preview."
+        )
+    if final_root.exists():
+        raise WorkspaceBackupCollisionError(
+            f"Backup already exists and will not be overwritten: {final_root}"
+        )
+    free_bytes = _destination_free_bytes(destination, disk_usage_reader)
+    if free_bytes < plan.required_free_bytes:
+        raise WorkspaceBackupSpaceError(
+            "Insufficient destination free space for backup: "
+            f"required {plan.required_free_bytes} bytes, available {free_bytes} bytes."
+        )
+    return destination
+
+
+def _create_staging_payload(
+    plan: WorkspaceBackupPlan,
+    staging_root: Path,
+) -> Path:
+    """Populate a staging root that this execution already created exclusively."""
+    try:
+        payload_root = staging_root / BACKUP_PAYLOAD_ROOT
+        payload_root.mkdir(exist_ok=False)
+        for relative in plan.inventory.directories:
+            _payload_path(payload_root, relative).mkdir(exist_ok=False)
+    except OSError as error:
+        raise WorkspaceBackupCopyError(
+            f"Could not create backup staging tree: {staging_root}"
+        ) from error
+    return payload_root
+
+
+def _verify_source_matches_copied(
+    plan: WorkspaceBackupPlan,
+    copied: Sequence[BackupFileEntry],
+    *,
+    chunk_size: int,
+) -> None:
+    observed_inventory = inventory_workspace(plan.workspace_root)
+    if not _same_inventory(plan.inventory, observed_inventory):
+        raise WorkspaceBackupDriftError(
+            "The workspace changed while the backup was being created."
+        )
+    copied_by_path = {entry.path: entry for entry in copied}
+    for source_entry in plan.inventory.files:
+        current = _hash_file(
+            _payload_path(plan.workspace_root, source_entry.path),
+            relative=source_entry.path,
+            area="source",
+            chunk_size=chunk_size,
+        )
+        if current != copied_by_path.get(source_entry.path):
+            raise WorkspaceBackupDriftError(
+                "The workspace changed while the backup was being created: "
+                f"{source_entry.path}"
+            )
+
+
+def _verify_staged_payload(
+    plan: WorkspaceBackupPlan,
+    payload_root: Path,
+    copied: Sequence[BackupFileEntry],
+    *,
+    chunk_size: int,
+) -> None:
+    observed_inventory = inventory_workspace(payload_root)
+    if not _same_inventory(plan.inventory, observed_inventory):
+        raise WorkspaceBackupVerificationError(
+            "Staged backup inventory does not match the reviewed workspace inventory."
+        )
+    copied_by_path = {entry.path: entry for entry in copied}
+    for expected in copied:
+        actual = _hash_file(
+            _payload_path(payload_root, expected.path),
+            relative=expected.path,
+            area="staged",
+            chunk_size=chunk_size,
+        )
+        if actual != copied_by_path[expected.path]:
+            raise WorkspaceBackupVerificationError(
+                f"Staged backup file failed integrity verification: {expected.path}"
+            )
+
+
+def _write_verified_manifest(
+    staging_root: Path,
+    manifest: WorkspaceBackupManifest,
+) -> str:
+    manifest_path = staging_root / BACKUP_MANIFEST_FILENAME
+    temporary = staging_root / f".{BACKUP_MANIFEST_FILENAME}.tmp"
+    payload = serialize_workspace_backup_manifest(manifest)
+    try:
+        with temporary.open("xb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary.replace(manifest_path)
+        persisted = manifest_path.read_bytes()
+    except OSError as error:
+        raise WorkspaceBackupVerificationError(
+            "Could not persist backup manifest in verified staging."
+        ) from error
+    if persisted != payload:
+        raise WorkspaceBackupVerificationError(
+            "Persisted backup manifest bytes do not match canonical serialization."
+        )
+    parsed = parse_workspace_backup_manifest(persisted)
+    if parsed != manifest:
+        raise WorkspaceBackupVerificationError(
+            "Persisted backup manifest failed read-after-write validation."
+        )
+    return hashlib.sha256(persisted).hexdigest()
+
+
+def _cleanup_staging(staging_root: Path) -> str | None:
+    if not staging_root.exists():
+        return None
+    try:
+        shutil.rmtree(staging_root)
+    except OSError:
+        return str(staging_root)
+    return None
+
+
+def _publish_staging(staging_root: Path, final_root: Path) -> None:
+    """Publish a verified staging directory without intentionally replacing state."""
+    if final_root.exists():
+        raise WorkspaceBackupCollisionError(
+            f"Backup already exists and will not be overwritten: {final_root}"
+        )
+    try:
+        os.rename(staging_root, final_root)
+    except FileExistsError as error:
+        raise WorkspaceBackupCollisionError(
+            f"Backup already exists and will not be overwritten: {final_root}"
+        ) from error
+    except OSError as error:
+        raise WorkspaceBackupPublicationError(
+            f"Could not publish verified backup: {final_root}"
+        ) from error
+
+
+def create_workspace_backup(
+    plan: WorkspaceBackupPlan,
+    *,
+    services: CoreBackupServices | None = None,
+    disk_usage_reader: DiskUsageReader = _read_disk_usage,
+    staging_nonce_factory: StagingNonceFactory = _default_staging_nonce,
+    file_copier: FileCopier = _copy_regular_file,
+    chunk_size: int = BACKUP_COPY_CHUNK_BYTES,
+    after_copy_hook: AfterCopyHook | None = None,
+    before_publish_hook: BeforePublishHook | None = None,
+) -> WorkspaceBackupResult:
+    """Create, verify, and publish one reviewed whole-workspace backup."""
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be greater than zero")
+    active_services = services or load_core_backup_services()
+
+    # All source checks happen before the first destination mutation.
+    _recheck_plan_source(plan, active_services)
+    _prepare_destination_for_execution(
+        plan,
+        disk_usage_reader=disk_usage_reader,
+    )
+
+    staging_root = _staging_root(plan, staging_nonce_factory())
+    try:
+        staging_root.mkdir(exist_ok=False)
+    except FileExistsError as error:
+        raise WorkspaceBackupCollisionError(
+            "Backup staging path already exists and will not be overwritten: "
+            f"{staging_root}"
+        ) from error
+    except OSError as error:
+        raise WorkspaceBackupCopyError(
+            f"Could not create backup staging root: {staging_root}"
+        ) from error
+
+    try:
+        payload_root = _create_staging_payload(plan, staging_root)
+        copied: list[BackupFileEntry] = []
+        for source_entry in plan.inventory.files:
+            copied.append(
+                file_copier(
+                    plan.workspace_root,
+                    payload_root,
+                    source_entry.path,
+                    chunk_size,
+                )
+            )
+
+        if after_copy_hook is not None:
+            after_copy_hook(plan.workspace_root, payload_root)
+
+        _verify_source_matches_copied(
+            plan,
+            copied,
+            chunk_size=chunk_size,
+        )
+        _verify_staged_payload(
+            plan,
+            payload_root,
+            copied,
+            chunk_size=chunk_size,
+        )
+        manifest = create_workspace_backup_manifest(plan, copied)
+        manifest_sha256 = _write_verified_manifest(staging_root, manifest)
+
+        if before_publish_hook is not None:
+            before_publish_hook(staging_root, plan.final_backup_root)
+        _publish_staging(staging_root, plan.final_backup_root)
+        return WorkspaceBackupResult(
+            final_backup_root=plan.final_backup_root,
+            manifest=manifest,
+            manifest_sha256=manifest_sha256,
+        )
+    except WorkspaceBackupError as error:
+        remaining = _cleanup_staging(staging_root)
+        if remaining is not None:
+            raise WorkspaceBackupCopyError(
+                f"{error} Incomplete staging remains at: {remaining}"
+            ) from error
+        raise
+    except OSError as error:
+        remaining = _cleanup_staging(staging_root)
+        message = "Backup creation failed due to a filesystem error."
+        if remaining is not None:
+            message += f" Incomplete staging remains at: {remaining}"
+        raise WorkspaceBackupCopyError(message) from error
+
+__all__ = [
+    "BACKUP_COPY_CHUNK_BYTES",
+    "BACKUP_HASH_ALGORITHM",
+    "BACKUP_MANIFEST_FILENAME",
+    "BACKUP_MANIFEST_RECORD_TYPE",
+    "BACKUP_MANIFEST_SCHEMA_VERSION",
+    "BACKUP_MINIMUM_RESERVE_BYTES",
+    "BACKUP_NAME_PREFIX",
+    "BACKUP_PAYLOAD_ROOT",
+    "BackupFileEntry",
+    "BackupSourceFile",
+    "CoreBackupServices",
+    "WorkspaceBackupCollisionError",
+    "WorkspaceBackupCopyError",
+    "WorkspaceBackupDestinationError",
+    "WorkspaceBackupDriftError",
+    "WorkspaceBackupError",
+    "WorkspaceBackupInventory",
+    "WorkspaceBackupManifest",
+    "WorkspaceBackupManifestError",
+    "WorkspaceBackupPlan",
+    "WorkspaceBackupPublicationError",
+    "WorkspaceBackupResult",
+    "WorkspaceBackupSourceError",
+    "WorkspaceBackupSpaceError",
+    "WorkspaceBackupUnsupportedEntryError",
+    "WorkspaceBackupVerificationError",
+    "backup_name",
+    "create_workspace_backup",
+    "create_workspace_backup_manifest",
+    "inventory_workspace",
+    "load_core_backup_services",
+    "parse_workspace_backup_manifest",
+    "plan_workspace_backup",
+    "required_backup_free_bytes",
+    "serialize_workspace_backup_manifest",
+    "workspace_backup_manifest_sha256",
+    "workspace_backup_manifest_to_dict",
+]

--- a/paper_data_suite/workspace_backup_cli.py
+++ b/paper_data_suite/workspace_backup_cli.py
@@ -1,0 +1,151 @@
+"""Teacher-facing command orchestration for whole-workspace backup creation."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+from paper_data_suite.compatibility import CompatibilityManifestError
+from paper_data_suite.workspace_backup import (
+    WorkspaceBackupError,
+    WorkspaceBackupPlan,
+    WorkspaceBackupResult,
+    create_workspace_backup,
+    plan_workspace_backup,
+)
+from paper_data_suite.workspace_cli import workspace_source_label
+from paper_data_suite.workspace_setup import (
+    CoreWorkspaceQualificationError,
+    CoreWorkspaceServiceError,
+)
+
+InputReader = Callable[[str], str]
+
+
+def _read(prompt: str, input_fn: InputReader) -> str | None:
+    try:
+        return input_fn(prompt).strip()
+    except (EOFError, KeyboardInterrupt):
+        return None
+
+
+def render_workspace_backup_plan(plan: WorkspaceBackupPlan) -> str:
+    """Render one bounded read-only backup preview without listing payload paths."""
+    lines = [
+        "Paper Data Suite workspace backup",
+        "",
+        f"Resolved workspace: {plan.workspace_root}",
+        f"Workspace source: {workspace_source_label(plan.workspace_source)}",
+        f"Destination parent: {plan.destination_parent}",
+        f"Proposed backup: {plan.final_backup_root}",
+        f"Directories: {plan.inventory.directory_count}",
+        f"Files: {plan.inventory.file_count}",
+        f"Payload bytes: {plan.inventory.total_bytes}",
+        f"Destination free bytes: {plan.destination_free_bytes}",
+        f"Minimum required free bytes: {plan.required_free_bytes}",
+        "Backup format: pds_workspace_backup_manifest v1",
+        "",
+        "Privacy warning:",
+        "  This backup contains the same potentially sensitive classroom/student",
+        "  data as the workspace. Store it only in an appropriate teacher-controlled",
+        "  or institutionally approved location.",
+        "  PDS does not encrypt, upload, or cloud-sync this backup.",
+        "",
+        "No backup has been created yet.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_workspace_backup_result(
+    plan: WorkspaceBackupPlan,
+    result: WorkspaceBackupResult,
+) -> str:
+    """Render a bounded completion summary for one verified published backup."""
+    manifest = result.manifest
+    lines = [
+        "Workspace backup complete",
+        "",
+        f"Source workspace: {plan.workspace_root}",
+        f"Backup: {result.final_backup_root}",
+        f"Directories: {manifest.directory_count}",
+        f"Files: {manifest.file_count}",
+        f"Payload bytes: {manifest.total_bytes}",
+        f"Created at: {manifest.created_at}",
+        f"Manifest SHA-256: {result.manifest_sha256}",
+        "",
+        "SHA-256 supports integrity checking; it does not encrypt or authenticate",
+        "the backup.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _cancel_backup() -> int:
+    print("Workspace backup cancelled. No backup was created.")
+    return 0
+
+
+def _print_refusal(error: Exception) -> None:
+    message = str(error)[:500] or error.__class__.__name__
+    print(f"Backup refused: {message}", file=sys.stderr)
+
+
+def _print_failure(error: Exception) -> None:
+    message = str(error)[:500] or error.__class__.__name__
+    print(f"Backup failed: {message}", file=sys.stderr)
+
+
+def _confirm_backup(input_fn: InputReader) -> bool:
+    while True:
+        choice = _read("Type BACKUP to create the backup, or Q to cancel: ", input_fn)
+        if choice is None or choice == "Q":
+            return False
+        if choice == "BACKUP":
+            return True
+        print("Enter exact uppercase BACKUP to continue, or Q to cancel.")
+
+
+def run_workspace_backup_create(
+    destination: Path,
+    *,
+    assume_yes: bool = False,
+    input_fn: InputReader = input,
+) -> int:
+    """Plan, confirm, create, verify, and publish one whole-workspace backup."""
+    try:
+        plan = plan_workspace_backup(destination)
+    except (
+        CompatibilityManifestError,
+        CoreWorkspaceQualificationError,
+        CoreWorkspaceServiceError,
+        WorkspaceBackupError,
+        OSError,
+    ) as error:
+        _print_refusal(error)
+        return 1
+
+    print(render_workspace_backup_plan(plan), end="")
+    if not assume_yes and not _confirm_backup(input_fn):
+        return _cancel_backup()
+
+    try:
+        result = create_workspace_backup(plan)
+    except (
+        CompatibilityManifestError,
+        CoreWorkspaceQualificationError,
+        CoreWorkspaceServiceError,
+        WorkspaceBackupError,
+        OSError,
+    ) as error:
+        _print_failure(error)
+        return 1
+
+    print(render_workspace_backup_result(plan, result), end="")
+    return 0
+
+
+__all__ = (
+    "render_workspace_backup_plan",
+    "render_workspace_backup_result",
+    "run_workspace_backup_create",
+)

--- a/scripts/smoke_test_workspace_backup_wheel.py
+++ b/scripts/smoke_test_workspace_backup_wheel.py
@@ -1,0 +1,638 @@
+"""Smoke-test installed whole-workspace backup creation from built wheels."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import venv
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+
+class WorkspaceBackupSmokeTestError(RuntimeError):
+    """Raised when installed workspace-backup acceptance fails."""
+
+
+@dataclass(frozen=True, slots=True)
+class FileSnapshot:
+    """Independent file facts used by the smoke test."""
+
+    path: str
+    size: int
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class TreeSnapshot:
+    """Independent directory/file snapshot used to compare source and payload."""
+
+    directories: tuple[str, ...]
+    files: tuple[FileSnapshot, ...]
+
+
+_MANIFEST_KEYS = frozenset(
+    {
+        "record_type",
+        "schema_version",
+        "backup_id",
+        "created_at",
+        "suite_version",
+        "core_version",
+        "payload_root",
+        "hash_algorithm",
+        "directory_count",
+        "file_count",
+        "total_bytes",
+        "directories",
+        "files",
+        "exclusions",
+    }
+)
+_FILE_KEYS = frozenset({"path", "size", "sha256"})
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    input_text: str | None = None,
+    expected_returncode: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=dict(env),
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != expected_returncode:
+        raise WorkspaceBackupSmokeTestError(
+            "Command returned an unexpected status "
+            f"({result.returncode}, expected {expected_returncode}): "
+            f"{' '.join(command)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _venv_python(environment: Path) -> Path:
+    if os.name == "nt":
+        return environment / "Scripts" / "python.exe"
+    return environment / "bin" / "python"
+
+
+def _scripts_directory(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> Path:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            "import sysconfig; print(sysconfig.get_path('scripts'))",
+        ],
+        cwd=cwd,
+        env=env,
+    )
+    return Path(result.stdout.strip())
+
+
+def _isolated_command_env(
+    base_env: Mapping[str, str],
+    *,
+    user_home: Path,
+) -> dict[str, str]:
+    env = dict(base_env)
+    for key in tuple(env):
+        if key.upper() in {"PYTHONPATH", "PDS_WORKSPACE_ROOT"}:
+            env.pop(key, None)
+
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONNOUSERSITE"] = "1"
+    env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    env["PIP_NO_INDEX"] = "1"
+    env["HOME"] = str(user_home)
+    env["USERPROFILE"] = str(user_home)
+    env["APPDATA"] = str(user_home / "AppData" / "Roaming")
+    env["XDG_CONFIG_HOME"] = str(user_home / ".config")
+    return env
+
+
+def _assert_installed_suite_location(
+    python: Path,
+    *,
+    environment: Path,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> None:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            (
+                "from pathlib import Path; import paper_data_suite; "
+                "print(Path(paper_data_suite.__file__).resolve())"
+            ),
+        ],
+        cwd=cwd,
+        env=env,
+    )
+    installed_path = Path(result.stdout.strip()).resolve()
+    try:
+        installed_path.relative_to(environment.resolve())
+    except ValueError as error:
+        raise WorkspaceBackupSmokeTestError(
+            "Smoke test imported paper_data_suite outside the isolated environment: "
+            f"{installed_path}"
+        ) from error
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while True:
+            chunk = stream.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _relative(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _snapshot_tree(root: Path) -> TreeSnapshot:
+    directories: list[str] = []
+    files: list[FileSnapshot] = []
+    for current, dirnames, filenames in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        dirnames.sort()
+        filenames.sort()
+        for name in dirnames:
+            path = current_path / name
+            if path.is_symlink():
+                raise WorkspaceBackupSmokeTestError(
+                    f"Synthetic smoke tree unexpectedly contains a symlink: {path}"
+                )
+            directories.append(_relative(root, path))
+        for name in filenames:
+            path = current_path / name
+            if path.is_symlink() or not path.is_file():
+                raise WorkspaceBackupSmokeTestError(
+                    f"Synthetic smoke tree contains unsupported file entry: {path}"
+                )
+            files.append(
+                FileSnapshot(
+                    path=_relative(root, path),
+                    size=path.stat().st_size,
+                    sha256=_sha256(path),
+                )
+            )
+    return TreeSnapshot(
+        directories=tuple(sorted(directories)),
+        files=tuple(sorted(files, key=lambda item: item.path)),
+    )
+
+
+def _json_object(path: Path) -> dict[str, object]:
+    try:
+        raw: object = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise WorkspaceBackupSmokeTestError(
+            f"Could not read backup manifest as UTF-8 JSON: {path}"
+        ) from error
+    if not isinstance(raw, dict) or any(not isinstance(key, str) for key in raw):
+        raise WorkspaceBackupSmokeTestError("Backup manifest is not a JSON object.")
+    return cast(dict[str, object], raw)
+
+
+def _string_list(value: object, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise WorkspaceBackupSmokeTestError(f"{label} is not a string array.")
+    return tuple(cast(list[str], value))
+
+
+def _manifest_file_entries(value: object) -> tuple[FileSnapshot, ...]:
+    if not isinstance(value, list):
+        raise WorkspaceBackupSmokeTestError("Manifest files is not an array.")
+    result: list[FileSnapshot] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict) or any(not isinstance(key, str) for key in item):
+            raise WorkspaceBackupSmokeTestError(
+                f"Manifest files[{index}] is not an object."
+            )
+        mapping = cast(dict[str, object], item)
+        if frozenset(mapping) != _FILE_KEYS:
+            raise WorkspaceBackupSmokeTestError(
+                f"Manifest files[{index}] has unexpected fields."
+            )
+        path = mapping.get("path")
+        size = mapping.get("size")
+        sha256 = mapping.get("sha256")
+        if not isinstance(path, str):
+            raise WorkspaceBackupSmokeTestError(
+                f"Manifest files[{index}].path is invalid."
+            )
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            raise WorkspaceBackupSmokeTestError(
+                f"Manifest files[{index}].size is invalid."
+            )
+        if (
+            not isinstance(sha256, str)
+            or len(sha256) != 64
+            or any(character not in "0123456789abcdef" for character in sha256)
+        ):
+            raise WorkspaceBackupSmokeTestError(
+                f"Manifest files[{index}].sha256 is invalid."
+            )
+        result.append(FileSnapshot(path=path, size=size, sha256=sha256))
+    return tuple(result)
+
+
+def _contains_string(value: object, needle: str) -> bool:
+    if isinstance(value, str):
+        return needle in value
+    if isinstance(value, list):
+        return any(_contains_string(item, needle) for item in value)
+    if isinstance(value, dict):
+        return any(_contains_string(item, needle) for item in value.values())
+    return False
+
+
+def _assert_manifest_matches_source(
+    manifest_path: Path,
+    *,
+    source_root: Path,
+    final_root: Path,
+    source: TreeSnapshot,
+) -> None:
+    manifest = _json_object(manifest_path)
+    if _contains_string(manifest, str(source_root.resolve())):
+        raise WorkspaceBackupSmokeTestError(
+            "Portable manifest leaked the absolute source workspace path."
+        )
+    if frozenset(manifest) != _MANIFEST_KEYS:
+        raise WorkspaceBackupSmokeTestError("Backup manifest fields are unexpected.")
+    expected_scalars = {
+        "record_type": "pds_workspace_backup_manifest",
+        "schema_version": "1",
+        "backup_id": final_root.name,
+        "payload_root": "workspace",
+        "hash_algorithm": "sha256",
+    }
+    for key, expected in expected_scalars.items():
+        if manifest.get(key) != expected:
+            raise WorkspaceBackupSmokeTestError(
+                f"Unexpected manifest {key}: {manifest.get(key)!r}"
+            )
+    for key in ("created_at", "suite_version", "core_version"):
+        value = manifest.get(key)
+        if not isinstance(value, str) or not value:
+            raise WorkspaceBackupSmokeTestError(f"Manifest {key} is invalid.")
+    if manifest.get("exclusions") != []:
+        raise WorkspaceBackupSmokeTestError("Manifest exclusions must be empty in v1.")
+
+    directories = _string_list(manifest.get("directories"), "Manifest directories")
+    files = _manifest_file_entries(manifest.get("files"))
+    if directories != source.directories:
+        raise WorkspaceBackupSmokeTestError(
+            "Manifest directory inventory does not match the source tree."
+        )
+    if files != source.files:
+        raise WorkspaceBackupSmokeTestError(
+            "Manifest file inventory/hashes do not match the source tree."
+        )
+    if manifest.get("directory_count") != len(source.directories):
+        raise WorkspaceBackupSmokeTestError("Manifest directory_count is incorrect.")
+    if manifest.get("file_count") != len(source.files):
+        raise WorkspaceBackupSmokeTestError("Manifest file_count is incorrect.")
+    expected_bytes = sum(item.size for item in source.files)
+    if manifest.get("total_bytes") != expected_bytes:
+        raise WorkspaceBackupSmokeTestError("Manifest total_bytes is incorrect.")
+
+
+def _assert_clean_directory(path: Path) -> None:
+    contents = tuple(path.iterdir())
+    if contents:
+        raise WorkspaceBackupSmokeTestError(
+            "Workspace-backup smoke created working-directory artifacts: "
+            + ", ".join(item.name for item in contents)
+        )
+
+
+def _assert_help(output: str) -> None:
+    normalized = " ".join(output.split())
+    required = (
+        "currently resolved Core workspace",
+        "--destination",
+        "--yes",
+        "potentially sensitive data",
+        "does not encrypt, upload, or cloud-sync",
+    )
+    missing = [fragment for fragment in required if fragment not in normalized]
+    if missing:
+        raise WorkspaceBackupSmokeTestError(
+            "Installed backup help is missing expected content: " + ", ".join(missing)
+        )
+
+
+def _exercise_installed_collision(
+    python: Path,
+    *,
+    destination: Path,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> None:
+    code = """
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+from paper_data_suite.workspace_backup import (
+    WorkspaceBackupCollisionError,
+    backup_name,
+    plan_workspace_backup,
+)
+
+destination = Path(sys.argv[1])
+fixed = datetime(2026, 8, 20, 19, 1, 2, 345678, tzinfo=timezone.utc)
+final_root = destination / backup_name(fixed)
+final_root.mkdir(parents=True)
+sentinel = final_root / "sentinel.txt"
+sentinel.write_text("preserve", encoding="utf-8")
+try:
+    plan_workspace_backup(destination, clock=lambda: fixed)
+except WorkspaceBackupCollisionError:
+    pass
+else:
+    raise SystemExit("collision was not refused")
+if sentinel.read_text(encoding="utf-8") != "preserve":
+    raise SystemExit("collision modified the existing backup")
+""".strip()
+    _run(
+        [str(python), "-c", code, str(destination)],
+        cwd=cwd,
+        env=env,
+    )
+
+
+def smoke_test_workspace_backup_wheel(
+    suite_wheel: Path,
+    core_wheel: Path,
+) -> None:
+    """Exercise installed whole-workspace backup creation beside exact Core."""
+    suite_wheel = suite_wheel.resolve()
+    core_wheel = core_wheel.resolve()
+    if not suite_wheel.is_file():
+        raise WorkspaceBackupSmokeTestError(
+            f"Suite wheel does not exist: {suite_wheel}"
+        )
+    if not core_wheel.is_file():
+        raise WorkspaceBackupSmokeTestError(f"Core wheel does not exist: {core_wheel}")
+
+    with tempfile.TemporaryDirectory(prefix="pds-backup-smoke-") as temporary:
+        temp_root = Path(temporary)
+        environment = temp_root / "venv"
+        run_directory = temp_root / "run"
+        user_home = temp_root / "user"
+        workspace = temp_root / "workspace"
+        backup_parent = temp_root / "backups"
+        cancel_parent = temp_root / "cancel-backups"
+        collision_parent = temp_root / "collision-backups"
+        run_directory.mkdir()
+        user_home.mkdir()
+
+        venv.EnvBuilder(with_pip=True).create(environment)
+        python = _venv_python(environment)
+        command_env = _isolated_command_env(os.environ, user_home=user_home)
+
+        _run(
+            [str(python), "-m", "pip", "install", "--no-deps", str(core_wheel)],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _run(
+            [str(python), "-m", "pip", "install", "--no-deps", str(suite_wheel)],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _run(
+            [str(python), "-m", "pip", "check"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _assert_installed_suite_location(
+            python,
+            environment=environment,
+            cwd=run_directory,
+            env=command_env,
+        )
+
+        scripts = _scripts_directory(
+            python,
+            cwd=run_directory,
+            env=command_env,
+        )
+        launcher = scripts / ("pds.exe" if os.name == "nt" else "pds")
+        if not launcher.is_file():
+            raise WorkspaceBackupSmokeTestError(
+                f"Installed pds launcher does not exist: {launcher}"
+            )
+
+        module_help = _run(
+            [
+                str(python),
+                "-m",
+                "paper_data_suite",
+                "backup",
+                "create",
+                "--help",
+            ],
+            cwd=run_directory,
+            env=command_env,
+        )
+        console_help = _run(
+            [str(launcher), "backup", "create", "--help"],
+            cwd=run_directory,
+            env=command_env,
+        )
+        _assert_help(module_help.stdout)
+        _assert_help(console_help.stdout)
+
+        _run(
+            [str(launcher), "workspace", "set", str(workspace)],
+            cwd=run_directory,
+            env=command_env,
+        )
+        (workspace / "classes" / "future-module" / "empty").mkdir(parents=True)
+        (workspace / "classes" / "future-module" / "opaque.bin").write_bytes(
+            b"\x00\xffsynthetic"
+        )
+        (workspace / ".hidden").write_text("synthetic hidden", encoding="utf-8")
+        (workspace / "zero.dat").write_bytes(b"")
+        sensitive_name = workspace / "classes" / "student-private.csv"
+        sensitive_name.write_text("synthetic-only", encoding="utf-8")
+        source_before = _snapshot_tree(workspace)
+
+        cancelled = _run(
+            [
+                str(python),
+                "-m",
+                "paper_data_suite",
+                "backup",
+                "create",
+                "--destination",
+                str(cancel_parent),
+            ],
+            cwd=run_directory,
+            env=command_env,
+            input_text="Q\n",
+        )
+        if "No backup was created" not in cancelled.stdout:
+            raise WorkspaceBackupSmokeTestError(
+                "Installed module-form cancellation did not report no creation."
+            )
+        if cancel_parent.exists():
+            raise WorkspaceBackupSmokeTestError(
+                "Cancellation created the destination before confirmation."
+            )
+
+        inside = workspace / "backup-destination"
+        refused = _run(
+            [
+                str(launcher),
+                "backup",
+                "create",
+                "--destination",
+                str(inside),
+                "--yes",
+            ],
+            cwd=run_directory,
+            env=command_env,
+            expected_returncode=1,
+        )
+        if "Backup refused" not in refused.stderr:
+            raise WorkspaceBackupSmokeTestError(
+                "Installed backup did not clearly refuse an inside-workspace "
+                "destination."
+            )
+        if inside.exists():
+            raise WorkspaceBackupSmokeTestError(
+                "Inside-workspace refusal created destination state."
+            )
+
+        created = _run(
+            [
+                str(launcher),
+                "backup",
+                "create",
+                "--destination",
+                str(backup_parent),
+                "--yes",
+            ],
+            cwd=run_directory,
+            env=command_env,
+        )
+        if "Workspace backup complete" not in created.stdout:
+            raise WorkspaceBackupSmokeTestError(
+                "Installed backup did not report verified completion."
+            )
+        if sensitive_name.name in created.stdout:
+            raise WorkspaceBackupSmokeTestError(
+                "Normal installed backup output leaked a payload filename."
+            )
+
+        completed = tuple(
+            path
+            for path in backup_parent.iterdir()
+            if path.is_dir() and path.name.startswith("pds-workspace-backup-")
+        )
+        if len(completed) != 1:
+            raise WorkspaceBackupSmokeTestError(
+                f"Expected one completed backup, found {len(completed)}."
+            )
+        incomplete = tuple(backup_parent.glob(".*.incomplete-*"))
+        if incomplete:
+            raise WorkspaceBackupSmokeTestError(
+                "Successful backup left incomplete staging state."
+            )
+        final_root = completed[0]
+        manifest_path = final_root / "manifest.json"
+        payload_root = final_root / "workspace"
+        if not manifest_path.is_file() or not payload_root.is_dir():
+            raise WorkspaceBackupSmokeTestError(
+                "Completed backup does not contain manifest.json plus workspace/."
+            )
+
+        source_after = _snapshot_tree(workspace)
+        if source_after != source_before:
+            raise WorkspaceBackupSmokeTestError(
+                "Backup creation modified the source workspace tree."
+            )
+        payload = _snapshot_tree(payload_root)
+        if payload != source_before:
+            raise WorkspaceBackupSmokeTestError(
+                "Backup payload does not independently match source bytes/tree."
+            )
+        _assert_manifest_matches_source(
+            manifest_path,
+            source_root=workspace,
+            final_root=final_root,
+            source=source_before,
+        )
+        manifest_hash = _sha256(manifest_path)
+        if f"Manifest SHA-256: {manifest_hash}" not in created.stdout:
+            raise WorkspaceBackupSmokeTestError(
+                "Completion output manifest SHA-256 does not match persisted bytes."
+            )
+
+        _exercise_installed_collision(
+            python,
+            destination=collision_parent,
+            cwd=run_directory,
+            env=command_env,
+        )
+        _assert_clean_directory(run_directory)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the installed workspace-backup smoke-test parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Install the built Paper Data Suite wheel beside the exact Core wheel "
+            "and exercise whole-workspace backup creation in an isolated profile."
+        )
+    )
+    parser.add_argument("suite_wheel", type=Path)
+    parser.add_argument("core_wheel", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run installed whole-workspace backup acceptance from the command line."""
+    arguments = build_parser().parse_args(argv)
+    try:
+        smoke_test_workspace_backup_wheel(
+            arguments.suite_wheel,
+            arguments.core_wheel,
+        )
+    except WorkspaceBackupSmokeTestError as error:
+        print(f"Workspace backup smoke test failed: {error}", file=sys.stderr)
+        return 1
+    print("Workspace backup wheel smoke test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_test_workspace_backup_wheel.py
+++ b/tests/test_smoke_test_workspace_backup_wheel.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import smoke_test_workspace_backup_wheel
+
+
+def test_main_invokes_workspace_backup_smoke_with_cli_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "suite.whl"
+    core = tmp_path / "core.whl"
+    observed: list[tuple[Path, Path]] = []
+
+    def fake_smoke(suite_wheel: Path, core_wheel: Path) -> None:
+        observed.append((suite_wheel, core_wheel))
+
+    monkeypatch.setattr(
+        smoke_test_workspace_backup_wheel,
+        "smoke_test_workspace_backup_wheel",
+        fake_smoke,
+    )
+
+    assert smoke_test_workspace_backup_wheel.main((str(suite), str(core))) == 0
+    assert observed == [(suite, core)]
+    assert capsys.readouterr().out.strip() == (
+        "Workspace backup wheel smoke test passed."
+    )
+
+
+def test_main_returns_failure_when_workspace_backup_smoke_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "suite.whl"
+    core = tmp_path / "core.whl"
+
+    def fail_smoke(suite_wheel: Path, core_wheel: Path) -> None:
+        del suite_wheel, core_wheel
+        raise smoke_test_workspace_backup_wheel.WorkspaceBackupSmokeTestError(
+            "synthetic failure"
+        )
+
+    monkeypatch.setattr(
+        smoke_test_workspace_backup_wheel,
+        "smoke_test_workspace_backup_wheel",
+        fail_smoke,
+    )
+
+    assert smoke_test_workspace_backup_wheel.main((str(suite), str(core))) == 1
+    assert "synthetic failure" in capsys.readouterr().err
+
+
+def test_isolated_command_env_removes_workspace_and_pythonpath_variants(
+    tmp_path: Path,
+) -> None:
+    result = smoke_test_workspace_backup_wheel._isolated_command_env(
+        {
+            "PATH": "synthetic",
+            "PYTHONPATH": "source-a",
+            "PythonPath": "source-b",
+            "PDS_WORKSPACE_ROOT": "real-workspace",
+        },
+        user_home=tmp_path / "user",
+    )
+
+    assert result["PATH"] == "synthetic"
+    assert all(key.upper() != "PYTHONPATH" for key in result)
+    assert all(key.upper() != "PDS_WORKSPACE_ROOT" for key in result)
+    assert result["PYTHONNOUSERSITE"] == "1"
+    assert result["HOME"] == str(tmp_path / "user")
+    assert result["USERPROFILE"] == str(tmp_path / "user")
+
+
+def test_snapshot_tree_preserves_empty_hidden_binary_and_zero_byte_content(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    (root / "nested" / "empty").mkdir(parents=True)
+    (root / ".hidden").write_text("hidden", encoding="utf-8")
+    (root / "nested" / "opaque.bin").write_bytes(b"\x00\xff")
+    (root / "zero.dat").write_bytes(b"")
+
+    snapshot = smoke_test_workspace_backup_wheel._snapshot_tree(root)
+
+    assert snapshot.directories == ("nested", "nested/empty")
+    assert tuple(item.path for item in snapshot.files) == (
+        ".hidden",
+        "nested/opaque.bin",
+        "zero.dat",
+    )
+    assert tuple(item.size for item in snapshot.files) == (6, 2, 0)
+
+
+def test_manifest_assertion_rejects_absolute_source_path_leak(tmp_path: Path) -> None:
+    source = tmp_path / "workspace"
+    final = tmp_path / "backup" / "pds-workspace-backup-20260820T190102345678Z"
+    final.mkdir(parents=True)
+    manifest = final / "manifest.json"
+    payload = {
+        "record_type": "pds_workspace_backup_manifest",
+        "schema_version": "1",
+        "backup_id": final.name,
+        "created_at": "2026-08-20T19:01:02.345678Z",
+        "suite_version": "0.1.0.dev0",
+        "core_version": "0.6.0",
+        "payload_root": "workspace",
+        "hash_algorithm": "sha256",
+        "directory_count": 0,
+        "file_count": 0,
+        "total_bytes": 0,
+        "directories": [],
+        "files": [],
+        "exclusions": [],
+        "source": str(source.resolve()),
+    }
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        smoke_test_workspace_backup_wheel.WorkspaceBackupSmokeTestError,
+        match="absolute source workspace path",
+    ):
+        smoke_test_workspace_backup_wheel._assert_manifest_matches_source(
+            manifest,
+            source_root=source,
+            final_root=final,
+            source=smoke_test_workspace_backup_wheel.TreeSnapshot((), ()),
+        )

--- a/tests/test_workspace_backup.py
+++ b/tests/test_workspace_backup.py
@@ -1,0 +1,888 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from paper_data_suite.compatibility import load_release_compatibility_manifest
+from paper_data_suite.workspace_backup import (
+    BACKUP_MANIFEST_RECORD_TYPE,
+    BACKUP_MANIFEST_SCHEMA_VERSION,
+    BACKUP_MINIMUM_RESERVE_BYTES,
+    BACKUP_PAYLOAD_ROOT,
+    BackupFileEntry,
+    CoreBackupServices,
+    WorkspaceBackupCollisionError,
+    WorkspaceBackupCopyError,
+    WorkspaceBackupDestinationError,
+    WorkspaceBackupDriftError,
+    WorkspaceBackupManifestError,
+    WorkspaceBackupSourceError,
+    WorkspaceBackupSpaceError,
+    WorkspaceBackupUnsupportedEntryError,
+    WorkspaceBackupVerificationError,
+    backup_name,
+    create_workspace_backup,
+    create_workspace_backup_manifest,
+    inventory_workspace,
+    load_core_backup_services,
+    parse_workspace_backup_manifest,
+    plan_workspace_backup,
+    required_backup_free_bytes,
+    serialize_workspace_backup_manifest,
+    workspace_backup_manifest_sha256,
+)
+from paper_data_suite.workspace_setup import WorkspaceInspector
+
+
+@dataclass
+class FakeStatus:
+    root: Path
+    source: str
+    exists: bool
+    is_dir: bool
+    is_writable: bool
+    config_path: Path
+    default_root: Path
+
+
+class FakeCoreBackup:
+    def __init__(
+        self,
+        root: Path,
+        *,
+        source: str = "saved_config",
+        exists: bool | None = None,
+        is_dir: bool | None = None,
+    ) -> None:
+        self.root = root
+        self.source = source
+        self._exists = exists
+        self._is_dir = is_dir
+        self.inspect_calls = 0
+
+    def inspect(self, explicit_root: str | Path | None = None) -> FakeStatus:
+        assert explicit_root is None
+        self.inspect_calls += 1
+        exists = self.root.exists() if self._exists is None else self._exists
+        is_dir = self.root.is_dir() if self._is_dir is None else self._is_dir
+        return FakeStatus(
+            root=self.root,
+            source=self.source,
+            exists=exists,
+            is_dir=is_dir,
+            is_writable=False,
+            config_path=self.root.parent / "config.json",
+            default_root=self.root.parent / "default",
+        )
+
+    def services(self, core_version: str = "0.6.0") -> CoreBackupServices:
+        return CoreBackupServices(
+            inspect_workspace_root=cast(WorkspaceInspector, self.inspect),
+            core_version=core_version,
+        )
+
+
+FIXED_TIME = datetime(2026, 8, 20, 17, 48, 12, 123456, tzinfo=timezone.utc)
+EXPECTED_NAME = "pds-workspace-backup-20260820T174812123456Z"
+
+
+def free_space(value: int):  # type: ignore[no-untyped-def]
+    return lambda _path: SimpleNamespace(total=value * 2, used=value, free=value)
+
+
+def test_backup_name_is_utc_and_windows_safe() -> None:
+    eastern = timezone(-timedelta(hours=4))
+    local = datetime(2026, 8, 20, 13, 48, 12, 123456, tzinfo=eastern)
+
+    assert backup_name(local) == EXPECTED_NAME
+    assert ":" not in backup_name(local)
+
+
+def test_backup_name_rejects_naive_datetime() -> None:
+    with pytest.raises(WorkspaceBackupManifestError, match="timezone-aware"):
+        backup_name(datetime(2026, 8, 20, 17, 48, 12))
+
+
+def test_required_space_uses_minimum_reserve_and_two_percent() -> None:
+    assert required_backup_free_bytes(0) == BACKUP_MINIMUM_RESERVE_BYTES
+    assert required_backup_free_bytes(1024) == 1024 + BACKUP_MINIMUM_RESERVE_BYTES
+
+    large = 10 * 1024 * 1024 * 1024
+    assert required_backup_free_bytes(large) == (
+        large + ((large * 2 + 99) // 100)
+    )
+
+
+def test_inventory_is_complete_sorted_and_opaque(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    (root / ".pds").mkdir(parents=True)
+    (root / "classes" / "future-module" / "empty").mkdir(parents=True)
+    (root / "classes" / "future-module" / "opaque.bin").write_bytes(b"\x00\xffx")
+    (root / ".hidden").write_text("secret-looking", encoding="utf-8")
+    (root / "zero.dat").write_bytes(b"")
+
+    inventory = inventory_workspace(root)
+
+    assert inventory.directories == (
+        ".pds",
+        "classes",
+        "classes/future-module",
+        "classes/future-module/empty",
+    )
+    assert tuple(item.path for item in inventory.files) == (
+        ".hidden",
+        "classes/future-module/opaque.bin",
+        "zero.dat",
+    )
+    assert tuple(item.size for item in inventory.files) == (14, 3, 0)
+    assert inventory.total_bytes == 17
+
+
+def test_inventory_rejects_symlink_without_following_it(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.write_text("do not copy", encoding="utf-8")
+    link = root / "outside-link"
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation unavailable")
+
+    with pytest.raises(
+        WorkspaceBackupUnsupportedEntryError,
+        match="does not follow linked filesystem entry",
+    ):
+        inventory_workspace(root)
+
+
+def _planned_backup(tmp_path: Path):  # type: ignore[no-untyped-def]
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "empty").mkdir()
+    (root / "alpha.bin").write_bytes(b"alpha")
+    destination = tmp_path / "backups"
+    fake = FakeCoreBackup(root)
+    required = required_backup_free_bytes(5)
+    plan = plan_workspace_backup(
+        destination,
+        services=fake.services(),
+        clock=lambda: FIXED_TIME,
+        disk_usage_reader=free_space(required),
+    )
+    return root, destination, fake, plan
+
+
+def test_plan_is_read_only_and_does_not_require_source_writability(
+    tmp_path: Path,
+) -> None:
+    root, destination, fake, plan = _planned_backup(tmp_path)
+
+    assert fake.inspect_calls == 1
+    assert plan.workspace_root == root.resolve()
+    assert plan.workspace_source == "saved_config"
+    assert plan.destination_parent == destination.resolve()
+    assert plan.final_backup_root == destination.resolve() / EXPECTED_NAME
+    assert plan.backup_id == EXPECTED_NAME
+    assert plan.destination_parent_exists is False
+    assert plan.inventory.file_count == 1
+    assert plan.inventory.directory_count == 1
+    assert plan.inventory.total_bytes == 5
+    assert not destination.exists()
+    assert (root / "alpha.bin").read_bytes() == b"alpha"
+
+
+def test_plan_refuses_missing_workspace(tmp_path: Path) -> None:
+    root = tmp_path / "missing"
+    fake = FakeCoreBackup(root, exists=False, is_dir=False)
+
+    with pytest.raises(WorkspaceBackupSourceError, match="does not exist"):
+        plan_workspace_backup(
+            tmp_path / "backups",
+            services=fake.services(),
+            clock=lambda: FIXED_TIME,
+            disk_usage_reader=free_space(10**9),
+        )
+
+
+def test_plan_refuses_non_directory_workspace(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.write_text("not a directory", encoding="utf-8")
+    fake = FakeCoreBackup(root, exists=True, is_dir=False)
+
+    with pytest.raises(WorkspaceBackupSourceError, match="not a directory"):
+        plan_workspace_backup(
+            tmp_path / "backups",
+            services=fake.services(),
+            clock=lambda: FIXED_TIME,
+            disk_usage_reader=free_space(10**9),
+        )
+
+
+@pytest.mark.parametrize("relative", (".", "child", "child/grandchild"))
+def test_plan_refuses_destination_at_or_inside_workspace(
+    tmp_path: Path,
+    relative: str,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    destination = root if relative == "." else root / relative
+
+    with pytest.raises(WorkspaceBackupDestinationError, match="outside"):
+        plan_workspace_backup(
+            destination,
+            services=FakeCoreBackup(root).services(),
+            clock=lambda: FIXED_TIME,
+            disk_usage_reader=free_space(10**9),
+        )
+
+
+def test_plan_allows_safe_destination_parent_that_contains_workspace_sibling(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+
+    plan = plan_workspace_backup(
+        tmp_path,
+        services=FakeCoreBackup(root).services(),
+        clock=lambda: FIXED_TIME,
+        disk_usage_reader=free_space(10**9),
+    )
+
+    assert plan.final_backup_root == tmp_path / EXPECTED_NAME
+
+
+def test_plan_resolves_destination_alias_before_containment(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    alias = tmp_path / "alias"
+    try:
+        alias.symlink_to(root, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlink creation unavailable")
+
+    with pytest.raises(WorkspaceBackupDestinationError, match="outside"):
+        plan_workspace_backup(
+            alias,
+            services=FakeCoreBackup(root).services(),
+            clock=lambda: FIXED_TIME,
+            disk_usage_reader=free_space(10**9),
+        )
+
+
+def test_plan_refuses_existing_final_backup_collision(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    destination = tmp_path / "backups"
+    root.mkdir()
+    destination.mkdir()
+    (destination / EXPECTED_NAME).mkdir()
+
+    with pytest.raises(WorkspaceBackupCollisionError, match="will not be overwritten"):
+        plan_workspace_backup(
+            destination,
+            services=FakeCoreBackup(root).services(),
+            clock=lambda: FIXED_TIME,
+            disk_usage_reader=free_space(10**9),
+        )
+
+
+def test_plan_refuses_insufficient_space_and_accepts_exact_threshold(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "payload").write_bytes(b"12345")
+    required = required_backup_free_bytes(5)
+
+    with pytest.raises(WorkspaceBackupSpaceError, match="Insufficient"):
+        plan_workspace_backup(
+            tmp_path / "backups",
+            services=FakeCoreBackup(root).services(),
+            clock=lambda: FIXED_TIME,
+            disk_usage_reader=free_space(required - 1),
+        )
+
+    plan = plan_workspace_backup(
+        tmp_path / "backups",
+        services=FakeCoreBackup(root).services(),
+        clock=lambda: FIXED_TIME,
+        disk_usage_reader=free_space(required),
+    )
+    assert plan.destination_free_bytes == required
+    assert plan.required_free_bytes == required
+
+
+def test_plan_refuses_destination_that_is_a_file(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    destination = tmp_path / "backups"
+    destination.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(WorkspaceBackupDestinationError, match="not a directory"):
+        plan_workspace_backup(
+            destination,
+            services=FakeCoreBackup(root).services(),
+            clock=lambda: FIXED_TIME,
+            disk_usage_reader=free_space(10**9),
+        )
+
+
+def test_plan_reports_free_space_provider_failure(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+
+    def fail(_path: str | os.PathLike[str]):
+        raise OSError("synthetic disk query failure")
+
+    with pytest.raises(WorkspaceBackupDestinationError, match="free space"):
+        plan_workspace_backup(
+            tmp_path / "backups",
+            services=FakeCoreBackup(root).services(),
+            clock=lambda: FIXED_TIME,
+            disk_usage_reader=fail,
+        )
+
+
+def test_manifest_is_deterministic_portable_and_round_trips(tmp_path: Path) -> None:
+    _root, _destination, _fake, plan = _planned_backup(tmp_path)
+    digest = hashlib.sha256(b"alpha").hexdigest()
+    manifest = create_workspace_backup_manifest(
+        plan,
+        (BackupFileEntry(path="alpha.bin", size=5, sha256=digest),),
+    )
+
+    first = serialize_workspace_backup_manifest(manifest)
+    second = serialize_workspace_backup_manifest(manifest)
+    parsed = parse_workspace_backup_manifest(first)
+
+    assert first == second
+    assert parsed == manifest
+    assert manifest.record_type == BACKUP_MANIFEST_RECORD_TYPE
+    assert manifest.schema_version == BACKUP_MANIFEST_SCHEMA_VERSION
+    assert manifest.payload_root == BACKUP_PAYLOAD_ROOT
+    assert manifest.exclusions == ()
+    assert str(plan.workspace_root).encode() not in first
+    assert b"saved_config" not in first
+    assert workspace_backup_manifest_sha256(manifest) == (
+        hashlib.sha256(first).hexdigest()
+    )
+    assert first.endswith(b"\n")
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        r"folder\child.txt",
+        r"..\outside.txt",
+        "C:relative.txt",
+        "file.txt:stream",
+        "line\nbreak.txt",
+    ),
+)
+def test_manifest_paths_reject_nonportable_or_control_syntax(path: str) -> None:
+    with pytest.raises(WorkspaceBackupManifestError, match="path"):
+        BackupFileEntry(path=path, size=0, sha256="0" * 64)
+
+
+def test_manifest_file_entries_must_match_reviewed_inventory(tmp_path: Path) -> None:
+    _root, _destination, _fake, plan = _planned_backup(tmp_path)
+    digest = "0" * 64
+
+    with pytest.raises(WorkspaceBackupManifestError, match="do not match"):
+        create_workspace_backup_manifest(
+            plan,
+            (BackupFileEntry(path="different.bin", size=5, sha256=digest),),
+        )
+
+
+def test_manifest_parser_rejects_unknown_and_duplicate_fields(tmp_path: Path) -> None:
+    _root, _destination, _fake, plan = _planned_backup(tmp_path)
+    manifest = create_workspace_backup_manifest(
+        plan,
+        (
+            BackupFileEntry(
+                path="alpha.bin",
+                size=5,
+                sha256=hashlib.sha256(b"alpha").hexdigest(),
+            ),
+        ),
+    )
+    mapping = json.loads(serialize_workspace_backup_manifest(manifest))
+    mapping["unexpected"] = True
+
+    with pytest.raises(WorkspaceBackupManifestError, match="unknown field"):
+        parse_workspace_backup_manifest(json.dumps(mapping))
+
+    duplicate = '{"record_type":"x","record_type":"y"}'
+    with pytest.raises(WorkspaceBackupManifestError, match="duplicate JSON object key"):
+        parse_workspace_backup_manifest(duplicate)
+
+
+def test_manifest_v1_refuses_nonempty_exclusions(tmp_path: Path) -> None:
+    _root, _destination, _fake, plan = _planned_backup(tmp_path)
+    manifest = create_workspace_backup_manifest(
+        plan,
+        (BackupFileEntry(path="alpha.bin", size=5, sha256="0" * 64),),
+    )
+    mapping = json.loads(serialize_workspace_backup_manifest(manifest))
+    mapping["exclusions"] = ["*.tmp"]
+
+    with pytest.raises(WorkspaceBackupManifestError, match="empty.*exclusions"):
+        parse_workspace_backup_manifest(json.dumps(mapping))
+
+
+def test_load_services_qualifies_core_before_import_and_exposes_reader_only() -> None:
+    manifest = load_release_compatibility_manifest()
+    core = next(
+        component
+        for component in manifest.components
+        if "shared_core" in component.capabilities
+    )
+    events: list[str] = []
+
+    def version_lookup(distribution: str) -> str:
+        events.append(f"version:{distribution}")
+        return core.version
+
+    module = SimpleNamespace(
+        inspect_workspace_root=lambda explicit_root=None: None,
+        ensure_workspace_root=lambda path, create=True: Path(path),
+        save_workspace_root=lambda path: Path(path),
+        clear_saved_workspace_root=lambda: False,
+    )
+
+    def importer(name: str) -> object:
+        events.append(f"import:{name}")
+        return module
+
+    services = load_core_backup_services(
+        manifest,
+        version_lookup=version_lookup,
+        module_importer=importer,
+    )
+
+    assert events == [f"version:{core.distribution}", "import:pds_core.workspace"]
+    assert services.core_version == core.version
+    assert not hasattr(services, "ensure_workspace_root")
+    assert not hasattr(services, "save_workspace_root")
+    assert not hasattr(services, "clear_saved_workspace_root")
+
+
+def _creation_plan(tmp_path: Path):  # type: ignore[no-untyped-def]
+    root = tmp_path / "workspace"
+    (root / ".pds").mkdir(parents=True)
+    (root / "empty").mkdir()
+    (root / "future" / "module").mkdir(parents=True)
+    (root / "alpha.bin").write_bytes(b"alpha")
+    (root / "future" / "module" / "zero.dat").write_bytes(b"")
+    destination = tmp_path / "backups"
+    fake = FakeCoreBackup(root)
+    required = required_backup_free_bytes(5)
+    plan = plan_workspace_backup(
+        destination,
+        services=fake.services(),
+        clock=lambda: FIXED_TIME,
+        disk_usage_reader=free_space(required + 1024),
+    )
+    return root, destination, fake, plan, required
+
+
+def test_create_backup_copies_opaque_tree_verifies_manifest_and_publishes(
+    tmp_path: Path,
+) -> None:
+    root, destination, fake, plan, required = _creation_plan(tmp_path)
+    source_before = {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+    result = create_workspace_backup(
+        plan,
+        services=fake.services(),
+        disk_usage_reader=free_space(required + 1024),
+        staging_nonce_factory=lambda: "fixed",
+        chunk_size=2,
+    )
+
+    assert result.final_backup_root == destination / EXPECTED_NAME
+    assert result.final_backup_root.is_dir()
+    assert result.manifest_path.is_file()
+    assert (result.payload_root / "empty").is_dir()
+    assert (result.payload_root / "future" / "module").is_dir()
+    assert (result.payload_root / "alpha.bin").read_bytes() == b"alpha"
+    assert (result.payload_root / "future" / "module" / "zero.dat").read_bytes() == b""
+    assert parse_workspace_backup_manifest(result.manifest_path.read_bytes()) == (
+        result.manifest
+    )
+    assert result.manifest_sha256 == hashlib.sha256(
+        result.manifest_path.read_bytes()
+    ).hexdigest()
+    assert tuple(entry.path for entry in result.manifest.files) == (
+        "alpha.bin",
+        "future/module/zero.dat",
+    )
+    assert result.manifest.files[0].sha256 == hashlib.sha256(b"alpha").hexdigest()
+    assert not list(destination.glob(".*.incomplete-*"))
+    source_after = {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+    assert source_after == source_before
+
+
+def test_create_backup_rechecks_reviewed_source_before_destination_mutation(
+    tmp_path: Path,
+) -> None:
+    root, destination, fake, plan, required = _creation_plan(tmp_path)
+    (root / "late.bin").write_bytes(b"late")
+
+    with pytest.raises(WorkspaceBackupDriftError, match="after backup preview"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+        )
+
+    assert not destination.exists()
+
+
+def test_create_backup_detects_same_size_source_change_after_copy(
+    tmp_path: Path,
+) -> None:
+    root, destination, fake, plan, required = _creation_plan(tmp_path)
+
+    def mutate(source_root: Path, _payload_root: Path) -> None:
+        (source_root / "alpha.bin").write_bytes(b"bravo")
+
+    with pytest.raises(WorkspaceBackupDriftError, match="changed while"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+            after_copy_hook=mutate,
+        )
+
+    assert not (destination / EXPECTED_NAME).exists()
+    assert not list(destination.glob(".*.incomplete-*"))
+    assert (root / "alpha.bin").read_bytes() == b"bravo"
+
+
+def test_create_backup_detects_added_source_entry_after_copy(tmp_path: Path) -> None:
+    root, destination, fake, plan, required = _creation_plan(tmp_path)
+
+    def mutate(source_root: Path, _payload_root: Path) -> None:
+        (source_root / "added.bin").write_bytes(b"new")
+
+    with pytest.raises(WorkspaceBackupDriftError, match="changed while"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+            after_copy_hook=mutate,
+        )
+
+    assert not (destination / EXPECTED_NAME).exists()
+    assert not list(destination.glob(".*.incomplete-*"))
+
+
+def test_create_backup_detects_removed_source_entry_after_copy(tmp_path: Path) -> None:
+    root, destination, fake, plan, required = _creation_plan(tmp_path)
+
+    def mutate(source_root: Path, _payload_root: Path) -> None:
+        (source_root / "alpha.bin").unlink()
+
+    with pytest.raises(WorkspaceBackupDriftError, match="changed while"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+            after_copy_hook=mutate,
+        )
+
+    assert not (destination / EXPECTED_NAME).exists()
+    assert not list(destination.glob(".*.incomplete-*"))
+
+
+def test_create_backup_detects_directory_change_after_copy(tmp_path: Path) -> None:
+    _root, destination, fake, plan, required = _creation_plan(tmp_path)
+
+    def mutate(source_root: Path, _payload_root: Path) -> None:
+        (source_root / "new-empty-directory").mkdir()
+
+    with pytest.raises(WorkspaceBackupDriftError, match="changed while"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+            after_copy_hook=mutate,
+        )
+
+    assert not (destination / EXPECTED_NAME).exists()
+    assert not list(destination.glob(".*.incomplete-*"))
+
+
+def test_create_backup_cleans_staging_after_copy_failure(tmp_path: Path) -> None:
+    _root, destination, fake, plan, required = _creation_plan(tmp_path)
+
+    def fail_copy(
+        _source_root: Path,
+        _payload_root: Path,
+        relative: str,
+        _chunk_size: int,
+    ) -> BackupFileEntry:
+        raise WorkspaceBackupCopyError(f"synthetic copy failure: {relative}")
+
+    with pytest.raises(WorkspaceBackupCopyError, match="synthetic copy failure"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+            file_copier=fail_copy,
+        )
+
+    assert destination.is_dir()
+    assert not (destination / EXPECTED_NAME).exists()
+    assert not list(destination.glob(".*.incomplete-*"))
+
+
+def test_create_backup_wraps_filesystem_copy_failure_and_cleans_staging(
+    tmp_path: Path,
+) -> None:
+    _root, destination, fake, plan, required = _creation_plan(tmp_path)
+
+    def fail_copy(
+        _source_root: Path,
+        _payload_root: Path,
+        _relative: str,
+        _chunk_size: int,
+    ) -> BackupFileEntry:
+        raise OSError("synthetic disk-full style failure")
+
+    with pytest.raises(WorkspaceBackupCopyError, match="filesystem error"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+            file_copier=fail_copy,
+        )
+
+    assert not (destination / EXPECTED_NAME).exists()
+    assert not list(destination.glob(".*.incomplete-*"))
+
+
+def test_create_backup_manifest_failure_cleans_staging(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.workspace_backup as backup
+
+    _root, destination, fake, plan, required = _creation_plan(tmp_path)
+
+    def fail_manifest(
+        _staging_root: Path,
+        _manifest: object,
+    ) -> str:
+        raise WorkspaceBackupVerificationError("synthetic manifest write failure")
+
+    monkeypatch.setattr(backup, "_write_verified_manifest", fail_manifest)
+
+    with pytest.raises(WorkspaceBackupVerificationError, match="manifest write"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+        )
+
+    assert not (destination / EXPECTED_NAME).exists()
+    assert not list(destination.glob(".*.incomplete-*"))
+
+
+def test_create_backup_reports_staging_when_cleanup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.workspace_backup as backup
+
+    _root, destination, fake, plan, required = _creation_plan(tmp_path)
+
+    def fail_copy(
+        _source_root: Path,
+        _payload_root: Path,
+        _relative: str,
+        _chunk_size: int,
+    ) -> BackupFileEntry:
+        raise WorkspaceBackupCopyError("synthetic copy failure")
+
+    def fail_cleanup(_path: Path) -> None:
+        raise OSError("synthetic cleanup failure")
+
+    monkeypatch.setattr(backup.shutil, "rmtree", fail_cleanup)
+
+    with pytest.raises(WorkspaceBackupCopyError, match="Incomplete staging remains"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+            file_copier=fail_copy,
+        )
+
+    staging = destination / f".{EXPECTED_NAME}.incomplete-fixed"
+    assert staging.is_dir()
+    assert not (destination / EXPECTED_NAME).exists()
+
+
+def test_create_backup_verifies_staged_bytes_independently(tmp_path: Path) -> None:
+    _root, destination, fake, plan, required = _creation_plan(tmp_path)
+
+    def corrupt_copy(
+        _source_root: Path,
+        payload_root: Path,
+        relative: str,
+        _chunk_size: int,
+    ) -> BackupFileEntry:
+        target = payload_root.joinpath(*relative.split("/"))
+        target.write_bytes(b"wrong" if relative == "alpha.bin" else b"")
+        expected_bytes = b"alpha" if relative == "alpha.bin" else b""
+        return BackupFileEntry(
+            path=relative,
+            size=len(expected_bytes),
+            sha256=hashlib.sha256(expected_bytes).hexdigest(),
+        )
+
+    with pytest.raises(WorkspaceBackupVerificationError, match="integrity"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+            file_copier=corrupt_copy,
+        )
+
+    assert not (destination / EXPECTED_NAME).exists()
+    assert not list(destination.glob(".*.incomplete-*"))
+
+
+def test_create_backup_refuses_publication_collision_without_overwrite(
+    tmp_path: Path,
+) -> None:
+    _root, destination, fake, plan, required = _creation_plan(tmp_path)
+
+    def collide(_staging_root: Path, final_root: Path) -> None:
+        final_root.mkdir()
+        (final_root / "sentinel.txt").write_text("preserve", encoding="utf-8")
+
+    with pytest.raises(WorkspaceBackupCollisionError, match="will not be overwritten"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+            before_publish_hook=collide,
+        )
+
+    assert (destination / EXPECTED_NAME / "sentinel.txt").read_text(
+        encoding="utf-8"
+    ) == "preserve"
+    assert not list(destination.glob(".*.incomplete-*"))
+
+
+def test_create_backup_refuses_empty_publication_collision_without_overwrite(
+    tmp_path: Path,
+) -> None:
+    _root, destination, fake, plan, required = _creation_plan(tmp_path)
+
+    def collide(_staging_root: Path, final_root: Path) -> None:
+        final_root.mkdir()
+
+    with pytest.raises(WorkspaceBackupCollisionError, match="will not be overwritten"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+            before_publish_hook=collide,
+        )
+
+    assert (destination / EXPECTED_NAME).is_dir()
+    assert not tuple((destination / EXPECTED_NAME).iterdir())
+    assert not list(destination.glob(".*.incomplete-*"))
+
+
+def test_create_backup_rechecks_free_space_at_execution(tmp_path: Path) -> None:
+    _root, destination, fake, plan, required = _creation_plan(tmp_path)
+
+    with pytest.raises(WorkspaceBackupSpaceError, match="Insufficient"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required - 1),
+            staging_nonce_factory=lambda: "fixed",
+        )
+
+    # Destination parent may be created at the confirmed execution boundary,
+    # but no staging or completed backup is allowed.
+    assert destination.is_dir()
+    assert not (destination / EXPECTED_NAME).exists()
+    assert not list(destination.glob(".*.incomplete-*"))
+
+
+def test_create_backup_refuses_changed_core_workspace_resolution(
+    tmp_path: Path,
+) -> None:
+    _root, destination, fake, plan, required = _creation_plan(tmp_path)
+    replacement = tmp_path / "replacement"
+    replacement.mkdir()
+    fake.root = replacement
+
+    with pytest.raises(WorkspaceBackupDriftError, match="resolved workspace changed"):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+        )
+
+    assert not destination.exists()
+
+
+def test_create_backup_preserves_preexisting_staging_collision(tmp_path: Path) -> None:
+    _root, destination, fake, plan, required = _creation_plan(tmp_path)
+    destination.mkdir()
+    staging = destination / f".{EXPECTED_NAME}.incomplete-fixed"
+    staging.mkdir()
+    sentinel = staging / "sentinel.txt"
+    sentinel.write_text("preserve", encoding="utf-8")
+
+    with pytest.raises(
+        WorkspaceBackupCollisionError,
+        match="staging path already exists",
+    ):
+        create_workspace_backup(
+            plan,
+            services=fake.services(),
+            disk_usage_reader=free_space(required + 1024),
+            staging_nonce_factory=lambda: "fixed",
+        )
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve"
+    assert not (destination / EXPECTED_NAME).exists()

--- a/tests/test_workspace_backup_cli.py
+++ b/tests/test_workspace_backup_cli.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from paper_data_suite.workspace_backup import (
+    BACKUP_HASH_ALGORITHM,
+    BACKUP_MANIFEST_RECORD_TYPE,
+    BACKUP_MANIFEST_SCHEMA_VERSION,
+    BACKUP_PAYLOAD_ROOT,
+    BackupFileEntry,
+    BackupSourceFile,
+    WorkspaceBackupDestinationError,
+    WorkspaceBackupInventory,
+    WorkspaceBackupManifest,
+    WorkspaceBackupPlan,
+    WorkspaceBackupResult,
+    WorkspaceBackupVerificationError,
+)
+from paper_data_suite.workspace_backup_cli import (
+    render_workspace_backup_plan,
+    render_workspace_backup_result,
+    run_workspace_backup_create,
+)
+
+
+def _plan(tmp_path: Path) -> WorkspaceBackupPlan:
+    created = datetime(2026, 8, 20, 18, 45, 1, 123456, tzinfo=timezone.utc)
+    inventory = WorkspaceBackupInventory(
+        directories=("classes", "empty"),
+        files=(BackupSourceFile("classes/student-private.csv", 12),),
+        total_bytes=12,
+    )
+    return WorkspaceBackupPlan(
+        workspace_root=tmp_path / "workspace",
+        workspace_source="saved_config",
+        destination_parent=tmp_path / "backups",
+        final_backup_root=(
+            tmp_path / "backups" / "pds-workspace-backup-20260820T184501123456Z"
+        ),
+        backup_id="pds-workspace-backup-20260820T184501123456Z",
+        created_at=created,
+        suite_version="0.1.0.dev0",
+        core_version="0.6.0",
+        inventory=inventory,
+        destination_free_bytes=100_000_000,
+        required_free_bytes=67_108_876,
+        destination_parent_exists=True,
+    )
+
+
+def _result(plan: WorkspaceBackupPlan) -> WorkspaceBackupResult:
+    manifest = WorkspaceBackupManifest(
+        record_type=BACKUP_MANIFEST_RECORD_TYPE,
+        schema_version=BACKUP_MANIFEST_SCHEMA_VERSION,
+        backup_id=plan.backup_id,
+        created_at=plan.created_at,
+        suite_version=plan.suite_version,
+        core_version=plan.core_version,
+        payload_root=BACKUP_PAYLOAD_ROOT,
+        hash_algorithm=BACKUP_HASH_ALGORITHM,
+        directory_count=2,
+        file_count=1,
+        total_bytes=12,
+        directories=("classes", "empty"),
+        files=(BackupFileEntry("classes/student-private.csv", 12, "a" * 64),),
+        exclusions=(),
+    )
+    return WorkspaceBackupResult(
+        final_backup_root=plan.final_backup_root,
+        manifest=manifest,
+        manifest_sha256="b" * 64,
+    )
+
+
+def test_render_plan_is_bounded_and_privacy_explicit(tmp_path: Path) -> None:
+    output = render_workspace_backup_plan(_plan(tmp_path))
+    assert "saved workspace selection" in output
+    assert "Directories: 2" in output
+    assert "Files: 1" in output
+    assert "Minimum required free bytes" in output
+    assert "potentially sensitive" in output
+    assert "does not encrypt, upload, or cloud-sync" in output
+    assert "student-private.csv" not in output
+    assert "No backup has been created yet." in output
+
+
+def test_render_result_is_bounded_and_explains_hash_limit(tmp_path: Path) -> None:
+    plan = _plan(tmp_path)
+    output = render_workspace_backup_result(plan, _result(plan))
+    assert "Workspace backup complete" in output
+    assert f"Backup: {plan.final_backup_root}" in output
+    assert "Manifest SHA-256: " + "b" * 64 in output
+    assert "does not encrypt or authenticate" in output
+    assert "student-private.csv" not in output
+
+
+def test_interactive_q_cancels_before_create(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import paper_data_suite.workspace_backup_cli as cli
+
+    plan = _plan(tmp_path)
+    monkeypatch.setattr(cli, "plan_workspace_backup", lambda _destination: plan)
+    monkeypatch.setattr(
+        cli,
+        "create_workspace_backup",
+        lambda _plan: pytest.fail("creator must not run on cancellation"),
+    )
+    assert run_workspace_backup_create(
+        tmp_path / "backups", input_fn=lambda _prompt: "Q"
+    ) == 0
+    assert "No backup was created" in capsys.readouterr().out
+
+
+def test_confirmation_requires_exact_uppercase_backup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import paper_data_suite.workspace_backup_cli as cli
+
+    plan = _plan(tmp_path)
+    responses = iter(("backup", "Q"))
+    monkeypatch.setattr(cli, "plan_workspace_backup", lambda _destination: plan)
+    monkeypatch.setattr(
+        cli,
+        "create_workspace_backup",
+        lambda _plan: pytest.fail("lowercase backup must not authorize creation"),
+    )
+    assert run_workspace_backup_create(
+        tmp_path / "backups", input_fn=lambda _prompt: next(responses)
+    ) == 0
+    output = capsys.readouterr().out
+    assert "exact uppercase BACKUP" in output
+    assert "No backup was created" in output
+
+
+def test_exact_backup_authorizes_creator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import paper_data_suite.workspace_backup_cli as cli
+
+    plan = _plan(tmp_path)
+    result = _result(plan)
+    calls: list[WorkspaceBackupPlan] = []
+    monkeypatch.setattr(cli, "plan_workspace_backup", lambda _destination: plan)
+
+    def create(received: WorkspaceBackupPlan) -> WorkspaceBackupResult:
+        calls.append(received)
+        return result
+
+    monkeypatch.setattr(cli, "create_workspace_backup", create)
+    assert run_workspace_backup_create(
+        tmp_path / "backups", input_fn=lambda _prompt: "BACKUP"
+    ) == 0
+    assert calls == [plan]
+    assert "Workspace backup complete" in capsys.readouterr().out
+
+
+def test_yes_bypasses_prompt_but_still_renders_preview(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import paper_data_suite.workspace_backup_cli as cli
+
+    plan = _plan(tmp_path)
+    result = _result(plan)
+    monkeypatch.setattr(cli, "plan_workspace_backup", lambda _destination: plan)
+    monkeypatch.setattr(cli, "create_workspace_backup", lambda _plan: result)
+
+    def no_input(_prompt: str) -> str:
+        raise AssertionError("--yes must bypass interactive input")
+
+    assert run_workspace_backup_create(
+        tmp_path / "backups", assume_yes=True, input_fn=no_input
+    ) == 0
+    output = capsys.readouterr().out
+    assert "No backup has been created yet." in output
+    assert "Workspace backup complete" in output
+
+
+def test_preflight_failure_is_refused_without_creator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import paper_data_suite.workspace_backup_cli as cli
+
+    monkeypatch.setattr(
+        cli,
+        "plan_workspace_backup",
+        lambda _destination: (_ for _ in ()).throw(
+            WorkspaceBackupDestinationError("destination is inside workspace")
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "create_workspace_backup",
+        lambda _plan: pytest.fail("creator must not run after preflight refusal"),
+    )
+    assert run_workspace_backup_create(tmp_path / "bad", assume_yes=True) == 1
+    assert "Backup refused: destination is inside workspace" in capsys.readouterr().err
+
+
+def test_creation_failure_is_reported_as_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import paper_data_suite.workspace_backup_cli as cli
+
+    plan = _plan(tmp_path)
+    monkeypatch.setattr(cli, "plan_workspace_backup", lambda _destination: plan)
+    monkeypatch.setattr(
+        cli,
+        "create_workspace_backup",
+        lambda _plan: (_ for _ in ()).throw(
+            WorkspaceBackupVerificationError("copied bytes do not match")
+        ),
+    )
+    assert run_workspace_backup_create(tmp_path / "backups", assume_yes=True) == 1
+    assert "Backup failed: copied bytes do not match" in capsys.readouterr().err

--- a/tests/test_workspace_backup_dispatch.py
+++ b/tests/test_workspace_backup_dispatch.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paper_data_suite.cli import main
+
+
+def test_backup_group_without_subcommand_shows_help(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(("backup",)) == 0
+    output = capsys.readouterr().out
+    normalized = " ".join(output.split())
+    assert "usage: pds backup" in normalized
+    assert "{create}" in normalized
+    assert "currently resolved Core workspace" in normalized
+
+
+def test_backup_create_help_documents_explicit_sensitive_copy_boundary(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as raised:
+        main(("backup", "create", "--help"))
+
+    assert raised.value.code == 0
+    output = capsys.readouterr().out
+    normalized = " ".join(output.split())
+    assert "usage: pds backup create" in normalized
+    assert "--destination" in normalized
+    assert "--yes" in normalized
+    assert "currently resolved Core workspace" in normalized
+    assert "potentially sensitive data" in normalized
+    assert "does not encrypt, upload, or cloud-sync" in normalized
+
+
+def test_backup_create_dispatches_destination_and_yes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.cli as cli
+
+    calls: list[tuple[Path, bool]] = []
+
+    def run_backup(destination: Path, *, assume_yes: bool = False) -> int:
+        calls.append((destination, assume_yes))
+        return 7
+
+    monkeypatch.setattr(cli, "run_workspace_backup_create", run_backup)
+
+    assert (
+        main(
+            (
+                "backup",
+                "create",
+                "--destination",
+                "C:/PDS Backups",
+                "--yes",
+            )
+        )
+        == 7
+    )
+    assert calls == [(Path("C:/PDS Backups"), True)]
+
+
+def test_backup_create_dispatches_interactive_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.cli as cli
+
+    calls: list[tuple[Path, bool]] = []
+
+    def run_backup(destination: Path, *, assume_yes: bool = False) -> int:
+        calls.append((destination, assume_yes))
+        return 0
+
+    monkeypatch.setattr(cli, "run_workspace_backup_create", run_backup)
+
+    assert main(("backup", "create", "--destination", "backups")) == 0
+    assert calls == [(Path("backups"), False)]


### PR DESCRIPTION
## Summary

Completes Paper Data Suite issue #10 by adding suite-owned, timestamped, non-overwriting whole-workspace backup creation for the currently resolved Core workspace.

The implementation treats backup as opaque byte custody rather than semantic ownership: the suite copies the workspace filesystem without parsing, normalizing, repairing, or reinterpreting Core- or module-owned records.

## What this adds

- `pds backup create --destination <path>`;
- equivalent `python -m paper_data_suite backup create --destination <path>`;
- exact suite-qualified Core validation before workspace access;
- read-only resolution of the currently active Core workspace;
- deterministic UTC timestamped backup naming;
- explicit destination-parent selection;
- canonical source/destination containment checks;
- protection against backup creation inside the active workspace;
- conservative destination free-space preflight;
- complete regular-file and empty-directory inventory;
- opaque streaming byte copy with SHA-256 hashing;
- deterministic versioned `pds_workspace_backup_manifest` v1;
- portable, fail-closed relative-path validation;
- staging under clearly incomplete temporary state;
- source-drift detection during backup creation;
- independent staged-payload inventory and hash verification;
- atomic/non-overwriting publication to the final backup name;
- best-effort cleanup of incomplete staging after handled failures;
- preservation of pre-existing staging/final paths on collision;
- bounded privacy-conscious preview, failure, and success output;
- exact uppercase `BACKUP` authorization for interactive creation;
- explicit `--yes` support for noninteractive acceptance;
- cancellation with no backup creation;
- operational backup documentation and README integration;
- dedicated installed-wheel workspace-backup acceptance.

## Backup format

A completed backup has the form:

`<destination>/pds-workspace-backup-<UTC timestamp>/`

containing:

- `manifest.json` — deterministic shell-owned backup metadata and SHA-256 inventory;
- `workspace/` — the opaque copied workspace payload.

Manifest v1 records file-relative paths, sizes, hashes, directory inventory, versions, counts, timestamp, and fixed exclusion policy without embedding parsed student data or absolute source file paths.

The manifest path grammar rejects ambiguous cross-platform values such as backslashes, colon-bearing Windows-style paths, traversal components, and control characters so the later restore implementation has a portable fail-closed contract.

## Safety and ownership boundaries

The backup implementation:

- does not modify the source workspace;
- does not require the source workspace to be writable;
- does not initialize or select another workspace;
- does not import sibling PDS applications;
- does not parse module-owned records;
- does not omit canonical files based on domain interpretation;
- does not follow unsafe symbolic-link/junction traversal;
- does not overwrite an existing completed backup;
- does not publish incomplete data under a completed backup name;
- does not provide cloud upload, synchronization, encryption, retention, pruning, or scheduling;
- does not implement restore.

Backup remains the suite shell's explicit opaque-custody exception while Core remains authoritative for workspace resolution and all Core/module record semantics remain with their owning repositories.

## Relationship to #11

This PR establishes the stable backup layout and manifest contract required by the next issue.

It intentionally does **not** add:

- `pds backup verify`;
- `pds backup restore`;
- in-place restoration;
- automatic restored-workspace selection;
- semantic merge or migration behavior.

Those remain scoped to #11.

## Validation

Local source validation:

- focused backup acceptance: `58 passed, 2 skipped`;
- full suite: `451 passed, 6 skipped`;
- `python -m ruff check .` — passed;
- `python -m mypy` — passed across 33 source files;
- `git diff --check` — passed;
- `python -m pip check` — passed;
- compatibility-manifest validation — passed.

Packaging:

- sdist built successfully;
- wheel built successfully;
- `twine check` passed for both artifacts;
- package wheel validation passed.

Installed-wheel acceptance:

- general wheel smoke — passed;
- workspace wheel smoke — passed;
- classroom-setup wheel smoke — passed;
- workspace-backup wheel smoke — passed.

The dedicated backup smoke verifies installed console and module invocation, cancellation, source preservation, inside-workspace refusal, deterministic manifest/inventory integrity, byte/hash equality, and collision protection using only the suite and exact qualified Core wheel.

The local Windows skips are limited to unavailable symlink-creation privileges and unavailable `pwsh`; cross-platform CI remains the final platform-specific verification.

Closes #10