### PR TITLE
feat: add backup verification and alternate-location restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,24 @@ jobs:
             "$suiteWheel" `
             "$env:PDS_CORE_WHEEL"
 
+      - name: Installed workspace restore acceptance
+        if: matrix.python == '3.11'
+        shell: pwsh
+        run: |
+          $wheels = @(
+            Get-ChildItem `
+              -LiteralPath $env:PDS_DIST_DIR `
+              -Filter "*.whl" `
+              -File
+          )
+          if ($wheels.Count -ne 1) {
+            throw "Expected exactly one suite wheel; found $($wheels.Count)."
+          }
+
+          python scripts/smoke_test_workspace_restore_wheel.py `
+            "$($wheels[0].FullName)" `
+            "$env:PDS_CORE_WHEEL"
+
       - name: Verify repository hygiene
         shell: pwsh
         run: |

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ installable. The shell now provides read-only environment diagnostics through
 `pds doctor`, suite-qualified application inventory through `pds modules`,
 verified out-of-process application launching through `pds launch <component-id>`,
 Core-backed workspace selection/validation through `pds workspace`, guided shared
-classroom setup through `pds setup`, and verified whole-workspace backup creation
-through `pds backup create`. Additional teacher-facing workflows are added by
-later v0.1.0 issues.
+classroom setup through `pds setup`, and whole-workspace backup creation,
+independent verification, and safe alternate-location restore through
+`pds backup create`, `pds backup verify`, and `pds backup restore`.
+Additional teacher-facing workflows are added by later v0.1.0 issues.
 
 The package metadata requires Python 3.11 or newer and
 `pds-core>=0.6,<0.7`. Those broad package requirements do **not** by themselves
@@ -276,13 +277,46 @@ confidentiality or digital-signature authenticity. External synchronization of a
 chosen OneDrive or other managed folder remains behavior of that storage system,
 not PDS.
 
-Issue #10 implements creation-time self-verification only. Standalone backup
-verification and restore-to-an-explicit-alternate-location belong to the following
-backup/restore issue.
-
 The manifest/layout contract, privacy boundary, staging/publication model, source
 consistency limits, and installed-wheel acceptance are documented in
 [`docs/operations/workspace-backup.md`](docs/operations/workspace-backup.md).
+
+## Workspace backup verification and restore
+
+Independently verify a completed backup with:
+
+```powershell
+pds backup verify "D:\\PDS Backups\\pds-workspace-backup-<timestamp>"
+```
+
+Restore verified opaque workspace bytes to a new explicit alternate location with:
+
+```powershell
+pds backup restore `
+  "D:\\PDS Backups\\pds-workspace-backup-<timestamp>" `
+  --destination "D:\\PDS Recovery\\restored-workspace"
+```
+
+`backup verify` is read-only and checks completed-backup identity, canonical
+manifest bytes, exact directory/file inventory, sizes, and streamed SHA-256
+digests. It does not resolve Core or require sibling applications. SHA-256 proves
+agreement with the supplied manifest, not who created the backup or whether its
+records are semantically compatible with every currently installed component.
+
+`backup restore` fully verifies the backup before preview and again before
+mutation, exactly qualifies Core to protect the currently resolved workspace,
+requires a nonexistent explicit destination, stages and independently verifies
+the restored byte tree, and publishes only after integrity checks succeed.
+Interactive restore requires exact uppercase `RESTORE`; `--yes` bypasses only
+that prompt.
+
+Restore never merges into or overwrites an existing directory, never rewrites
+owner records, and never automatically selects the recovered workspace. To adopt
+a restored copy later, use a separate intentional `pds workspace set <path>`.
+
+The verification/restore contract, failure semantics, privacy boundary, and
+installed-wheel acceptance are documented in
+[`docs/operations/workspace-restore.md`](docs/operations/workspace-restore.md).
 
 ## Architecture direction
 
@@ -330,6 +364,8 @@ pds doctor
 pds doctor --workspace <path>
 pds backup
 pds backup create --destination <path> [--yes]
+pds backup verify <backup>
+pds backup restore <backup> --destination <path> [--yes]
 pds modules
 pds launch <component-id>
 pds setup
@@ -345,6 +381,8 @@ python -m paper_data_suite --version
 python -m paper_data_suite doctor
 python -m paper_data_suite backup
 python -m paper_data_suite backup create --destination <path> [--yes]
+python -m paper_data_suite backup verify <backup>
+python -m paper_data_suite backup restore <backup> --destination <path> [--yes]
 python -m paper_data_suite modules
 python -m paper_data_suite launch <component-id>
 python -m paper_data_suite setup
@@ -363,8 +401,11 @@ saving it; `workspace setup`, `set`, and `reset` are the explicit workspace
 mutation surfaces. `pds setup` is the explicit shared-classroom mutation surface
 and remains read-only until exact final `APPLY`. `pds backup create` leaves the
 source workspace read-only and creates an external copy only after exact `BACKUP`
-or explicit `--yes`. `launch` crosses only the verified public application boundary;
-module-owned behavior remains owned by the launched application.
+or explicit `--yes`. `pds backup verify` is read-only. `pds backup restore`
+creates only a new verified alternate workspace after exact `RESTORE` or explicit
+`--yes`; it never changes Core's selected workspace. `launch` crosses only the
+verified public application boundary; module-owned behavior remains owned by the
+launched application.
 
 ## Development validation
 
@@ -390,6 +431,7 @@ python .\scripts\smoke_test_wheel.py <suite-wheel> <core-wheel>
 python .\scripts\smoke_test_workspace_wheel.py <suite-wheel> <core-wheel>
 python .\scripts\smoke_test_classroom_setup_wheel.py <suite-wheel> <core-wheel>
 python .\scripts\smoke_test_workspace_backup_wheel.py <suite-wheel> <core-wheel>
+python .\scripts\smoke_test_workspace_restore_wheel.py <suite-wheel> <core-wheel>
 ```
 
 The Core-only smoke proves legitimate partial installation behavior. The dedicated
@@ -402,8 +444,12 @@ suite setup-plan artifacts, and idempotent reruns. The dedicated workspace-backu
 smoke uses another isolated profile to prove module/console command installation,
 mutation-free cancellation, inside-workspace refusal, source immutability, complete
 opaque payload/hash inventory, manifest privacy, non-overwrite collision behavior,
-and absence of sibling-module requirements. To exercise the complete
-suite-qualified application composition, place every exact component wheel declared
+and absence of sibling-module requirements. The dedicated workspace-restore smoke
+uses another isolated profile to prove standalone verification, restore cancellation,
+active-workspace protection, byte-exact alternate restore, unchanged Core selection,
+existing-destination refusal, incomplete/tampered-backup refusal, and absence of
+sibling-module requirements. To exercise the complete suite-qualified application
+composition, place every exact component wheel declared
 by the manifest in one artifact directory and run:
 
 ```powershell
@@ -454,6 +500,8 @@ Do not place a real classroom PDS workspace inside this repository.
 - [`docs/operations/workspace-backup.md`](docs/operations/workspace-backup.md)
   — whole-workspace opaque backup creation, deterministic manifest, safety, and
   acceptance.
+- [`docs/operations/workspace-restore.md`](docs/operations/workspace-restore.md)
+  — independent backup verification and safe alternate-location restore.
 - [`docs/development-plan.md`](docs/development-plan.md) — suite-wide
   pilot-readiness and development program.
 - [`docs/pds-viz-identity.md`](docs/pds-viz-identity.md) — shared Paper Data

--- a/docs/operations/workspace-backup.md
+++ b/docs/operations/workspace-backup.md
@@ -360,21 +360,21 @@ Exit behavior is:
 `Workspace backup complete` is printed only after verified staging has been
 published at the final backup path.
 
-## Restore boundary
+## Verification and restore boundary
 
-Issue #10 implements **creation-time self-verification only**. It does not claim that
-a backup can yet be restored.
+Creation-time self-verification remains part of `pds backup create`.
 
-The following backup/restore issue owns:
+Independent later verification and recovery are now provided by:
 
 ```text
-pds backup verify
-pds backup restore
+pds backup verify <backup>
+pds backup restore <backup> --destination <path>
 ```
 
-That work must independently validate this manifest/inventory/hashes and restore only
-to an explicit alternate safe location. A restored workspace must not become the
-selected Core workspace automatically.
+Those commands consume this unchanged v1 manifest/layout contract. Restore is limited
+to a new explicit alternate location and never automatically changes Core's selected
+workspace. See [`workspace-restore.md`](workspace-restore.md) for the verification,
+restore, drift, staging, publication, and selection-boundary contract.
 
 ## Installed-wheel acceptance
 
@@ -396,10 +396,8 @@ with synthetic data only, that:
 
 ## Non-goals
 
-Backup creation does not provide:
+Backup creation itself does not provide:
 
-- restore;
-- a standalone verification command;
 - in-place active-workspace replacement;
 - automatic selection of restored workspaces;
 - ZIP/TAR archives;

--- a/docs/operations/workspace-restore.md
+++ b/docs/operations/workspace-restore.md
@@ -1,0 +1,470 @@
+# Workspace backup verification and restore
+
+## Purpose
+
+Paper Data Suite can independently verify a completed whole-workspace backup and
+restore verified opaque workspace bytes to one explicit alternate location.
+
+The commands are:
+
+```powershell
+pds backup verify <backup>
+pds backup restore <backup> --destination <path>
+```
+
+Equivalent module invocations are:
+
+```powershell
+python -m paper_data_suite backup verify <backup>
+python -m paper_data_suite backup restore <backup> --destination <path>
+```
+
+This work consumes the backup-v1 format documented in
+[`workspace-backup.md`](workspace-backup.md). It does not define a second backup
+format.
+
+The controlling architecture rule remains:
+
+```text
+opaque byte custody != semantic record ownership
+```
+
+Verification and restore inspect filesystem shape, sizes, and bytes. They do not
+parse, normalize, repair, migrate, merge, or reinterpret Core- or module-owned
+records.
+
+## Verification
+
+`pds backup verify` is read-only and noninteractive.
+
+A completed v1 backup must have the canonical layout:
+
+```text
+pds-workspace-backup-YYYYMMDDTHHMMSSffffffZ/
+  manifest.json
+  workspace/
+```
+
+Verification rejects incomplete `.incomplete-*` staging, malformed or
+noncanonical manifests, backup-name/manifest identity disagreement, missing or
+unexpected top-level state, unsupported filesystem redirection, and payload
+inventory or hash disagreement.
+
+The payload directory set and ordinary-file set must match the manifest exactly.
+This includes hidden files, unknown future module trees, zero-byte files, and
+empty directories.
+
+Every file is checked by:
+
+1. confirming the entry is an ordinary regular file;
+2. comparing its size with the manifest;
+3. streaming it in bounded chunks;
+4. calculating SHA-256 independently; and
+5. comparing the digest with the manifest.
+
+A same-size byte change is therefore detected.
+
+Verification does not resolve or select the active Core workspace and does not
+require sibling PDS applications.
+
+### Verification output
+
+Successful verification reports bounded operational facts:
+
+- backup root;
+- backup ID;
+- creation time;
+- recorded suite version;
+- recorded Core version;
+- directory count;
+- file count;
+- payload bytes; and
+- SHA-256 of the persisted manifest.
+
+Normal output does not dump the complete file inventory, per-file digests,
+student names, student IDs, grades, roster rows, or file contents.
+
+## Integrity is not authenticity
+
+SHA-256 proves agreement between the supplied manifest and payload bytes. It does
+not prove who created the backup.
+
+An actor capable of replacing both `manifest.json` and `workspace/` could create a
+new internally consistent pair.
+
+Verification therefore must not be described as:
+
+```text
+signed
+authenticated
+trusted
+tamper-proof
+```
+
+unless a future contract introduces an authentication mechanism.
+
+Likewise:
+
+```text
+integrity != runtime compatibility
+```
+
+The manifest's recorded suite/Core versions are provenance. A byte-valid backup
+is not automatically guaranteed to be semantically usable by every currently
+installed component.
+
+## Restore destination contract
+
+Restore requires:
+
+```powershell
+pds backup restore <backup> --destination <path>
+```
+
+`--destination` is the **exact final restored workspace root**.
+
+This differs from backup creation, where `--destination` names the parent under
+which a timestamped backup directory is generated.
+
+If the command is:
+
+```powershell
+pds backup restore `
+  "D:\PDS Backups\pds-workspace-backup-20260820T174812123456Z" `
+  --destination "D:\PDS Recovery\restored-workspace"
+```
+
+the payload is restored directly as:
+
+```text
+D:\PDS Recovery\restored-workspace\
+  <contents formerly under backup-root\workspace\>
+```
+
+PDS does not create an extra nested `workspace/` directory and does not copy
+backup `manifest.json` into the restored workspace.
+
+## Full verification before restore
+
+Restore never copies from an unverified backup.
+
+Before preview, PDS independently verifies the complete backup using the same
+verification service as `pds backup verify`.
+
+Immediately after confirmation, before destination mutation, PDS verifies the
+reviewed backup again.
+
+There is no:
+
+```text
+--force
+--skip-verification
+--ignore-hash-errors
+```
+
+escape hatch.
+
+## Core qualification and active-workspace protection
+
+Restore exactly qualifies Core through the suite release-compatibility contract
+and uses the public Core workspace inspection service to identify the currently
+resolved workspace.
+
+Restore does not call Core to:
+
+- initialize the destination;
+- save the destination as selected;
+- clear the current selection; or
+- rewrite workspace metadata.
+
+The resolved workspace path is protected even if that path does not currently
+exist.
+
+The restore destination must not:
+
+- equal the resolved workspace;
+- be inside the resolved workspace; or
+- contain the resolved workspace.
+
+This preserves:
+
+```text
+restore bytes != change active workspace
+```
+
+## Destination safety
+
+The restore destination must be explicit and must not already exist.
+
+An existing empty directory is refused just like an existing nonempty directory
+or file. This issue intentionally defines no merge or overwrite semantics.
+
+The destination must not overlap:
+
+- the completed backup root;
+- the backup `workspace/` payload; or
+- the currently resolved Core workspace.
+
+Path checks use canonical filesystem semantics rather than string prefixes and
+account for path expansion, aliases, `..`, case/platform path behavior, and
+missing destination ancestors.
+
+An existing destination expressed through environment or user-home expansion is
+still an existing destination and is refused during planning.
+
+## Free-space preflight
+
+Restore reuses the conservative backup threshold:
+
+```text
+required_free_bytes =
+    total_payload_bytes
+    + max(64 MiB, ceil(total_payload_bytes * 0.02))
+```
+
+Free space is inspected on the filesystem that will contain the destination.
+
+The check is performed during preview planning and repeated after confirmation.
+It remains a safeguard, not a reservation; a later disk-full error still fails
+safely.
+
+## Restore preview and authorization
+
+The preview contains bounded facts including:
+
+- source backup;
+- backup ID and creation time;
+- recorded suite/Core versions;
+- manifest SHA-256;
+- directory/file counts;
+- payload bytes;
+- currently resolved workspace and resolution source;
+- exact restore destination;
+- destination free bytes; and
+- minimum required free bytes.
+
+It also states that the current workspace will not be modified and that the
+restored workspace will not be selected automatically.
+
+Interactive restore requires exact uppercase:
+
+```text
+RESTORE
+```
+
+`Q`, end-of-input, or keyboard interruption cancels safely.
+
+Other input does not authorize restoration.
+
+For deliberate automation:
+
+```powershell
+pds backup restore <backup> --destination <path> --yes
+```
+
+`--yes` bypasses only the prompt. It does not bypass verification, Core
+qualification, containment, free-space checks, destination nonexistence, drift
+detection, staged verification, or publication collision checks.
+
+## Staging and byte copy
+
+Restore never copies directly into the requested final destination.
+
+After post-confirmation revalidation, PDS creates one exclusive sibling staging
+directory with a name conceptually like:
+
+```text
+.<destination-name>.pds-restore.incomplete-<nonce>
+```
+
+The nonce is operational state only.
+
+Within staging, PDS:
+
+1. recreates every manifest directory, including empty directories;
+2. streams each manifest-qualified payload file in bounded chunks;
+3. hashes the bytes actually written;
+4. flushes/fsyncs copied files;
+5. rejects source type/size/hash drift;
+6. re-verifies the completed source backup after copying;
+7. independently inventories the staging tree;
+8. independently hashes every staged file; and
+9. publishes only when the staged tree exactly matches the manifest.
+
+No record serializer or module-specific validator participates.
+
+## Backup drift
+
+A completed backup can still be changed externally while restore is running.
+
+Paper Data Suite has no global filesystem lock and does not claim adversarial
+same-user filesystem isolation.
+
+Instead it uses conservative observed-drift detection:
+
+- full verification before preview;
+- full verification again before mutation;
+- streamed copy with per-file expected size/hash;
+- full source-backup verification after copy; and
+- independent staged-tree verification.
+
+If observed backup state changes, restore fails rather than publishing a mixed
+tree.
+
+The backup is never modified to make it consistent.
+
+## Publication and collision behavior
+
+A successful final destination appears only after the staging tree has passed
+verification.
+
+Immediately before publication PDS checks again that the final destination does
+not exist. A destination already present at that boundary is refused and is not
+merged, overwritten, or deleted.
+
+The source backup and current Core workspace remain unchanged.
+
+## Failure cleanup
+
+On handled failure PDS removes only staging owned by the current restore attempt,
+best-effort.
+
+It never deletes:
+
+- the source backup;
+- the current workspace;
+- a pre-existing final destination; or
+- another pre-existing incomplete staging directory.
+
+If owned staging cannot be removed, the failure reports the remaining incomplete
+staging path. That path is not a completed restored workspace.
+
+Abrupt process or operating-system failure may also leave incomplete staging.
+PDS does not automatically prune unrelated historical staging.
+
+## Successful completion
+
+Only after verified publication does the command print:
+
+```text
+Workspace restore complete
+```
+
+The result explicitly states:
+
+```text
+The currently resolved workspace was not changed.
+The restored workspace was not selected automatically.
+```
+
+A teacher can inspect current selection separately:
+
+```powershell
+pds workspace show
+```
+
+If the recovered copy should become active, that is a distinct intentional Core
+operation:
+
+```powershell
+pds workspace set "<restore-destination>"
+```
+
+Restore never chains or invokes that command automatically.
+
+## Privacy boundary
+
+Verification and restore operate over potentially sensitive classroom data.
+
+Default output is deliberately bounded and does not print:
+
+- complete manifest inventory;
+- per-file hashes;
+- file contents;
+- roster rows;
+- student names or IDs;
+- grades or scores; or
+- parsed owner records.
+
+A failure may identify one offending relative path when needed for remediation,
+but it does not print file contents.
+
+PDS does not upload backups, restored workspaces, or telemetry.
+
+Restore does not add encryption.
+
+## Version provenance and migration
+
+A successful byte restore means the copied tree matches the verified backup.
+
+It does not mean historical records have been migrated to the currently installed
+Core/module versions.
+
+Restore does not:
+
+- bump schema versions;
+- run owner migrations;
+- repair malformed records;
+- infer semantic compatibility; or
+- import sibling modules to validate their records.
+
+Any required migration remains owned by the corresponding component contract.
+
+## Exit behavior
+
+```text
+0  successful verification/restore or explicit restore cancellation
+1  safely refused or failed verification/restore
+2  argparse/usage error
+```
+
+Success is never reported before all relevant verification/publication checks
+complete.
+
+## Installed-wheel acceptance
+
+`scripts/smoke_test_workspace_restore_wheel.py` validates verification and restore
+from built suite/Core wheels in an isolated virtual environment and synthetic user
+profile.
+
+It proves, with synthetic data only, that:
+
+- only the suite and exact Core wheel are required;
+- console and module verify/restore command surfaces are installed;
+- a completed backup verifies independently;
+- manifest SHA-256 reporting matches persisted bytes;
+- normal output does not leak a synthetic sensitive filename;
+- restore cancellation creates no final destination;
+- the active workspace cannot be used as restore destination;
+- a successful alternate restore is byte/tree identical to the synthetic source;
+- backup `manifest.json` is not injected into the restored workspace;
+- Core's selected workspace remains unchanged;
+- an existing destination is refused and preserved;
+- incomplete backup staging is refused;
+- same-size tampered backup bytes fail verification;
+- no restore staging remains after successful completion; and
+- the smoke working directory remains clean.
+
+## Non-goals
+
+Verification/restore does not provide:
+
+- in-place active-workspace replacement;
+- merge into an existing directory;
+- overwrite flags;
+- automatic `pds workspace set`;
+- automatic Core selection mutation;
+- semantic merge;
+- selective class/student/module restore;
+- module-aware record repair;
+- schema migration;
+- runtime-compatibility inference;
+- ZIP/TAR extraction semantics;
+- compression;
+- encryption/password management;
+- digital signatures/authenticated manifests;
+- cloud upload/download;
+- scheduled recovery;
+- retention/pruning;
+- VSS or operating-system snapshots; or
+- a global cross-module lock.

--- a/paper_data_suite/cli.py
+++ b/paper_data_suite/cli.py
@@ -28,7 +28,11 @@ from paper_data_suite.compatibility import (
     load_release_compatibility_manifest,
 )
 from paper_data_suite.doctor import collect_doctor_diagnostics, render_doctor_report
-from paper_data_suite.workspace_backup_cli import run_workspace_backup_create
+from paper_data_suite.workspace_backup_cli import (
+    run_workspace_backup_create,
+    run_workspace_backup_restore,
+    run_workspace_backup_verify,
+)
 from paper_data_suite.workspace_cli import (
     run_workspace_reset,
     run_workspace_set,
@@ -116,11 +120,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     backup = subparsers.add_parser(
         "backup",
-        help="create protected whole-workspace backups",
+        help="create, verify, or safely restore whole-workspace backups",
         description=(
-            "Create protected whole-workspace backups of the currently resolved "
-            "Core workspace. Backup copies are opaque byte custody: PDS does not "
-            "rewrite owner records, encrypt, upload, or cloud-sync them."
+            "Create protected whole-workspace backups, independently verify a "
+            "completed backup, or restore verified opaque workspace bytes to a "
+            "new explicit alternate location. Restore never automatically selects "
+            "the recovered workspace."
         ),
     )
     backup.set_defaults(backup_parser=backup)
@@ -145,6 +150,47 @@ def build_parser() -> argparse.ArgumentParser:
         "--yes",
         action="store_true",
         help="create after preflight without the interactive BACKUP confirmation",
+    )
+    backup_verify = backup_subparsers.add_parser(
+        "verify",
+        help="independently verify a completed workspace backup",
+        description=(
+            "Verify the completed backup-v1 manifest, exact payload inventory, "
+            "sizes, and SHA-256 hashes without modifying the backup or resolving "
+            "the active Core workspace. Integrity verification is not a digital "
+            "signature or runtime-compatibility guarantee."
+        ),
+    )
+    backup_verify.add_argument(
+        "backup",
+        type=Path,
+        help="explicit completed backup root containing manifest.json and workspace/",
+    )
+    backup_restore = backup_subparsers.add_parser(
+        "restore",
+        help="restore a verified backup to a new alternate workspace location",
+        description=(
+            "Verify a completed backup and restore its opaque workspace payload to "
+            "one explicit destination that must not already exist. The active Core "
+            "workspace is protected and the restored workspace is not selected "
+            "automatically."
+        ),
+    )
+    backup_restore.add_argument(
+        "backup",
+        type=Path,
+        help="explicit completed backup root containing manifest.json and workspace/",
+    )
+    backup_restore.add_argument(
+        "--destination",
+        required=True,
+        type=Path,
+        help="exact final restored workspace root; it must not already exist",
+    )
+    backup_restore.add_argument(
+        "--yes",
+        action="store_true",
+        help="restore after full preflight without interactive RESTORE confirmation",
     )
     subparsers.add_parser(
         "setup",
@@ -352,6 +398,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
         if arguments.backup_command == "create":
             return run_workspace_backup_create(
+                arguments.destination,
+                assume_yes=arguments.yes,
+            )
+        if arguments.backup_command == "verify":
+            return run_workspace_backup_verify(arguments.backup)
+        if arguments.backup_command == "restore":
+            return run_workspace_backup_restore(
+                arguments.backup,
                 arguments.destination,
                 assume_yes=arguments.yes,
             )

--- a/paper_data_suite/workspace_backup_cli.py
+++ b/paper_data_suite/workspace_backup_cli.py
@@ -14,7 +14,18 @@ from paper_data_suite.workspace_backup import (
     create_workspace_backup,
     plan_workspace_backup,
 )
+from paper_data_suite.workspace_backup_verification import (
+    WorkspaceBackupVerificationResult,
+    verify_workspace_backup,
+)
 from paper_data_suite.workspace_cli import workspace_source_label
+from paper_data_suite.workspace_restore import (
+    WorkspaceRestoreError,
+    WorkspaceRestorePlan,
+    WorkspaceRestoreResult,
+    plan_workspace_restore,
+    restore_workspace_backup,
+)
 from paper_data_suite.workspace_setup import (
     CoreWorkspaceQualificationError,
     CoreWorkspaceServiceError,
@@ -78,6 +89,169 @@ def render_workspace_backup_result(
         "the backup.",
     ]
     return "\n".join(lines) + "\n"
+
+
+def render_workspace_backup_verification_result(
+    result: WorkspaceBackupVerificationResult,
+) -> str:
+    """Render one bounded completed-backup integrity result."""
+    manifest = result.manifest
+    lines = [
+        "Workspace backup verified",
+        "",
+        f"Backup: {result.backup_root}",
+        f"Backup ID: {manifest.backup_id}",
+        f"Created at: {manifest.created_at}",
+        f"Recorded suite version: {manifest.suite_version}",
+        f"Recorded Core version: {manifest.core_version}",
+        f"Directories: {manifest.directory_count}",
+        f"Files: {manifest.file_count}",
+        f"Payload bytes: {manifest.total_bytes}",
+        f"Manifest SHA-256: {result.manifest_sha256}",
+        "",
+        "The manifest and payload agree byte-for-byte with backup format v1.",
+        "SHA-256 verifies integrity against this manifest; it is not a",
+        "digital signature and does not prove who created the backup.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def run_workspace_backup_verify(backup: Path) -> int:
+    """Independently verify one completed workspace backup."""
+    try:
+        result = verify_workspace_backup(backup)
+    except (WorkspaceBackupError, OSError) as error:
+        message = str(error)[:500] or error.__class__.__name__
+        print(f"Backup verification failed: {message}", file=sys.stderr)
+        return 1
+    print(render_workspace_backup_verification_result(result), end="")
+    return 0
+
+
+def render_workspace_restore_plan(plan: WorkspaceRestorePlan) -> str:
+    """Render one bounded verified restore preview."""
+    manifest = plan.verification.manifest
+    lines = [
+        "Paper Data Suite workspace restore",
+        "",
+        f"Backup: {plan.backup_root}",
+        f"Backup ID: {manifest.backup_id}",
+        f"Backup created at: {manifest.created_at}",
+        f"Recorded suite version: {manifest.suite_version}",
+        f"Recorded Core version: {manifest.core_version}",
+        f"Manifest SHA-256: {plan.manifest_sha256}",
+        f"Directories: {manifest.directory_count}",
+        f"Files: {manifest.file_count}",
+        f"Payload bytes: {manifest.total_bytes}",
+        f"Currently resolved workspace: {plan.workspace_root}",
+        f"Workspace source: {workspace_source_label(plan.workspace_source)}",
+        f"Restore destination: {plan.destination_root}",
+        f"Destination free bytes: {plan.destination_free_bytes}",
+        f"Minimum required free bytes: {plan.required_free_bytes}",
+        "",
+        "Privacy warning:",
+        "  The restored workspace contains the same potentially sensitive",
+        "  classroom/student data as the backup. Store it only in an appropriate",
+        "  teacher-controlled or institutionally approved location.",
+        "",
+        "The currently resolved workspace will not be modified.",
+        "The restored workspace will not be selected automatically.",
+        "No restore destination has been created yet.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_workspace_restore_result(
+    plan: WorkspaceRestorePlan,
+    result: WorkspaceRestoreResult,
+) -> str:
+    """Render a bounded completion summary for one published restore."""
+    manifest = result.manifest
+    lines = [
+        "Workspace restore complete",
+        "",
+        f"Backup ID: {manifest.backup_id}",
+        f"Source backup: {plan.backup_root}",
+        f"Restore destination: {result.destination_root}",
+        f"Directories: {manifest.directory_count}",
+        f"Files: {manifest.file_count}",
+        f"Payload bytes: {manifest.total_bytes}",
+        f"Manifest SHA-256: {result.manifest_sha256}",
+        "",
+        "The currently resolved workspace was not changed.",
+        "The restored workspace was not selected automatically.",
+        "To review current selection, run: pds workspace show",
+        (
+            "To select this restored workspace later, run: "
+            f'pds workspace set "{result.destination_root}"'
+        ),
+        "",
+        "Byte-perfect restoration does not itself prove runtime/schema",
+        "compatibility with the currently installed suite or modules.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _cancel_restore() -> int:
+    print("Workspace restore cancelled. No restore destination was created.")
+    return 0
+
+
+def _confirm_restore(input_fn: InputReader) -> bool:
+    while True:
+        choice = _read(
+            "Type RESTORE to create the alternate restored workspace, or Q to cancel: ",
+            input_fn,
+        )
+        if choice is None or choice == "Q":
+            return False
+        if choice == "RESTORE":
+            return True
+        print("Enter exact uppercase RESTORE to continue, or Q to cancel.")
+
+
+def run_workspace_backup_restore(
+    backup: Path,
+    destination: Path,
+    *,
+    assume_yes: bool = False,
+    input_fn: InputReader = input,
+) -> int:
+    """Verify, preview, confirm, and restore to a new alternate location."""
+    try:
+        plan = plan_workspace_restore(backup, destination)
+    except (
+        CompatibilityManifestError,
+        CoreWorkspaceQualificationError,
+        CoreWorkspaceServiceError,
+        WorkspaceBackupError,
+        WorkspaceRestoreError,
+        OSError,
+    ) as error:
+        message = str(error)[:500] or error.__class__.__name__
+        print(f"Restore refused: {message}", file=sys.stderr)
+        return 1
+
+    print(render_workspace_restore_plan(plan), end="")
+    if not assume_yes and not _confirm_restore(input_fn):
+        return _cancel_restore()
+
+    try:
+        result = restore_workspace_backup(plan)
+    except (
+        CompatibilityManifestError,
+        CoreWorkspaceQualificationError,
+        CoreWorkspaceServiceError,
+        WorkspaceBackupError,
+        WorkspaceRestoreError,
+        OSError,
+    ) as error:
+        message = str(error)[:500] or error.__class__.__name__
+        print(f"Restore failed: {message}", file=sys.stderr)
+        return 1
+
+    print(render_workspace_restore_result(plan, result), end="")
+    return 0
 
 
 def _cancel_backup() -> int:
@@ -147,5 +321,10 @@ def run_workspace_backup_create(
 __all__ = (
     "render_workspace_backup_plan",
     "render_workspace_backup_result",
+    "render_workspace_backup_verification_result",
+    "render_workspace_restore_plan",
+    "render_workspace_restore_result",
     "run_workspace_backup_create",
+    "run_workspace_backup_restore",
+    "run_workspace_backup_verify",
 )

--- a/paper_data_suite/workspace_backup_verification.py
+++ b/paper_data_suite/workspace_backup_verification.py
@@ -1,0 +1,352 @@
+"""Independent integrity verification for completed whole-workspace backups.
+
+Verification treats a backup as opaque filesystem custody. It validates the
+suite-owned manifest and byte inventory without parsing Core- or module-owned
+records and without resolving or mutating the active workspace.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from paper_data_suite.workspace_backup import (
+    BACKUP_COPY_CHUNK_BYTES,
+    BACKUP_MANIFEST_FILENAME,
+    BACKUP_NAME_PREFIX,
+    BACKUP_PAYLOAD_ROOT,
+    BackupFileEntry,
+    WorkspaceBackupError,
+    WorkspaceBackupManifest,
+    WorkspaceBackupVerificationError,
+    inventory_workspace,
+    parse_workspace_backup_manifest,
+    serialize_workspace_backup_manifest,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceBackupVerificationResult:
+    """Verified facts for one completed backup."""
+
+    backup_root: Path
+    manifest: WorkspaceBackupManifest
+    manifest_sha256: str
+
+    @property
+    def payload_root(self) -> Path:
+        return self.backup_root / BACKUP_PAYLOAD_ROOT
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.backup_root / BACKUP_MANIFEST_FILENAME
+
+
+def _redirecting_reparse(status: os.stat_result) -> bool:
+    attributes = getattr(status, "st_file_attributes", 0)
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    if not reparse_flag or not attributes & reparse_flag:
+        return False
+    tag = getattr(status, "st_reparse_tag", None)
+    redirect_tags = {
+        value
+        for value in (
+            getattr(stat, "IO_REPARSE_TAG_SYMLINK", None),
+            getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", None),
+        )
+        if value is not None
+    }
+    return tag in redirect_tags
+
+
+def _canonical_backup_root(path: str | Path) -> Path:
+    raw = os.fspath(path)
+    if not raw.strip():
+        raise WorkspaceBackupVerificationError("Backup path cannot be empty.")
+    expanded = Path(os.path.expandvars(os.path.expanduser(raw)))
+    try:
+        supplied_status = expanded.lstat()
+    except OSError as error:
+        raise WorkspaceBackupVerificationError(
+            f"Backup does not exist or cannot be inspected: {expanded}"
+        ) from error
+    if stat.S_ISLNK(supplied_status.st_mode) or _redirecting_reparse(
+        supplied_status
+    ):
+        raise WorkspaceBackupVerificationError(
+            "Backup root must not be a redirecting filesystem entry."
+        )
+    if not stat.S_ISDIR(supplied_status.st_mode):
+        raise WorkspaceBackupVerificationError(
+            f"Backup root is not a directory: {expanded}"
+        )
+    try:
+        root = expanded.resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise WorkspaceBackupVerificationError(
+            f"Backup does not exist or cannot be resolved: {expanded}"
+        ) from error
+    try:
+        status = root.lstat()
+    except OSError as error:
+        raise WorkspaceBackupVerificationError(
+            f"Could not inspect backup root: {root}"
+        ) from error
+    if stat.S_ISLNK(status.st_mode) or _redirecting_reparse(status):
+        raise WorkspaceBackupVerificationError(
+            "Backup root must not be a redirecting filesystem entry."
+        )
+    if not stat.S_ISDIR(status.st_mode):
+        raise WorkspaceBackupVerificationError(
+            f"Backup root is not a directory: {root}"
+        )
+    if root.name.startswith(".") and ".incomplete-" in root.name:
+        raise WorkspaceBackupVerificationError(
+            "Incomplete backup staging is not a completed backup."
+        )
+    return root
+
+
+def _top_level_entry_status(path: Path, *, expected: str) -> os.stat_result:
+    try:
+        status = path.lstat()
+    except OSError as error:
+        raise WorkspaceBackupVerificationError(
+            f"Completed backup is missing required {expected}: {path.name}"
+        ) from error
+    if stat.S_ISLNK(status.st_mode) or _redirecting_reparse(status):
+        raise WorkspaceBackupVerificationError(
+            f"Completed backup {expected} must not be a linked filesystem entry: "
+            f"{path.name}"
+        )
+    return status
+
+
+def _validate_top_level(backup_root: Path) -> tuple[Path, Path]:
+    try:
+        with os.scandir(backup_root) as scan:
+            names = tuple(sorted(entry.name for entry in scan))
+    except OSError as error:
+        raise WorkspaceBackupVerificationError(
+            f"Could not enumerate backup root: {backup_root}"
+        ) from error
+
+    expected = (BACKUP_MANIFEST_FILENAME, BACKUP_PAYLOAD_ROOT)
+    if names != expected:
+        missing = tuple(name for name in expected if name not in names)
+        extra = tuple(name for name in names if name not in expected)
+        details: list[str] = []
+        if missing:
+            details.append("missing " + ", ".join(missing))
+        if extra:
+            details.append("unexpected top-level entries present")
+        suffix = "; ".join(details) or "top-level layout mismatch"
+        raise WorkspaceBackupVerificationError(
+            f"Completed backup top-level layout is invalid: {suffix}."
+        )
+
+    manifest_path = backup_root / BACKUP_MANIFEST_FILENAME
+    payload_root = backup_root / BACKUP_PAYLOAD_ROOT
+    manifest_status = _top_level_entry_status(manifest_path, expected="manifest")
+    payload_status = _top_level_entry_status(payload_root, expected="payload")
+    if not stat.S_ISREG(manifest_status.st_mode):
+        raise WorkspaceBackupVerificationError(
+            "Completed backup manifest.json is not an ordinary file."
+        )
+    if not stat.S_ISDIR(payload_status.st_mode):
+        raise WorkspaceBackupVerificationError(
+            "Completed backup workspace payload is not an ordinary directory."
+        )
+    return manifest_path, payload_root
+
+
+def _load_manifest(
+    manifest_path: Path,
+    backup_root: Path,
+) -> tuple[WorkspaceBackupManifest, bytes]:
+    try:
+        payload = manifest_path.read_bytes()
+    except OSError as error:
+        raise WorkspaceBackupVerificationError(
+            "Could not read backup manifest.json."
+        ) from error
+    try:
+        manifest = parse_workspace_backup_manifest(payload)
+    except WorkspaceBackupError:
+        raise
+    except (TypeError, ValueError) as error:
+        raise WorkspaceBackupVerificationError(
+            "Backup manifest.json failed v1 validation."
+        ) from error
+
+    if backup_root.name != manifest.backup_id:
+        if ".incomplete-" in backup_root.name:
+            raise WorkspaceBackupVerificationError(
+                "Incomplete backup staging is not a completed backup."
+            )
+        raise WorkspaceBackupVerificationError(
+            "Backup directory name does not match manifest backup_id."
+        )
+    if not backup_root.name.startswith(BACKUP_NAME_PREFIX):
+        raise WorkspaceBackupVerificationError(
+            "Backup directory name is not a canonical completed backup name."
+        )
+
+    canonical = serialize_workspace_backup_manifest(manifest)
+    if payload != canonical:
+        raise WorkspaceBackupVerificationError(
+            "Backup manifest bytes are not the canonical deterministic v1 "
+            "serialization."
+        )
+    return manifest, payload
+
+
+def _payload_path(payload_root: Path, relative: str) -> Path:
+    return payload_root.joinpath(*PurePosixPath(relative).parts)
+
+
+def _hash_payload_file(
+    payload_root: Path,
+    expected: BackupFileEntry,
+    *,
+    chunk_size: int,
+) -> BackupFileEntry:
+    path = _payload_path(payload_root, expected.path)
+    try:
+        before = path.lstat()
+    except OSError as error:
+        raise WorkspaceBackupVerificationError(
+            f"Backup payload file cannot be inspected: {expected.path}"
+        ) from error
+    if stat.S_ISLNK(before.st_mode) or _redirecting_reparse(before):
+        raise WorkspaceBackupVerificationError(
+            f"Backup payload contains linked filesystem entry: {expected.path}"
+        )
+    if not stat.S_ISREG(before.st_mode):
+        raise WorkspaceBackupVerificationError(
+            f"Backup payload entry is not an ordinary file: {expected.path}"
+        )
+
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with path.open("rb") as stream:
+            opened = os.fstat(stream.fileno())
+            if not stat.S_ISREG(opened.st_mode):
+                raise WorkspaceBackupVerificationError(
+                    f"Backup payload file changed type while opening: {expected.path}"
+                )
+            while True:
+                chunk = stream.read(chunk_size)
+                if not chunk:
+                    break
+                total += len(chunk)
+                digest.update(chunk)
+    except WorkspaceBackupError:
+        raise
+    except OSError as error:
+        raise WorkspaceBackupVerificationError(
+            f"Backup payload file cannot be read: {expected.path}"
+        ) from error
+
+    try:
+        after = path.lstat()
+    except OSError as error:
+        raise WorkspaceBackupVerificationError(
+            f"Backup payload file changed while being verified: {expected.path}"
+        ) from error
+    if stat.S_ISLNK(after.st_mode) or _redirecting_reparse(after):
+        raise WorkspaceBackupVerificationError(
+            f"Backup payload file changed type while being verified: {expected.path}"
+        )
+    if not stat.S_ISREG(after.st_mode):
+        raise WorkspaceBackupVerificationError(
+            f"Backup payload file changed type while being verified: {expected.path}"
+        )
+    if total != before.st_size or total != after.st_size:
+        raise WorkspaceBackupVerificationError(
+            f"Backup payload file changed size while being verified: {expected.path}"
+        )
+    return BackupFileEntry(
+        path=expected.path,
+        size=total,
+        sha256=digest.hexdigest(),
+    )
+
+
+def _verify_inventory(
+    payload_root: Path,
+    manifest: WorkspaceBackupManifest,
+    *,
+    chunk_size: int,
+) -> None:
+    try:
+        inventory = inventory_workspace(payload_root)
+    except WorkspaceBackupError as error:
+        raise WorkspaceBackupVerificationError(str(error)) from error
+
+    expected_directories = manifest.directories
+    observed_directories = inventory.directories
+    if observed_directories != expected_directories:
+        raise WorkspaceBackupVerificationError(
+            "Backup payload directory inventory does not match the manifest."
+        )
+
+    expected_sizes = tuple((entry.path, entry.size) for entry in manifest.files)
+    observed_sizes = tuple((entry.path, entry.size) for entry in inventory.files)
+    if observed_sizes != expected_sizes:
+        raise WorkspaceBackupVerificationError(
+            "Backup payload file inventory or sizes do not match the manifest."
+        )
+    if inventory.total_bytes != manifest.total_bytes:
+        raise WorkspaceBackupVerificationError(
+            "Backup payload total byte count does not match the manifest."
+        )
+
+    for expected in manifest.files:
+        actual = _hash_payload_file(
+            payload_root,
+            expected,
+            chunk_size=chunk_size,
+        )
+        if actual != expected:
+            raise WorkspaceBackupVerificationError(
+                f"Backup payload SHA-256 mismatch: {expected.path}"
+            )
+
+    try:
+        final_inventory = inventory_workspace(payload_root)
+    except WorkspaceBackupError as error:
+        raise WorkspaceBackupVerificationError(str(error)) from error
+    if final_inventory != inventory:
+        raise WorkspaceBackupVerificationError(
+            "Backup payload changed while verification was running."
+        )
+
+
+def verify_workspace_backup(
+    backup: str | Path,
+    *,
+    chunk_size: int = BACKUP_COPY_CHUNK_BYTES,
+) -> WorkspaceBackupVerificationResult:
+    """Independently verify one completed v1 backup without mutating it."""
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be greater than zero")
+    backup_root = _canonical_backup_root(backup)
+    manifest_path, payload_root = _validate_top_level(backup_root)
+    manifest, manifest_bytes = _load_manifest(manifest_path, backup_root)
+    _verify_inventory(payload_root, manifest, chunk_size=chunk_size)
+    return WorkspaceBackupVerificationResult(
+        backup_root=backup_root,
+        manifest=manifest,
+        manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
+    )
+
+
+__all__ = (
+    "WorkspaceBackupVerificationResult",
+    "verify_workspace_backup",
+)

--- a/paper_data_suite/workspace_restore.py
+++ b/paper_data_suite/workspace_restore.py
@@ -1,0 +1,907 @@
+"""Planning and execution for verified whole-workspace restore operations.
+
+Restore remains opaque filesystem custody. A completed backup is independently
+verified before planning and again immediately before mutation. Restored bytes
+are staged outside both the backup and active workspace, independently checked,
+and published only to a previously nonexistent explicit alternate location.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import hashlib
+import os
+import secrets
+import shutil
+import stat
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Protocol
+
+from paper_data_suite.workspace_backup import (
+    BACKUP_COPY_CHUNK_BYTES,
+    BackupFileEntry,
+    WorkspaceBackupError,
+    WorkspaceBackupManifest,
+    inventory_workspace,
+    required_backup_free_bytes,
+)
+from paper_data_suite.workspace_backup_verification import (
+    WorkspaceBackupVerificationResult,
+    verify_workspace_backup,
+)
+from paper_data_suite.workspace_setup import (
+    CoreWorkspaceServices,
+    load_core_workspace_services,
+)
+
+
+class WorkspaceRestoreError(RuntimeError):
+    """Base class for bounded restore failures."""
+
+
+class WorkspaceRestoreCoreError(WorkspaceRestoreError):
+    """Raised when Core cannot provide a usable resolved-workspace observation."""
+
+
+class WorkspaceRestoreDestinationError(WorkspaceRestoreError):
+    """Raised when the requested alternate restore destination is unsafe."""
+
+
+class WorkspaceRestoreSpaceError(WorkspaceRestoreDestinationError):
+    """Raised when destination free space is below the conservative threshold."""
+
+
+class WorkspaceRestoreDriftError(WorkspaceRestoreError):
+    """Raised when the reviewed backup or Core workspace state changes."""
+
+
+class WorkspaceRestoreCopyError(WorkspaceRestoreError):
+    """Raised when opaque restore copying cannot complete safely."""
+
+
+class WorkspaceRestoreVerificationError(WorkspaceRestoreError):
+    """Raised when staged restored bytes do not match the backup manifest."""
+
+
+class WorkspaceRestoreCollisionError(WorkspaceRestoreDestinationError):
+    """Raised when restore staging or the final destination already exists."""
+
+
+class WorkspaceRestorePublicationError(WorkspaceRestoreError):
+    """Raised when verified restore staging cannot be published safely."""
+
+
+class DiskUsageLike(Protocol):
+    """Read-only free-space field consumed from a disk-usage provider."""
+
+    @property
+    def free(self) -> int: ...
+
+
+DiskUsageReader = Callable[[str | os.PathLike[str]], DiskUsageLike]
+BackupVerifier = Callable[[str | Path], WorkspaceBackupVerificationResult]
+CoreServicesLoader = Callable[[], CoreWorkspaceServices]
+StagingNonceFactory = Callable[[], str]
+FileCopier = Callable[[Path, Path, BackupFileEntry, int], BackupFileEntry]
+AfterCopyHook = Callable[[Path, Path], None]
+BeforePublishHook = Callable[[Path, Path], None]
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceRestorePlan:
+    """Fully verified, read-only restore proposal shown before mutation."""
+
+    verification: WorkspaceBackupVerificationResult
+    workspace_root: Path
+    workspace_source: str
+    destination_root: Path
+    destination_parent: Path
+    destination_anchor: Path
+    destination_free_bytes: int
+    required_free_bytes: int
+    destination_parent_exists: bool
+
+    @property
+    def backup_root(self) -> Path:
+        return self.verification.backup_root
+
+    @property
+    def payload_root(self) -> Path:
+        return self.verification.payload_root
+
+    @property
+    def manifest_sha256(self) -> str:
+        return self.verification.manifest_sha256
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceRestoreResult:
+    """Verified alternate workspace after non-overwriting publication."""
+
+    destination_root: Path
+    manifest: WorkspaceBackupManifest
+    manifest_sha256: str
+
+
+def _read_disk_usage(path: str | os.PathLike[str]) -> DiskUsageLike:
+    return shutil.disk_usage(path)
+
+
+def _contains(parent: Path, child: Path) -> bool:
+    try:
+        child.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _overlaps(first: Path, second: Path) -> bool:
+    return first == second or _contains(first, second) or _contains(second, first)
+
+
+def _expanded_path(path: str | Path, label: str) -> Path:
+    raw = os.fspath(path)
+    if not raw.strip():
+        raise WorkspaceRestoreDestinationError(f"{label} cannot be empty.")
+    expanded = Path(os.path.expandvars(os.path.expanduser(raw)))
+    try:
+        return expanded.resolve(strict=False)
+    except (OSError, RuntimeError) as error:
+        raise WorkspaceRestoreDestinationError(
+            f"Could not resolve {label.lower()}."
+        ) from error
+
+
+def _path_entry_exists(path: str | Path) -> bool:
+    try:
+        return os.path.lexists(os.fspath(path))
+    except (OSError, TypeError, ValueError) as error:
+        raise WorkspaceRestoreDestinationError(
+            "Could not inspect restore destination existence."
+        ) from error
+
+
+def _nearest_existing_directory(path: Path) -> Path:
+    candidate = path
+    while True:
+        if candidate.exists():
+            if not candidate.is_dir():
+                raise WorkspaceRestoreDestinationError(
+                    "Restore destination has no usable existing directory ancestor."
+                )
+            try:
+                return candidate.resolve(strict=True)
+            except (OSError, RuntimeError) as error:
+                raise WorkspaceRestoreDestinationError(
+                    "Could not resolve restore destination filesystem anchor."
+                ) from error
+        if _path_entry_exists(candidate):
+            raise WorkspaceRestoreDestinationError(
+                "Restore destination passes through an unusable filesystem entry."
+            )
+        parent = candidate.parent
+        if parent == candidate:
+            break
+        candidate = parent
+    raise WorkspaceRestoreDestinationError(
+        "Restore destination has no usable existing directory ancestor."
+    )
+
+
+def _destination_free_bytes(
+    anchor: Path,
+    disk_usage_reader: DiskUsageReader,
+) -> int:
+    try:
+        usage = disk_usage_reader(anchor)
+        free = usage.free
+    except (OSError, TypeError, ValueError, AttributeError) as error:
+        raise WorkspaceRestoreDestinationError(
+            f"Could not inspect free space for restore destination: {anchor}"
+        ) from error
+    if not isinstance(free, int) or isinstance(free, bool) or free < 0:
+        raise WorkspaceRestoreDestinationError(
+            "Destination free-space provider returned an invalid value."
+        )
+    return free
+
+
+def _resolved_workspace(services: CoreWorkspaceServices) -> tuple[Path, str]:
+    try:
+        status = services.inspect_workspace_root()
+    except Exception as error:
+        message = str(error)[:300] or error.__class__.__name__
+        raise WorkspaceRestoreCoreError(
+            f"Core could not inspect the currently resolved workspace: {message}"
+        ) from error
+    try:
+        raw_root = Path(status.root)
+        source = status.source
+    except (AttributeError, TypeError, ValueError) as error:
+        raise WorkspaceRestoreCoreError(
+            "Core returned an invalid workspace status result."
+        ) from error
+    if not isinstance(source, str) or not source.strip():
+        raise WorkspaceRestoreCoreError(
+            "Core returned an invalid workspace resolution source."
+        )
+    try:
+        root = raw_root.resolve(strict=False)
+    except (OSError, RuntimeError) as error:
+        raise WorkspaceRestoreCoreError(
+            f"Could not resolve the Core workspace path: {raw_root}"
+        ) from error
+    return root, source
+
+
+def _assert_restore_separation(
+    destination_root: Path,
+    *,
+    backup_root: Path,
+    payload_root: Path,
+    workspace_root: Path,
+) -> None:
+    if _overlaps(destination_root, backup_root) or _overlaps(
+        destination_root, payload_root
+    ):
+        raise WorkspaceRestoreDestinationError(
+            "Restore destination must not overlap the source backup."
+        )
+    if _overlaps(destination_root, workspace_root):
+        raise WorkspaceRestoreDestinationError(
+            "Restore destination must not overlap the currently resolved workspace."
+        )
+
+
+def plan_workspace_restore(
+    backup: str | Path,
+    destination: str | Path,
+    *,
+    services: CoreWorkspaceServices | None = None,
+    services_loader: CoreServicesLoader = load_core_workspace_services,
+    verifier: BackupVerifier = verify_workspace_backup,
+    disk_usage_reader: DiskUsageReader = _read_disk_usage,
+) -> WorkspaceRestorePlan:
+    """Build a full read-only restore proposal without creating destination state."""
+    verification = verifier(backup)
+    active_services = services or services_loader()
+    workspace_root, workspace_source = _resolved_workspace(active_services)
+
+    expanded_destination = Path(
+        os.path.expandvars(os.path.expanduser(os.fspath(destination)))
+    )
+    destination_root = _expanded_path(destination, "Restore destination")
+    _assert_restore_separation(
+        destination_root,
+        backup_root=verification.backup_root,
+        payload_root=verification.payload_root,
+        workspace_root=workspace_root,
+    )
+    if _path_entry_exists(expanded_destination) or _path_entry_exists(
+        destination_root
+    ):
+        raise WorkspaceRestoreDestinationError(
+            f"Restore destination already exists and will not be modified: "
+            f"{destination_root}"
+        )
+
+    destination_parent = destination_root.parent
+    destination_anchor = _nearest_existing_directory(destination_parent)
+    free_bytes = _destination_free_bytes(destination_anchor, disk_usage_reader)
+    required_bytes = required_backup_free_bytes(
+        verification.manifest.total_bytes
+    )
+    if free_bytes < required_bytes:
+        raise WorkspaceRestoreSpaceError(
+            "Insufficient destination free space for restore: "
+            f"required {required_bytes} bytes, available {free_bytes} bytes."
+        )
+
+    return WorkspaceRestorePlan(
+        verification=verification,
+        workspace_root=workspace_root,
+        workspace_source=workspace_source,
+        destination_root=destination_root,
+        destination_parent=destination_parent,
+        destination_anchor=destination_anchor,
+        destination_free_bytes=free_bytes,
+        required_free_bytes=required_bytes,
+        destination_parent_exists=destination_parent.exists(),
+    )
+
+
+def _same_verification(
+    expected: WorkspaceBackupVerificationResult,
+    observed: WorkspaceBackupVerificationResult,
+) -> bool:
+    return (
+        expected.backup_root == observed.backup_root
+        and expected.manifest == observed.manifest
+        and expected.manifest_sha256 == observed.manifest_sha256
+    )
+
+
+def _recheck_restore_sources(
+    plan: WorkspaceRestorePlan,
+    *,
+    services: CoreWorkspaceServices,
+    verifier: BackupVerifier,
+) -> WorkspaceBackupVerificationResult:
+    try:
+        observed = verifier(plan.backup_root)
+    except WorkspaceBackupError as error:
+        raise WorkspaceRestoreDriftError(
+            "The backup no longer verifies as reviewed after restore preview."
+        ) from error
+    if not _same_verification(plan.verification, observed):
+        raise WorkspaceRestoreDriftError(
+            "The backup changed after restore preview; "
+            "verify and plan the restore again."
+        )
+    workspace_root, workspace_source = _resolved_workspace(services)
+    if (
+        workspace_root != plan.workspace_root
+        or workspace_source != plan.workspace_source
+    ):
+        raise WorkspaceRestoreDriftError(
+            "The currently resolved workspace changed after restore preview."
+        )
+    return observed
+
+
+def _prepare_destination_for_execution(
+    plan: WorkspaceRestorePlan,
+    *,
+    disk_usage_reader: DiskUsageReader,
+) -> Path:
+    destination = _expanded_path(plan.destination_root, "Restore destination")
+    if destination != plan.destination_root:
+        raise WorkspaceRestoreDestinationError(
+            "Restore destination resolved differently after confirmation; "
+            "rerun preview."
+        )
+    _assert_restore_separation(
+        destination,
+        backup_root=plan.backup_root,
+        payload_root=plan.payload_root,
+        workspace_root=plan.workspace_root,
+    )
+    if _path_entry_exists(destination):
+        raise WorkspaceRestoreCollisionError(
+            "Restore destination already exists and will not be modified: "
+            f"{destination}"
+        )
+
+    precreate_anchor = _nearest_existing_directory(destination.parent)
+    precreate_free_bytes = _destination_free_bytes(
+        precreate_anchor,
+        disk_usage_reader,
+    )
+    if precreate_free_bytes < plan.required_free_bytes:
+        raise WorkspaceRestoreSpaceError(
+            "Insufficient destination free space for restore: "
+            f"required {plan.required_free_bytes} bytes, "
+            f"available {precreate_free_bytes} bytes."
+        )
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise WorkspaceRestoreDestinationError(
+            f"Could not create restore destination parent: {destination.parent}"
+        ) from error
+    try:
+        parent = destination.parent.resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise WorkspaceRestoreDestinationError(
+            "Could not resolve restore destination parent after creation."
+        ) from error
+    if parent != plan.destination_parent:
+        raise WorkspaceRestoreDestinationError(
+            "Restore destination parent resolved differently after confirmation; "
+            "rerun preview."
+        )
+    final_root = parent / destination.name
+    _assert_restore_separation(
+        final_root,
+        backup_root=plan.backup_root,
+        payload_root=plan.payload_root,
+        workspace_root=plan.workspace_root,
+    )
+    if final_root != plan.destination_root:
+        raise WorkspaceRestoreDestinationError(
+            "Restore destination changed after confirmation; rerun preview."
+        )
+    if _path_entry_exists(final_root):
+        raise WorkspaceRestoreCollisionError(
+            f"Restore destination already exists and will not be modified: {final_root}"
+        )
+
+    current_anchor = _nearest_existing_directory(parent)
+    if current_anchor != parent:
+        raise WorkspaceRestoreDestinationError(
+            "Restore destination parent is not a stable ordinary directory."
+        )
+    if not _contains(precreate_anchor, parent) and precreate_anchor != parent:
+        raise WorkspaceRestoreDestinationError(
+            "Restore destination filesystem ancestry changed after confirmation."
+        )
+    free_bytes = _destination_free_bytes(parent, disk_usage_reader)
+    if free_bytes < plan.required_free_bytes:
+        raise WorkspaceRestoreSpaceError(
+            "Insufficient destination free space for restore: "
+            f"required {plan.required_free_bytes} bytes, "
+            f"available {free_bytes} bytes."
+        )
+    return parent
+
+
+def _default_staging_nonce() -> str:
+    return secrets.token_hex(8)
+
+
+def _staging_root(plan: WorkspaceRestorePlan, nonce: str) -> Path:
+    if not isinstance(nonce, str) or not nonce or any(
+        character not in (
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+        )
+        for character in nonce
+    ):
+        raise WorkspaceRestoreDestinationError("Restore staging nonce is invalid.")
+    return (
+        plan.destination_parent
+        / f".{plan.destination_root.name}.pds-restore.incomplete-{nonce}"
+    )
+
+
+def _redirecting_reparse(status: os.stat_result) -> bool:
+    attributes = getattr(status, "st_file_attributes", 0)
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    if not reparse_flag or not attributes & reparse_flag:
+        return False
+    tag = getattr(status, "st_reparse_tag", None)
+    redirect_tags = {
+        value
+        for value in (
+            getattr(stat, "IO_REPARSE_TAG_SYMLINK", None),
+            getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", None),
+        )
+        if value is not None
+    }
+    return tag in redirect_tags
+
+
+def _payload_path(root: Path, relative: str) -> Path:
+    return root.joinpath(*PurePosixPath(relative).parts)
+
+
+def _regular_file_status(
+    path: Path,
+    *,
+    relative: str,
+    area: str,
+) -> os.stat_result:
+    try:
+        status = path.lstat()
+    except OSError as error:
+        raise WorkspaceRestoreCopyError(
+            f"Could not inspect {area} file: {relative}"
+        ) from error
+    if stat.S_ISLNK(status.st_mode) or _redirecting_reparse(status):
+        raise WorkspaceRestoreDriftError(
+            f"Restore {area} contains linked filesystem entry: {relative}"
+        )
+    if not stat.S_ISREG(status.st_mode):
+        raise WorkspaceRestoreDriftError(
+            f"Restore {area} contains non-regular file entry: {relative}"
+        )
+    return status
+
+
+def _copy_verified_file(
+    payload_root: Path,
+    staging_root: Path,
+    expected: BackupFileEntry,
+    chunk_size: int,
+) -> BackupFileEntry:
+    """Copy one manifest-qualified payload file exclusively into restore staging."""
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be greater than zero")
+    source = _payload_path(payload_root, expected.path)
+    destination = _payload_path(staging_root, expected.path)
+    before = _regular_file_status(
+        source,
+        relative=expected.path,
+        area="backup payload",
+    )
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with source.open("rb") as input_stream, destination.open("xb") as output_stream:
+            opened = os.fstat(input_stream.fileno())
+            if not stat.S_ISREG(opened.st_mode):
+                raise WorkspaceRestoreDriftError(
+                    f"Backup payload file changed type while opening: {expected.path}"
+                )
+            while True:
+                chunk = input_stream.read(chunk_size)
+                if not chunk:
+                    break
+                output_stream.write(chunk)
+                digest.update(chunk)
+                total += len(chunk)
+            output_stream.flush()
+            os.fsync(output_stream.fileno())
+    except WorkspaceRestoreError:
+        raise
+    except FileExistsError as error:
+        raise WorkspaceRestoreCopyError(
+            f"Restore staging unexpectedly already contains file: {expected.path}"
+        ) from error
+    except OSError as error:
+        raise WorkspaceRestoreCopyError(
+            f"Could not copy verified backup payload file: {expected.path}"
+        ) from error
+    after = _regular_file_status(
+        source,
+        relative=expected.path,
+        area="backup payload",
+    )
+    copied = BackupFileEntry(
+        path=expected.path,
+        size=total,
+        sha256=digest.hexdigest(),
+    )
+    if total != before.st_size or total != after.st_size or copied != expected:
+        raise WorkspaceRestoreDriftError(
+            f"Backup payload changed while restore was copying: {expected.path}"
+        )
+    return copied
+
+
+def _create_staging_tree(
+    plan: WorkspaceRestorePlan,
+    staging_root: Path,
+) -> None:
+    try:
+        for relative in plan.verification.manifest.directories:
+            _payload_path(staging_root, relative).mkdir(exist_ok=False)
+    except OSError as error:
+        raise WorkspaceRestoreCopyError(
+            f"Could not create restore staging tree: {staging_root}"
+        ) from error
+
+
+def _hash_staged_file(
+    staging_root: Path,
+    expected: BackupFileEntry,
+    *,
+    chunk_size: int,
+) -> BackupFileEntry:
+    path = _payload_path(staging_root, expected.path)
+    try:
+        before = path.lstat()
+    except OSError as error:
+        raise WorkspaceRestoreVerificationError(
+            f"Restored staging file cannot be inspected: {expected.path}"
+        ) from error
+    if stat.S_ISLNK(before.st_mode) or _redirecting_reparse(before):
+        raise WorkspaceRestoreVerificationError(
+            f"Restored staging contains linked filesystem entry: {expected.path}"
+        )
+    if not stat.S_ISREG(before.st_mode):
+        raise WorkspaceRestoreVerificationError(
+            f"Restored staging entry is not an ordinary file: {expected.path}"
+        )
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with path.open("rb") as stream:
+            opened = os.fstat(stream.fileno())
+            if not stat.S_ISREG(opened.st_mode):
+                raise WorkspaceRestoreVerificationError(
+                    f"Restored staging file changed type while opening: {expected.path}"
+                )
+            while True:
+                chunk = stream.read(chunk_size)
+                if not chunk:
+                    break
+                total += len(chunk)
+                digest.update(chunk)
+    except WorkspaceRestoreError:
+        raise
+    except OSError as error:
+        raise WorkspaceRestoreVerificationError(
+            f"Restored staging file cannot be read: {expected.path}"
+        ) from error
+    try:
+        after = path.lstat()
+    except OSError as error:
+        raise WorkspaceRestoreVerificationError(
+            f"Restored staging file changed while being verified: {expected.path}"
+        ) from error
+    if not stat.S_ISREG(after.st_mode) or _redirecting_reparse(after):
+        raise WorkspaceRestoreVerificationError(
+            f"Restored staging file changed type while being verified: {expected.path}"
+        )
+    if total != before.st_size or total != after.st_size:
+        raise WorkspaceRestoreVerificationError(
+            f"Restored staging file changed size while being verified: {expected.path}"
+        )
+    return BackupFileEntry(
+        path=expected.path,
+        size=total,
+        sha256=digest.hexdigest(),
+    )
+
+
+def _verify_staged_restore(
+    staging_root: Path,
+    manifest: WorkspaceBackupManifest,
+    *,
+    chunk_size: int,
+) -> None:
+    try:
+        inventory = inventory_workspace(staging_root)
+    except WorkspaceBackupError as error:
+        raise WorkspaceRestoreVerificationError(str(error)) from error
+    if inventory.directories != manifest.directories:
+        raise WorkspaceRestoreVerificationError(
+            "Restored staging directory inventory does not match the manifest."
+        )
+    expected_sizes = tuple((item.path, item.size) for item in manifest.files)
+    observed_sizes = tuple((item.path, item.size) for item in inventory.files)
+    if (
+        observed_sizes != expected_sizes
+        or inventory.total_bytes != manifest.total_bytes
+    ):
+        raise WorkspaceRestoreVerificationError(
+            "Restored staging file inventory or sizes do not match the manifest."
+        )
+    for expected in manifest.files:
+        actual = _hash_staged_file(
+            staging_root,
+            expected,
+            chunk_size=chunk_size,
+        )
+        if actual != expected:
+            raise WorkspaceRestoreVerificationError(
+                f"Restored staging SHA-256 mismatch: {expected.path}"
+            )
+    try:
+        final_inventory = inventory_workspace(staging_root)
+    except WorkspaceBackupError as error:
+        raise WorkspaceRestoreVerificationError(str(error)) from error
+    if final_inventory != inventory:
+        raise WorkspaceRestoreVerificationError(
+            "Restored staging changed while verification was running."
+        )
+
+
+def _cleanup_staging(staging_root: Path) -> str | None:
+    if not staging_root.exists():
+        return None
+    try:
+        shutil.rmtree(staging_root)
+    except OSError:
+        return str(staging_root)
+    return None
+
+
+def _raise_rename_error(error_code: int, final_root: Path) -> None:
+    if error_code in (errno.EEXIST, errno.ENOTEMPTY):
+        raise FileExistsError(
+            error_code,
+            os.strerror(error_code),
+            os.fspath(final_root),
+        )
+    raise OSError(
+        error_code,
+        os.strerror(error_code),
+        os.fspath(final_root),
+    )
+
+
+def _try_renameat2_no_replace(staging_root: Path, final_root: Path) -> bool:
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        function = getattr(libc, "renameat2")
+    except (AttributeError, OSError):
+        return False
+
+    function.argtypes = (
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    )
+    function.restype = ctypes.c_int
+    ctypes.set_errno(0)
+    result = function(
+        -100,
+        os.fsencode(staging_root),
+        -100,
+        os.fsencode(final_root),
+        1,
+    )
+    if result != 0:
+        _raise_rename_error(ctypes.get_errno(), final_root)
+    return True
+
+
+def _try_renamex_no_replace(staging_root: Path, final_root: Path) -> bool:
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        function = getattr(libc, "renamex_np")
+    except (AttributeError, OSError):
+        return False
+
+    function.argtypes = (
+        ctypes.c_char_p,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    )
+    function.restype = ctypes.c_int
+    ctypes.set_errno(0)
+    result = function(
+        os.fsencode(staging_root),
+        os.fsencode(final_root),
+        0x00000004,
+    )
+    if result != 0:
+        _raise_rename_error(ctypes.get_errno(), final_root)
+    return True
+
+
+def _rename_no_replace(staging_root: Path, final_root: Path) -> None:
+    if os.name == "nt":
+        os.rename(staging_root, final_root)
+        return
+    if os.name == "posix":
+        if _try_renameat2_no_replace(staging_root, final_root):
+            return
+        if _try_renamex_no_replace(staging_root, final_root):
+            return
+    raise OSError(
+        errno.ENOTSUP,
+        "No supported non-overwriting directory rename primitive is available.",
+        os.fspath(final_root),
+    )
+
+
+def _publish_staging(staging_root: Path, final_root: Path) -> None:
+    if _path_entry_exists(final_root):
+        raise WorkspaceRestoreCollisionError(
+            f"Restore destination already exists and will not be modified: {final_root}"
+        )
+    try:
+        _rename_no_replace(staging_root, final_root)
+    except FileExistsError as error:
+        raise WorkspaceRestoreCollisionError(
+            f"Restore destination already exists and will not be modified: {final_root}"
+        ) from error
+    except OSError as error:
+        raise WorkspaceRestorePublicationError(
+            f"Could not publish verified restored workspace: {final_root}"
+        ) from error
+
+
+def restore_workspace_backup(
+    plan: WorkspaceRestorePlan,
+    *,
+    services: CoreWorkspaceServices | None = None,
+    services_loader: CoreServicesLoader = load_core_workspace_services,
+    verifier: BackupVerifier = verify_workspace_backup,
+    disk_usage_reader: DiskUsageReader = _read_disk_usage,
+    staging_nonce_factory: StagingNonceFactory = _default_staging_nonce,
+    file_copier: FileCopier = _copy_verified_file,
+    chunk_size: int = BACKUP_COPY_CHUNK_BYTES,
+    after_copy_hook: AfterCopyHook | None = None,
+    before_publish_hook: BeforePublishHook | None = None,
+) -> WorkspaceRestoreResult:
+    """Restore one reviewed verified backup to a new explicit alternate location."""
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be greater than zero")
+    active_services = services or services_loader()
+
+    # Reverify all reviewed source/safety state before the first destination mutation.
+    _recheck_restore_sources(
+        plan,
+        services=active_services,
+        verifier=verifier,
+    )
+    _prepare_destination_for_execution(
+        plan,
+        disk_usage_reader=disk_usage_reader,
+    )
+
+    staging_root = _staging_root(plan, staging_nonce_factory())
+    try:
+        staging_root.mkdir(exist_ok=False)
+    except FileExistsError as error:
+        raise WorkspaceRestoreCollisionError(
+            "Restore staging path already exists and will not be overwritten: "
+            f"{staging_root}"
+        ) from error
+    except OSError as error:
+        raise WorkspaceRestoreCopyError(
+            f"Could not create restore staging root: {staging_root}"
+        ) from error
+
+    try:
+        _create_staging_tree(plan, staging_root)
+        copied: list[BackupFileEntry] = []
+        for expected in plan.verification.manifest.files:
+            copied.append(
+                file_copier(
+                    plan.payload_root,
+                    staging_root,
+                    expected,
+                    chunk_size,
+                )
+            )
+
+        if after_copy_hook is not None:
+            after_copy_hook(plan.payload_root, staging_root)
+
+        try:
+            observed = verifier(plan.backup_root)
+        except WorkspaceBackupError as error:
+            raise WorkspaceRestoreDriftError(
+                "The backup changed while the restore was being created."
+            ) from error
+        if not _same_verification(plan.verification, observed):
+            raise WorkspaceRestoreDriftError(
+                "The backup changed while the restore was being created."
+            )
+        if tuple(copied) != plan.verification.manifest.files:
+            raise WorkspaceRestoreDriftError(
+                "Copied restore bytes do not match the reviewed backup manifest."
+            )
+        _verify_staged_restore(
+            staging_root,
+            plan.verification.manifest,
+            chunk_size=chunk_size,
+        )
+
+        if before_publish_hook is not None:
+            before_publish_hook(staging_root, plan.destination_root)
+        _publish_staging(staging_root, plan.destination_root)
+        return WorkspaceRestoreResult(
+            destination_root=plan.destination_root,
+            manifest=plan.verification.manifest,
+            manifest_sha256=plan.manifest_sha256,
+        )
+    except WorkspaceRestoreError as error:
+        remaining = _cleanup_staging(staging_root)
+        if remaining is not None:
+            raise WorkspaceRestoreCopyError(
+                f"{error} Incomplete restore staging remains at: {remaining}"
+            ) from error
+        raise
+    except (OSError, WorkspaceBackupError) as error:
+        remaining = _cleanup_staging(staging_root)
+        message = "Workspace restore failed due to a filesystem/integrity error."
+        if remaining is not None:
+            message += f" Incomplete restore staging remains at: {remaining}"
+        raise WorkspaceRestoreCopyError(message) from error
+
+
+__all__ = (
+    "WorkspaceRestoreCollisionError",
+    "WorkspaceRestoreCopyError",
+    "WorkspaceRestoreCoreError",
+    "WorkspaceRestoreDestinationError",
+    "WorkspaceRestoreDriftError",
+    "WorkspaceRestoreError",
+    "WorkspaceRestorePlan",
+    "WorkspaceRestorePublicationError",
+    "WorkspaceRestoreResult",
+    "WorkspaceRestoreSpaceError",
+    "WorkspaceRestoreVerificationError",
+    "plan_workspace_restore",
+    "restore_workspace_backup",
+)

--- a/scripts/smoke_test_workspace_restore_wheel.py
+++ b/scripts/smoke_test_workspace_restore_wheel.py
@@ -1,0 +1,632 @@
+"""Smoke-test installed backup verification and alternate-location restore."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import venv
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class WorkspaceRestoreSmokeTestError(RuntimeError):
+    """Raised when installed backup verification/restore acceptance fails."""
+
+
+@dataclass(frozen=True, slots=True)
+class FileSnapshot:
+    """Independent file facts used by the smoke test."""
+
+    path: str
+    size: int
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class TreeSnapshot:
+    """Independent directory/file snapshot for source/restore comparison."""
+
+    directories: tuple[str, ...]
+    files: tuple[FileSnapshot, ...]
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    input_text: str | None = None,
+    expected_returncode: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=dict(env),
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != expected_returncode:
+        raise WorkspaceRestoreSmokeTestError(
+            "Command returned an unexpected status "
+            f"({result.returncode}, expected {expected_returncode}): "
+            f"{' '.join(command)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _venv_python(environment: Path) -> Path:
+    if os.name == "nt":
+        return environment / "Scripts" / "python.exe"
+    return environment / "bin" / "python"
+
+
+def _scripts_directory(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> Path:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            "import sysconfig; print(sysconfig.get_path('scripts'))",
+        ],
+        cwd=cwd,
+        env=env,
+    )
+    return Path(result.stdout.strip())
+
+
+def _isolated_command_env(
+    base_env: Mapping[str, str],
+    *,
+    user_home: Path,
+) -> dict[str, str]:
+    env = dict(base_env)
+    for key in tuple(env):
+        if key.upper() in {"PYTHONPATH", "PDS_WORKSPACE_ROOT"}:
+            env.pop(key, None)
+
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONNOUSERSITE"] = "1"
+    env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    env["PIP_NO_INDEX"] = "1"
+    env["HOME"] = str(user_home)
+    env["USERPROFILE"] = str(user_home)
+    env["APPDATA"] = str(user_home / "AppData" / "Roaming")
+    env["XDG_CONFIG_HOME"] = str(user_home / ".config")
+    return env
+
+
+def _assert_installed_suite_location(
+    python: Path,
+    *,
+    environment: Path,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> None:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            (
+                "from pathlib import Path; import paper_data_suite; "
+                "print(Path(paper_data_suite.__file__).resolve())"
+            ),
+        ],
+        cwd=cwd,
+        env=env,
+    )
+    installed = Path(result.stdout.strip()).resolve()
+    try:
+        installed.relative_to(environment.resolve())
+    except ValueError as error:
+        raise WorkspaceRestoreSmokeTestError(
+            "Smoke test imported paper_data_suite outside the isolated environment: "
+            f"{installed}"
+        ) from error
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while True:
+            chunk = stream.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _relative(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _snapshot_tree(root: Path) -> TreeSnapshot:
+    directories: list[str] = []
+    files: list[FileSnapshot] = []
+    for current, dirnames, filenames in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        dirnames.sort()
+        filenames.sort()
+        for name in dirnames:
+            path = current_path / name
+            if path.is_symlink():
+                raise WorkspaceRestoreSmokeTestError(
+                    f"Synthetic smoke tree unexpectedly contains a symlink: {path}"
+                )
+            directories.append(_relative(root, path))
+        for name in filenames:
+            path = current_path / name
+            if path.is_symlink() or not path.is_file():
+                raise WorkspaceRestoreSmokeTestError(
+                    f"Synthetic smoke tree contains unsupported file entry: {path}"
+                )
+            files.append(
+                FileSnapshot(
+                    path=_relative(root, path),
+                    size=path.stat().st_size,
+                    sha256=_sha256(path),
+                )
+            )
+    return TreeSnapshot(
+        directories=tuple(sorted(directories)),
+        files=tuple(sorted(files, key=lambda item: item.path)),
+    )
+
+
+def _assert_clean_directory(path: Path) -> None:
+    contents = tuple(path.iterdir())
+    if contents:
+        raise WorkspaceRestoreSmokeTestError(
+            "Workspace-restore smoke created working-directory artifacts: "
+            + ", ".join(item.name for item in contents)
+        )
+
+
+def _assert_verify_help(output: str) -> None:
+    normalized = " ".join(output.split()).replace("- ", "-")
+    required = (
+        "manifest",
+        "SHA-256",
+        "without modifying",
+        "runtime-compatibility",
+    )
+    missing = [fragment for fragment in required if fragment not in normalized]
+    if missing:
+        raise WorkspaceRestoreSmokeTestError(
+            "Installed verify help is missing expected content: "
+            + ", ".join(missing)
+        )
+
+
+def _assert_restore_help(output: str) -> None:
+    normalized = " ".join(output.split())
+    required = (
+        "--destination",
+        "--yes",
+        "must not already exist",
+        "not selected automatically",
+    )
+    missing = [fragment for fragment in required if fragment not in normalized]
+    if missing:
+        raise WorkspaceRestoreSmokeTestError(
+            "Installed restore help is missing expected content: "
+            + ", ".join(missing)
+        )
+
+
+def _find_completed_backup(parent: Path) -> Path:
+    completed = tuple(
+        path
+        for path in parent.iterdir()
+        if path.is_dir() and path.name.startswith("pds-workspace-backup-")
+    )
+    if len(completed) != 1:
+        raise WorkspaceRestoreSmokeTestError(
+            f"Expected one completed backup, found {len(completed)}."
+        )
+    return completed[0]
+
+
+def _assert_no_sibling_apps(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> None:
+    code = """
+from importlib import metadata
+
+unexpected = (
+    "pds-concord",
+    "quillan",
+    "scoreform",
+    "pds-vitrine",
+    "pds-meridian",
+    "pds-portia",
+)
+installed = {
+    item.metadata.get("Name", "").lower()
+    for item in metadata.distributions()
+}
+present = [name for name in unexpected if name in installed]
+if present:
+    raise SystemExit("unexpected sibling PDS distributions: " + ", ".join(present))
+""".strip()
+    _run([str(python), "-c", code], cwd=cwd, env=env)
+
+
+def smoke_test_workspace_restore_wheel(
+    suite_wheel: Path,
+    core_wheel: Path,
+) -> None:
+    """Exercise installed verify/restore beside the exact Core wheel only."""
+    suite_wheel = suite_wheel.resolve()
+    core_wheel = core_wheel.resolve()
+    if not suite_wheel.is_file():
+        raise WorkspaceRestoreSmokeTestError(
+            f"Suite wheel does not exist: {suite_wheel}"
+        )
+    if not core_wheel.is_file():
+        raise WorkspaceRestoreSmokeTestError(
+            f"Core wheel does not exist: {core_wheel}"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="pds-restore-smoke-") as temporary:
+        temp_root = Path(temporary)
+        environment = temp_root / "venv"
+        run_directory = temp_root / "run"
+        user_home = temp_root / "user"
+        workspace = temp_root / "workspace"
+        backup_parent = temp_root / "backups"
+        restore_destination = temp_root / "recovery" / "restored-workspace"
+        cancel_destination = temp_root / "cancelled" / "restored-workspace"
+        existing_destination = temp_root / "existing-restore"
+        tampered_parent = temp_root / "tampered"
+        incomplete_parent = temp_root / "incomplete"
+        run_directory.mkdir()
+        user_home.mkdir()
+
+        venv.EnvBuilder(with_pip=True).create(environment)
+        python = _venv_python(environment)
+        env = _isolated_command_env(os.environ, user_home=user_home)
+
+        _run(
+            [str(python), "-m", "pip", "install", "--no-deps", str(core_wheel)],
+            cwd=run_directory,
+            env=env,
+        )
+        _run(
+            [str(python), "-m", "pip", "install", "--no-deps", str(suite_wheel)],
+            cwd=run_directory,
+            env=env,
+        )
+        _run(
+            [str(python), "-m", "pip", "check"],
+            cwd=run_directory,
+            env=env,
+        )
+        _assert_installed_suite_location(
+            python,
+            environment=environment,
+            cwd=run_directory,
+            env=env,
+        )
+        _assert_no_sibling_apps(python, cwd=run_directory, env=env)
+
+        scripts = _scripts_directory(
+            python,
+            cwd=run_directory,
+            env=env,
+        )
+        launcher = scripts / ("pds.exe" if os.name == "nt" else "pds")
+        if not launcher.is_file():
+            raise WorkspaceRestoreSmokeTestError(
+                f"Installed pds launcher does not exist: {launcher}"
+            )
+
+        module_verify_help = _run(
+            [
+                str(python),
+                "-m",
+                "paper_data_suite",
+                "backup",
+                "verify",
+                "--help",
+            ],
+            cwd=run_directory,
+            env=env,
+        )
+        console_restore_help = _run(
+            [str(launcher), "backup", "restore", "--help"],
+            cwd=run_directory,
+            env=env,
+        )
+        _assert_verify_help(module_verify_help.stdout)
+        _assert_restore_help(console_restore_help.stdout)
+
+        _run(
+            [str(launcher), "workspace", "set", str(workspace)],
+            cwd=run_directory,
+            env=env,
+        )
+        (workspace / "future-module" / "empty").mkdir(parents=True)
+        (workspace / "future-module" / "opaque.bin").write_bytes(
+            b"\x00\xffsynthetic"
+        )
+        (workspace / ".hidden").write_text(
+            "synthetic hidden",
+            encoding="utf-8",
+        )
+        (workspace / "zero.dat").write_bytes(b"")
+        sensitive = workspace / "student-private.csv"
+        sensitive.write_text("synthetic-only", encoding="utf-8")
+        source_before = _snapshot_tree(workspace)
+        workspace_show_before = _run(
+            [str(launcher), "workspace", "show"],
+            cwd=run_directory,
+            env=env,
+        ).stdout
+
+        created = _run(
+            [
+                str(launcher),
+                "backup",
+                "create",
+                "--destination",
+                str(backup_parent),
+                "--yes",
+            ],
+            cwd=run_directory,
+            env=env,
+        )
+        if "Workspace backup complete" not in created.stdout:
+            raise WorkspaceRestoreSmokeTestError(
+                "Installed backup creation did not report completion."
+            )
+        backup_root = _find_completed_backup(backup_parent)
+        manifest_path = backup_root / "manifest.json"
+        manifest_hash = _sha256(manifest_path)
+
+        module_verified = _run(
+            [
+                str(python),
+                "-m",
+                "paper_data_suite",
+                "backup",
+                "verify",
+                str(backup_root),
+            ],
+            cwd=run_directory,
+            env=env,
+        )
+        console_verified = _run(
+            [str(launcher), "backup", "verify", str(backup_root)],
+            cwd=run_directory,
+            env=env,
+        )
+        for output in (module_verified.stdout, console_verified.stdout):
+            if "Workspace backup verified" not in output:
+                raise WorkspaceRestoreSmokeTestError(
+                    "Installed backup verify did not report success."
+                )
+            if f"Manifest SHA-256: {manifest_hash}" not in output:
+                raise WorkspaceRestoreSmokeTestError(
+                    "Installed verify reported the wrong manifest SHA-256."
+                )
+            if sensitive.name in output:
+                raise WorkspaceRestoreSmokeTestError(
+                    "Normal verify output leaked a payload filename."
+                )
+
+        cancelled = _run(
+            [
+                str(python),
+                "-m",
+                "paper_data_suite",
+                "backup",
+                "restore",
+                str(backup_root),
+                "--destination",
+                str(cancel_destination),
+            ],
+            cwd=run_directory,
+            env=env,
+            input_text="Q\n",
+        )
+        if "Workspace restore cancelled" not in cancelled.stdout:
+            raise WorkspaceRestoreSmokeTestError(
+                "Installed module-form restore cancellation was not reported."
+            )
+        if cancel_destination.exists():
+            raise WorkspaceRestoreSmokeTestError(
+                "Restore cancellation created the final destination."
+            )
+
+        active_refusal = _run(
+            [
+                str(launcher),
+                "backup",
+                "restore",
+                str(backup_root),
+                "--destination",
+                str(workspace),
+                "--yes",
+            ],
+            cwd=run_directory,
+            env=env,
+            expected_returncode=1,
+        )
+        if "Restore refused" not in active_refusal.stderr:
+            raise WorkspaceRestoreSmokeTestError(
+                "Restore did not clearly refuse the active workspace destination."
+            )
+
+        restored = _run(
+            [
+                str(launcher),
+                "backup",
+                "restore",
+                str(backup_root),
+                "--destination",
+                str(restore_destination),
+                "--yes",
+            ],
+            cwd=run_directory,
+            env=env,
+        )
+        if "Workspace restore complete" not in restored.stdout:
+            raise WorkspaceRestoreSmokeTestError(
+                "Installed restore did not report verified completion."
+            )
+        if "was not selected automatically" not in restored.stdout:
+            raise WorkspaceRestoreSmokeTestError(
+                "Restore completion omitted the workspace-selection boundary."
+            )
+        if sensitive.name in restored.stdout:
+            raise WorkspaceRestoreSmokeTestError(
+                "Normal restore output leaked a payload filename."
+            )
+        if not restore_destination.is_dir():
+            raise WorkspaceRestoreSmokeTestError(
+                "Restore did not publish the explicit destination."
+            )
+        if (restore_destination / "manifest.json").exists():
+            raise WorkspaceRestoreSmokeTestError(
+                "Restore injected backup manifest.json into the workspace."
+            )
+        if _snapshot_tree(restore_destination) != source_before:
+            raise WorkspaceRestoreSmokeTestError(
+                "Restored workspace bytes/tree do not match the source snapshot."
+            )
+        if _snapshot_tree(workspace) != source_before:
+            raise WorkspaceRestoreSmokeTestError(
+                "Verification/restore modified the active source workspace."
+            )
+
+        workspace_show_after = _run(
+            [str(launcher), "workspace", "show"],
+            cwd=run_directory,
+            env=env,
+        ).stdout
+        if workspace_show_after != workspace_show_before:
+            raise WorkspaceRestoreSmokeTestError(
+                "Restore changed Core's selected workspace."
+            )
+
+        existing_destination.mkdir()
+        sentinel = existing_destination / "sentinel.txt"
+        sentinel.write_text("preserve", encoding="utf-8")
+        existing_refusal = _run(
+            [
+                str(launcher),
+                "backup",
+                "restore",
+                str(backup_root),
+                "--destination",
+                str(existing_destination),
+                "--yes",
+            ],
+            cwd=run_directory,
+            env=env,
+            expected_returncode=1,
+        )
+        if "Restore refused" not in existing_refusal.stderr:
+            raise WorkspaceRestoreSmokeTestError(
+                "Existing restore destination was not clearly refused."
+            )
+        if sentinel.read_text(encoding="utf-8") != "preserve":
+            raise WorkspaceRestoreSmokeTestError(
+                "Existing-destination refusal modified the sentinel."
+            )
+
+        incomplete_parent.mkdir()
+        incomplete = incomplete_parent / (
+            f".{backup_root.name}.incomplete-synthetic"
+        )
+        shutil.copytree(backup_root, incomplete)
+        incomplete_result = _run(
+            [str(launcher), "backup", "verify", str(incomplete)],
+            cwd=run_directory,
+            env=env,
+            expected_returncode=1,
+        )
+        if "Backup verification failed" not in incomplete_result.stderr:
+            raise WorkspaceRestoreSmokeTestError(
+                "Incomplete backup was not clearly refused."
+            )
+
+        tampered_parent.mkdir()
+        tampered = tampered_parent / backup_root.name
+        shutil.copytree(backup_root, tampered)
+        tampered_file = tampered / "workspace" / "future-module" / "opaque.bin"
+        original = tampered_file.read_bytes()
+        tampered_file.write_bytes(bytes((value ^ 1) for value in original))
+        tampered_result = _run(
+            [
+                str(python),
+                "-m",
+                "paper_data_suite",
+                "backup",
+                "verify",
+                str(tampered),
+            ],
+            cwd=run_directory,
+            env=env,
+            expected_returncode=1,
+        )
+        if "Backup verification failed" not in tampered_result.stderr:
+            raise WorkspaceRestoreSmokeTestError(
+                "Tampered backup was not clearly refused."
+            )
+
+        incomplete_staging = tuple(
+            restore_destination.parent.glob(".*.pds-restore.incomplete-*")
+        )
+        if incomplete_staging:
+            raise WorkspaceRestoreSmokeTestError(
+                "Successful restore left incomplete staging state."
+            )
+        _assert_clean_directory(run_directory)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the installed backup verification/restore smoke-test parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Install the built Paper Data Suite wheel beside the exact Core wheel "
+            "and exercise backup verification plus alternate-location restore."
+        )
+    )
+    parser.add_argument("suite_wheel", type=Path)
+    parser.add_argument("core_wheel", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run installed backup verification/restore acceptance."""
+    arguments = build_parser().parse_args(argv)
+    try:
+        smoke_test_workspace_restore_wheel(
+            arguments.suite_wheel,
+            arguments.core_wheel,
+        )
+    except WorkspaceRestoreSmokeTestError as error:
+        print(f"Workspace restore smoke test failed: {error}", file=sys.stderr)
+        return 1
+    print("Workspace restore wheel smoke test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_test_workspace_restore_wheel.py
+++ b/tests/test_smoke_test_workspace_restore_wheel.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import smoke_test_workspace_restore_wheel
+
+
+def test_main_invokes_workspace_restore_smoke_with_cli_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "suite.whl"
+    core = tmp_path / "core.whl"
+    observed: list[tuple[Path, Path]] = []
+
+    def fake_smoke(suite_wheel: Path, core_wheel: Path) -> None:
+        observed.append((suite_wheel, core_wheel))
+
+    monkeypatch.setattr(
+        smoke_test_workspace_restore_wheel,
+        "smoke_test_workspace_restore_wheel",
+        fake_smoke,
+    )
+
+    assert smoke_test_workspace_restore_wheel.main((str(suite), str(core))) == 0
+    assert observed == [(suite, core)]
+    assert capsys.readouterr().out.strip() == (
+        "Workspace restore wheel smoke test passed."
+    )
+
+
+def test_main_returns_failure_when_workspace_restore_smoke_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    suite = tmp_path / "suite.whl"
+    core = tmp_path / "core.whl"
+
+    def fail_smoke(suite_wheel: Path, core_wheel: Path) -> None:
+        del suite_wheel, core_wheel
+        raise smoke_test_workspace_restore_wheel.WorkspaceRestoreSmokeTestError(
+            "synthetic failure"
+        )
+
+    monkeypatch.setattr(
+        smoke_test_workspace_restore_wheel,
+        "smoke_test_workspace_restore_wheel",
+        fail_smoke,
+    )
+
+    assert smoke_test_workspace_restore_wheel.main((str(suite), str(core))) == 1
+    assert "synthetic failure" in capsys.readouterr().err
+
+
+def test_isolated_command_env_removes_workspace_and_pythonpath_variants(
+    tmp_path: Path,
+) -> None:
+    result = smoke_test_workspace_restore_wheel._isolated_command_env(
+        {
+            "PATH": "synthetic",
+            "PYTHONPATH": "source-a",
+            "PythonPath": "source-b",
+            "PDS_WORKSPACE_ROOT": "real-workspace",
+        },
+        user_home=tmp_path / "user",
+    )
+
+    assert result["PATH"] == "synthetic"
+    assert all(key.upper() != "PYTHONPATH" for key in result)
+    assert all(key.upper() != "PDS_WORKSPACE_ROOT" for key in result)
+    assert result["PYTHONNOUSERSITE"] == "1"
+    assert result["HOME"] == str(tmp_path / "user")
+    assert result["USERPROFILE"] == str(tmp_path / "user")
+
+
+def test_snapshot_tree_preserves_empty_hidden_binary_unicode_and_zero(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspace"
+    (root / "nested" / "empty").mkdir(parents=True)
+    (root / ".hidden").write_text("hidden", encoding="utf-8")
+    (root / "nested" / "opaque.bin").write_bytes(b"\x00\xff")
+    (root / "unicodé.txt").write_text("ok", encoding="utf-8")
+    (root / "zero.dat").write_bytes(b"")
+
+    snapshot = smoke_test_workspace_restore_wheel._snapshot_tree(root)
+
+    assert snapshot.directories == ("nested", "nested/empty")
+    assert tuple(item.path for item in snapshot.files) == (
+        ".hidden",
+        "nested/opaque.bin",
+        "unicodé.txt",
+        "zero.dat",
+    )
+    assert tuple(item.size for item in snapshot.files) == (6, 2, 2, 0)
+
+
+def test_verify_help_assertion_requires_integrity_boundary() -> None:
+    good = (
+        "Verify manifest SHA-256 without modifying a backup; "
+        "this is not a runtime-compatibility guarantee."
+    )
+    smoke_test_workspace_restore_wheel._assert_verify_help(good)
+
+    argparse_wrapped = (
+        "Verify manifest SHA-256 without modifying a backup; "
+        "this is not a runtime-\ncompatibility guarantee."
+    )
+    smoke_test_workspace_restore_wheel._assert_verify_help(argparse_wrapped)
+
+    with pytest.raises(
+        smoke_test_workspace_restore_wheel.WorkspaceRestoreSmokeTestError,
+        match="verify help",
+    ):
+        smoke_test_workspace_restore_wheel._assert_verify_help(
+            "verify a backup"
+        )
+
+
+def test_restore_help_assertion_requires_selection_and_destination_boundary() -> None:
+    good = (
+        "Restore to --destination which must not already exist; use --yes. "
+        "The restored workspace is not selected automatically."
+    )
+    smoke_test_workspace_restore_wheel._assert_restore_help(good)
+
+    with pytest.raises(
+        smoke_test_workspace_restore_wheel.WorkspaceRestoreSmokeTestError,
+        match="restore help",
+    ):
+        smoke_test_workspace_restore_wheel._assert_restore_help(
+            "restore a backup"
+        )

--- a/tests/test_workspace_backup_dispatch.py
+++ b/tests/test_workspace_backup_dispatch.py
@@ -14,8 +14,9 @@ def test_backup_group_without_subcommand_shows_help(
     output = capsys.readouterr().out
     normalized = " ".join(output.split())
     assert "usage: pds backup" in normalized
-    assert "{create}" in normalized
-    assert "currently resolved Core workspace" in normalized
+    assert "{create,verify,restore}" in normalized
+    assert "independently verify a completed backup" in normalized
+    assert "Restore never automatically selects" in normalized
 
 
 def test_backup_create_help_documents_explicit_sensitive_copy_boundary(

--- a/tests/test_workspace_backup_verification.py
+++ b/tests/test_workspace_backup_verification.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from paper_data_suite.workspace_backup import (
+    BACKUP_HASH_ALGORITHM,
+    BACKUP_MANIFEST_RECORD_TYPE,
+    BACKUP_MANIFEST_SCHEMA_VERSION,
+    BACKUP_PAYLOAD_ROOT,
+    BackupFileEntry,
+    WorkspaceBackupManifest,
+    WorkspaceBackupVerificationError,
+    backup_name,
+    serialize_workspace_backup_manifest,
+)
+from paper_data_suite.workspace_backup_verification import verify_workspace_backup
+
+FIXED_TIME = datetime(2026, 8, 20, 17, 48, 12, 123456, tzinfo=timezone.utc)
+
+
+def _write_backup(tmp_path: Path) -> tuple[Path, WorkspaceBackupManifest]:
+    backup_root = tmp_path / backup_name(FIXED_TIME)
+    payload = backup_root / BACKUP_PAYLOAD_ROOT
+    (payload / "classes" / "future-module" / "empty").mkdir(parents=True)
+    (payload / ".pds").mkdir()
+    (payload / "classes" / "future-module" / "opaque.bin").write_bytes(b"\x00\xffx")
+    (payload / "zero.dat").write_bytes(b"")
+    (payload / "unicodé.txt").write_text("hello", encoding="utf-8")
+    files = tuple(
+        BackupFileEntry(
+            path=path,
+            size=len(data),
+            sha256=hashlib.sha256(data).hexdigest(),
+        )
+        for path, data in (
+            ("classes/future-module/opaque.bin", b"\x00\xffx"),
+            ("unicodé.txt", b"hello"),
+            ("zero.dat", b""),
+        )
+    )
+    manifest = WorkspaceBackupManifest(
+        record_type=BACKUP_MANIFEST_RECORD_TYPE,
+        schema_version=BACKUP_MANIFEST_SCHEMA_VERSION,
+        backup_id=backup_root.name,
+        created_at=FIXED_TIME,
+        suite_version="0.1.0.dev0",
+        core_version="0.6.0",
+        payload_root=BACKUP_PAYLOAD_ROOT,
+        hash_algorithm=BACKUP_HASH_ALGORITHM,
+        directory_count=4,
+        file_count=3,
+        total_bytes=8,
+        directories=(
+            ".pds",
+            "classes",
+            "classes/future-module",
+            "classes/future-module/empty",
+        ),
+        files=files,
+        exclusions=(),
+    )
+    (backup_root / "manifest.json").write_bytes(
+        serialize_workspace_backup_manifest(manifest)
+    )
+    return backup_root, manifest
+
+
+def test_verify_accepts_complete_backup_without_core_or_module_semantics(
+    tmp_path: Path,
+) -> None:
+    backup_root, manifest = _write_backup(tmp_path)
+
+    result = verify_workspace_backup(backup_root, chunk_size=2)
+
+    assert result.backup_root == backup_root.resolve()
+    assert result.manifest == manifest
+    assert result.payload_root == backup_root.resolve() / "workspace"
+    assert result.manifest_sha256 == hashlib.sha256(
+        (backup_root / "manifest.json").read_bytes()
+    ).hexdigest()
+
+
+def test_verify_allows_backup_moved_to_different_parent(tmp_path: Path) -> None:
+    backup_root, _manifest = _write_backup(tmp_path / "original")
+    moved_parent = tmp_path / "moved"
+    moved_parent.mkdir()
+    moved = moved_parent / backup_root.name
+    backup_root.rename(moved)
+
+    assert verify_workspace_backup(moved).backup_root == moved.resolve()
+
+
+def test_verify_rejects_renamed_backup_root(tmp_path: Path) -> None:
+    backup_root, _manifest = _write_backup(tmp_path)
+    renamed = backup_root.with_name("pds-workspace-backup-20260820T174812999999Z")
+    backup_root.rename(renamed)
+
+    with pytest.raises(WorkspaceBackupVerificationError, match="backup_id"):
+        verify_workspace_backup(renamed)
+
+
+def test_verify_rejects_incomplete_staging_name(tmp_path: Path) -> None:
+    backup_root, _manifest = _write_backup(tmp_path)
+    incomplete = backup_root.with_name(f".{backup_root.name}.incomplete-deadbeef")
+    backup_root.rename(incomplete)
+
+    with pytest.raises(WorkspaceBackupVerificationError, match="Incomplete"):
+        verify_workspace_backup(incomplete)
+
+
+def test_verify_rejects_missing_or_extra_top_level_state(tmp_path: Path) -> None:
+    backup_root, _manifest = _write_backup(tmp_path / "missing")
+    (backup_root / "manifest.json").unlink()
+    with pytest.raises(WorkspaceBackupVerificationError, match="missing manifest"):
+        verify_workspace_backup(backup_root)
+
+    backup_root, _manifest = _write_backup(tmp_path / "extra")
+    (backup_root / "unexpected.txt").write_text("x", encoding="utf-8")
+    with pytest.raises(WorkspaceBackupVerificationError, match="unexpected"):
+        verify_workspace_backup(backup_root)
+
+
+def test_verify_rejects_noncanonical_manifest_bytes(tmp_path: Path) -> None:
+    backup_root, _manifest = _write_backup(tmp_path)
+    manifest_path = backup_root / "manifest.json"
+    mapping = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest_path.write_text(json.dumps(mapping), encoding="utf-8")
+
+    with pytest.raises(WorkspaceBackupVerificationError, match="canonical"):
+        verify_workspace_backup(backup_root)
+
+
+def test_verify_detects_same_size_payload_corruption(tmp_path: Path) -> None:
+    backup_root, _manifest = _write_backup(tmp_path)
+    payload = backup_root / "workspace" / "unicodé.txt"
+    payload.write_bytes(b"HELLO")
+
+    with pytest.raises(WorkspaceBackupVerificationError, match="SHA-256"):
+        verify_workspace_backup(backup_root)
+
+
+@pytest.mark.parametrize("mutation", ("extra-file", "missing-file", "missing-dir"))
+def test_verify_requires_exact_payload_inventory(tmp_path: Path, mutation: str) -> None:
+    backup_root, _manifest = _write_backup(tmp_path)
+    payload = backup_root / "workspace"
+    if mutation == "extra-file":
+        (payload / ".unexpected").write_bytes(b"x")
+    elif mutation == "missing-file":
+        (payload / "zero.dat").unlink()
+    else:
+        (payload / "classes" / "future-module" / "empty").rmdir()
+
+    with pytest.raises(WorkspaceBackupVerificationError, match="inventory"):
+        verify_workspace_backup(backup_root)
+
+
+def test_verify_rejects_linked_payload_entry_without_following(tmp_path: Path) -> None:
+    backup_root, _manifest = _write_backup(tmp_path)
+    payload = backup_root / "workspace"
+    target = tmp_path / "outside.txt"
+    target.write_bytes(b"do-not-read")
+    linked = payload / "zero.dat"
+    linked.unlink()
+    try:
+        linked.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation unavailable")
+
+    with pytest.raises(WorkspaceBackupVerificationError, match="linked"):
+        verify_workspace_backup(backup_root)
+
+
+def test_verify_rejects_backup_root_file(tmp_path: Path) -> None:
+    root = tmp_path / "pds-workspace-backup-20260820T174812123456Z"
+    root.write_bytes(b"not-a-directory")
+
+    with pytest.raises(WorkspaceBackupVerificationError, match="not a directory"):
+        verify_workspace_backup(root)
+
+
+def test_verify_rejects_backup_root_symlink_without_following(tmp_path: Path) -> None:
+    backup_root, _manifest = _write_backup(tmp_path / "target")
+    linked = tmp_path / "backup-link"
+    try:
+        linked.symlink_to(backup_root, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlink creation unavailable")
+
+    with pytest.raises(
+        WorkspaceBackupVerificationError,
+        match="redirecting filesystem entry",
+    ):
+        verify_workspace_backup(linked)
+
+
+def test_verify_rejects_invalid_chunk_size(tmp_path: Path) -> None:
+    backup_root, _manifest = _write_backup(tmp_path)
+    with pytest.raises(ValueError, match="greater than zero"):
+        verify_workspace_backup(backup_root, chunk_size=0)

--- a/tests/test_workspace_backup_verify_cli.py
+++ b/tests/test_workspace_backup_verify_cli.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from paper_data_suite.cli import build_parser, main
+from paper_data_suite.workspace_backup import (
+    BACKUP_HASH_ALGORITHM,
+    BACKUP_MANIFEST_RECORD_TYPE,
+    BACKUP_MANIFEST_SCHEMA_VERSION,
+    BACKUP_PAYLOAD_ROOT,
+    WorkspaceBackupManifest,
+    backup_name,
+    serialize_workspace_backup_manifest,
+)
+from paper_data_suite.workspace_backup_cli import run_workspace_backup_verify
+
+FIXED_TIME = datetime(2026, 8, 20, 17, 48, 12, 123456, tzinfo=timezone.utc)
+
+
+def _empty_backup(tmp_path: Path) -> Path:
+    root = tmp_path / backup_name(FIXED_TIME)
+    (root / "workspace").mkdir(parents=True)
+    manifest = WorkspaceBackupManifest(
+        record_type=BACKUP_MANIFEST_RECORD_TYPE,
+        schema_version=BACKUP_MANIFEST_SCHEMA_VERSION,
+        backup_id=root.name,
+        created_at=FIXED_TIME,
+        suite_version="0.1.0.dev0",
+        core_version="0.6.0",
+        payload_root=BACKUP_PAYLOAD_ROOT,
+        hash_algorithm=BACKUP_HASH_ALGORITHM,
+        directory_count=0,
+        file_count=0,
+        total_bytes=0,
+        directories=(),
+        files=(),
+        exclusions=(),
+    )
+    (root / "manifest.json").write_bytes(serialize_workspace_backup_manifest(manifest))
+    return root
+
+
+def test_parser_accepts_backup_verify() -> None:
+    arguments = build_parser().parse_args(["backup", "verify", "example"])
+    assert arguments.command == "backup"
+    assert arguments.backup_command == "verify"
+    assert arguments.backup == Path("example")
+
+
+def test_verify_cli_renders_bounded_success(
+    tmp_path: Path, capsys  # type: ignore[no-untyped-def]
+) -> None:
+    backup = _empty_backup(tmp_path)
+
+    assert run_workspace_backup_verify(backup) == 0
+
+    output = capsys.readouterr()
+    assert "Workspace backup verified" in output.out
+    assert f"Backup: {backup.resolve()}" in output.out
+    assert "Backup ID:" in output.out
+    assert "Recorded suite version: 0.1.0.dev0" in output.out
+    assert "Recorded Core version: 0.6.0" in output.out
+    assert "Directories: 0" in output.out
+    assert "Files: 0" in output.out
+    assert "Payload bytes: 0" in output.out
+    assert "Manifest SHA-256:" in output.out
+    assert "authentic" not in output.out.lower()
+    assert output.err == ""
+
+
+def test_verify_cli_failure_is_bounded(
+    tmp_path: Path, capsys  # type: ignore[no-untyped-def]
+) -> None:
+    missing = tmp_path / "missing"
+
+    assert run_workspace_backup_verify(missing) == 1
+
+    output = capsys.readouterr()
+    assert output.out == ""
+    assert output.err.startswith("Backup verification failed:")
+    assert len(output.err) < 700
+
+
+def test_main_dispatches_backup_verify(
+    tmp_path: Path, capsys  # type: ignore[no-untyped-def]
+) -> None:
+    backup = _empty_backup(tmp_path)
+
+    assert main(["backup", "verify", str(backup)]) == 0
+    assert "Workspace backup verified" in capsys.readouterr().out

--- a/tests/test_workspace_restore_cli.py
+++ b/tests/test_workspace_restore_cli.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import paper_data_suite.cli as cli_module
+import paper_data_suite.workspace_backup_cli as backup_cli_module
+from paper_data_suite.cli import build_parser
+from paper_data_suite.workspace_backup import (
+    BACKUP_HASH_ALGORITHM,
+    BACKUP_MANIFEST_RECORD_TYPE,
+    BACKUP_MANIFEST_SCHEMA_VERSION,
+    BACKUP_PAYLOAD_ROOT,
+    WorkspaceBackupManifest,
+)
+from paper_data_suite.workspace_backup_verification import (
+    WorkspaceBackupVerificationResult,
+)
+from paper_data_suite.workspace_restore import (
+    WorkspaceRestoreDestinationError,
+    WorkspaceRestorePlan,
+    WorkspaceRestoreResult,
+)
+
+FIXED_TIME = datetime(2026, 8, 20, 17, 48, 12, 123456, tzinfo=timezone.utc)
+BACKUP_ID = "pds-workspace-backup-20260820T174812123456Z"
+
+
+def _manifest() -> WorkspaceBackupManifest:
+    return WorkspaceBackupManifest(
+        record_type=BACKUP_MANIFEST_RECORD_TYPE,
+        schema_version=BACKUP_MANIFEST_SCHEMA_VERSION,
+        backup_id=BACKUP_ID,
+        created_at=FIXED_TIME,
+        suite_version="0.1.0",
+        core_version="0.6.0",
+        payload_root=BACKUP_PAYLOAD_ROOT,
+        hash_algorithm=BACKUP_HASH_ALGORITHM,
+        directory_count=0,
+        file_count=0,
+        total_bytes=0,
+        directories=(),
+        files=(),
+        exclusions=(),
+    )
+
+
+def _plan(tmp_path: Path) -> WorkspaceRestorePlan:
+    backup = tmp_path / BACKUP_ID
+    verification = WorkspaceBackupVerificationResult(
+        backup_root=backup,
+        manifest=_manifest(),
+        manifest_sha256="a" * 64,
+    )
+    return WorkspaceRestorePlan(
+        verification=verification,
+        workspace_root=tmp_path / "active",
+        workspace_source="saved_config",
+        destination_root=tmp_path / "restored",
+        destination_parent=tmp_path,
+        destination_anchor=tmp_path,
+        destination_free_bytes=10**9,
+        required_free_bytes=64 * 1024 * 1024,
+        destination_parent_exists=True,
+    )
+
+
+def test_restore_parser_requires_explicit_backup_and_destination() -> None:
+    parser = build_parser()
+    arguments = parser.parse_args(
+        [
+            "backup",
+            "restore",
+            "backup-root",
+            "--destination",
+            "restored-root",
+            "--yes",
+        ]
+    )
+
+    assert arguments.command == "backup"
+    assert arguments.backup_command == "restore"
+    assert arguments.backup == Path("backup-root")
+    assert arguments.destination == Path("restored-root")
+    assert arguments.yes is True
+
+
+def test_restore_cancel_is_noop(tmp_path: Path, monkeypatch, capsys) -> None:
+    plan = _plan(tmp_path)
+    calls = 0
+
+    monkeypatch.setattr(
+        backup_cli_module,
+        "plan_workspace_restore",
+        lambda _backup, _destination: plan,
+    )
+
+    def should_not_restore(_plan: WorkspaceRestorePlan) -> WorkspaceRestoreResult:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("restore must not execute after cancellation")
+
+    monkeypatch.setattr(
+        backup_cli_module,
+        "restore_workspace_backup",
+        should_not_restore,
+    )
+
+    result = backup_cli_module.run_workspace_backup_restore(
+        Path("backup"),
+        Path("destination"),
+        input_fn=lambda _prompt: "Q",
+    )
+
+    assert result == 0
+    assert calls == 0
+    output = capsys.readouterr()
+    assert "No restore destination has been created yet." in output.out
+    assert "Workspace restore cancelled." in output.out
+
+
+@pytest.mark.parametrize("exception_type", (EOFError, KeyboardInterrupt))
+def test_restore_eof_or_interrupt_cancels(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+    exception_type,
+) -> None:
+    plan = _plan(tmp_path)
+    monkeypatch.setattr(
+        backup_cli_module,
+        "plan_workspace_restore",
+        lambda _backup, _destination: plan,
+    )
+
+    def interrupted(_prompt: str) -> str:
+        raise exception_type()
+
+    result = backup_cli_module.run_workspace_backup_restore(
+        Path("backup"),
+        Path("destination"),
+        input_fn=interrupted,
+    )
+
+    assert result == 0
+    assert "Workspace restore cancelled." in capsys.readouterr().out
+
+
+def test_restore_requires_exact_uppercase_confirmation(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    plan = _plan(tmp_path)
+    monkeypatch.setattr(
+        backup_cli_module,
+        "plan_workspace_restore",
+        lambda _backup, _destination: plan,
+    )
+    monkeypatch.setattr(
+        backup_cli_module,
+        "restore_workspace_backup",
+        lambda reviewed: WorkspaceRestoreResult(
+            destination_root=reviewed.destination_root,
+            manifest=reviewed.verification.manifest,
+            manifest_sha256=reviewed.manifest_sha256,
+        ),
+    )
+    responses = iter(("restore", "RESTORE"))
+
+    result = backup_cli_module.run_workspace_backup_restore(
+        Path("backup"),
+        Path("destination"),
+        input_fn=lambda _prompt: next(responses),
+    )
+
+    assert result == 0
+    output = capsys.readouterr().out
+    assert "Enter exact uppercase RESTORE" in output
+    assert "Workspace restore complete" in output
+
+
+def test_restore_yes_bypasses_prompt_only_and_reports_selection_boundary(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    plan = _plan(tmp_path)
+    restored = WorkspaceRestoreResult(
+        destination_root=plan.destination_root,
+        manifest=plan.verification.manifest,
+        manifest_sha256=plan.manifest_sha256,
+    )
+    monkeypatch.setattr(
+        backup_cli_module,
+        "plan_workspace_restore",
+        lambda _backup, _destination: plan,
+    )
+    monkeypatch.setattr(
+        backup_cli_module,
+        "restore_workspace_backup",
+        lambda reviewed: restored if reviewed is plan else None,
+    )
+
+    def prompt_must_not_run(_prompt: str) -> str:
+        raise AssertionError("--yes must bypass only the interactive prompt")
+
+    result = backup_cli_module.run_workspace_backup_restore(
+        Path("backup"),
+        Path("destination"),
+        assume_yes=True,
+        input_fn=prompt_must_not_run,
+    )
+
+    assert result == 0
+    output = capsys.readouterr().out
+    assert "The currently resolved workspace was not changed." in output
+    assert "The restored workspace was not selected automatically." in output
+    assert "pds workspace show" in output
+    assert "pds workspace set" in output
+
+
+def test_restore_plan_failure_is_bounded(monkeypatch, capsys) -> None:
+    def refuse(_backup: Path, _destination: Path) -> WorkspaceRestorePlan:
+        raise WorkspaceRestoreDestinationError("destination already exists")
+
+    monkeypatch.setattr(backup_cli_module, "plan_workspace_restore", refuse)
+
+    result = backup_cli_module.run_workspace_backup_restore(
+        Path("backup"),
+        Path("destination"),
+        assume_yes=True,
+    )
+
+    assert result == 1
+    error = capsys.readouterr().err
+    assert "Restore refused:" in error
+    assert "destination already exists" in error
+
+
+def test_restore_execution_failure_is_bounded(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    plan = _plan(tmp_path)
+    monkeypatch.setattr(
+        backup_cli_module,
+        "plan_workspace_restore",
+        lambda _backup, _destination: plan,
+    )
+
+    def fail(_plan: WorkspaceRestorePlan) -> WorkspaceRestoreResult:
+        raise WorkspaceRestoreDestinationError("changed after confirmation")
+
+    monkeypatch.setattr(backup_cli_module, "restore_workspace_backup", fail)
+
+    result = backup_cli_module.run_workspace_backup_restore(
+        Path("backup"),
+        Path("destination"),
+        assume_yes=True,
+    )
+
+    assert result == 1
+    error = capsys.readouterr().err
+    assert "Restore failed:" in error
+    assert "changed after confirmation" in error
+
+
+def test_main_dispatches_restore(monkeypatch) -> None:
+    seen: list[tuple[Path, Path, bool]] = []
+
+    def run(backup: Path, destination: Path, *, assume_yes: bool = False) -> int:
+        seen.append((backup, destination, assume_yes))
+        return 17
+
+    monkeypatch.setattr(cli_module, "run_workspace_backup_restore", run)
+
+    result = cli_module.main(
+        [
+            "backup",
+            "restore",
+            "backup-root",
+            "--destination",
+            "restored-root",
+            "--yes",
+        ]
+    )
+
+    assert result == 17
+    assert seen == [(Path("backup-root"), Path("restored-root"), True)]

--- a/tests/test_workspace_restore_contract.py
+++ b/tests/test_workspace_restore_contract.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from paper_data_suite.workspace_backup import (
+    BACKUP_HASH_ALGORITHM,
+    BACKUP_MANIFEST_RECORD_TYPE,
+    BACKUP_MANIFEST_SCHEMA_VERSION,
+    BACKUP_PAYLOAD_ROOT,
+    BackupFileEntry,
+    WorkspaceBackupManifest,
+)
+from paper_data_suite.workspace_backup_cli import (
+    render_workspace_backup_verification_result,
+    render_workspace_restore_plan,
+    render_workspace_restore_result,
+)
+from paper_data_suite.workspace_backup_verification import (
+    WorkspaceBackupVerificationResult,
+)
+from paper_data_suite.workspace_restore import (
+    WorkspaceRestorePlan,
+    WorkspaceRestoreResult,
+)
+
+FIXED = datetime(2026, 8, 20, 17, 48, 12, 123456, tzinfo=timezone.utc)
+BACKUP_ID = "pds-workspace-backup-20260820T174812123456Z"
+
+
+def _manifest() -> WorkspaceBackupManifest:
+    name = "classes/student-private.csv"
+    payload = b"synthetic-only"
+    return WorkspaceBackupManifest(
+        record_type=BACKUP_MANIFEST_RECORD_TYPE,
+        schema_version=BACKUP_MANIFEST_SCHEMA_VERSION,
+        backup_id=BACKUP_ID,
+        created_at=FIXED,
+        suite_version="0.1.0.dev0",
+        core_version="0.6.0",
+        payload_root=BACKUP_PAYLOAD_ROOT,
+        hash_algorithm=BACKUP_HASH_ALGORITHM,
+        directory_count=1,
+        file_count=1,
+        total_bytes=len(payload),
+        directories=("classes",),
+        files=(
+            BackupFileEntry(
+                path=name,
+                size=len(payload),
+                sha256=hashlib.sha256(payload).hexdigest(),
+            ),
+        ),
+        exclusions=(),
+    )
+
+
+def test_verification_and_restore_normal_output_does_not_dump_payload_paths(
+    tmp_path: Path,
+) -> None:
+    manifest = _manifest()
+    backup = tmp_path / BACKUP_ID
+    verification = WorkspaceBackupVerificationResult(
+        backup_root=backup,
+        manifest=manifest,
+        manifest_sha256="a" * 64,
+    )
+    plan = WorkspaceRestorePlan(
+        verification=verification,
+        workspace_root=tmp_path / "active",
+        workspace_source="saved_config",
+        destination_root=tmp_path / "restored",
+        destination_parent=tmp_path,
+        destination_anchor=tmp_path,
+        destination_free_bytes=10**9,
+        required_free_bytes=64 * 1024 * 1024,
+        destination_parent_exists=True,
+    )
+    result = WorkspaceRestoreResult(
+        destination_root=plan.destination_root,
+        manifest=manifest,
+        manifest_sha256=verification.manifest_sha256,
+    )
+
+    output = (
+        render_workspace_backup_verification_result(verification)
+        + render_workspace_restore_plan(plan)
+        + render_workspace_restore_result(plan, result)
+    )
+
+    assert "student-private.csv" not in output
+    assert "synthetic-only" not in output
+    assert manifest.files[0].sha256 not in output
+    assert "Manifest SHA-256" in output
+
+
+def test_importing_verification_and_restore_creates_no_workspace_state(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "must-not-be-created"
+    user_home = tmp_path / "user"
+    user_home.mkdir()
+    env = dict(os.environ)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PDS_WORKSPACE_ROOT"] = str(workspace)
+    env["HOME"] = str(user_home)
+    env["USERPROFILE"] = str(user_home)
+    code = """
+import sys
+import paper_data_suite.workspace_backup_verification
+import paper_data_suite.workspace_restore
+
+for name in (
+    "pds_concord",
+    "quillan",
+    "scoreform",
+    "pds_vitrine",
+    "pds_meridian",
+    "pds_portia",
+):
+    if name in sys.modules:
+        raise SystemExit("unexpected sibling module import: " + name)
+""".strip()
+
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert not workspace.exists()
+
+
+def test_ci_runs_installed_restore_smoke_on_supported_platforms() -> None:
+    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert "Installed workspace restore acceptance" in workflow
+    assert "matrix.python == '3.11'" in workflow
+    assert "scripts/smoke_test_workspace_restore_wheel.py" in workflow

--- a/tests/test_workspace_restore_execution.py
+++ b/tests/test_workspace_restore_execution.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import paper_data_suite.workspace_restore as workspace_restore_module
+from paper_data_suite.workspace_backup import (
+    BACKUP_HASH_ALGORITHM,
+    BACKUP_MANIFEST_RECORD_TYPE,
+    BACKUP_MANIFEST_SCHEMA_VERSION,
+    BACKUP_PAYLOAD_ROOT,
+    BackupFileEntry,
+    WorkspaceBackupManifest,
+    backup_name,
+    serialize_workspace_backup_manifest,
+)
+from paper_data_suite.workspace_restore import (
+    WorkspaceRestoreCollisionError,
+    WorkspaceRestoreCopyError,
+    WorkspaceRestoreDriftError,
+    WorkspaceRestoreSpaceError,
+    WorkspaceRestoreVerificationError,
+    plan_workspace_restore,
+    restore_workspace_backup,
+)
+from paper_data_suite.workspace_setup import CoreWorkspaceServices
+
+FIXED = datetime(2026, 8, 20, 17, 48, 12, 123456, tzinfo=timezone.utc)
+
+
+def _backup(tmp_path: Path) -> Path:
+    root = tmp_path / backup_name(FIXED)
+    payload = root / "workspace"
+    (payload / "empty").mkdir(parents=True)
+    (payload / "nested").mkdir()
+    (payload / "nested" / "alpha.bin").write_bytes(b"alpha")
+    (payload / "zero").write_bytes(b"")
+    files = (
+        BackupFileEntry(
+            path="nested/alpha.bin",
+            size=5,
+            sha256=hashlib.sha256(b"alpha").hexdigest(),
+        ),
+        BackupFileEntry(
+            path="zero",
+            size=0,
+            sha256=hashlib.sha256(b"").hexdigest(),
+        ),
+    )
+    manifest = WorkspaceBackupManifest(
+        record_type=BACKUP_MANIFEST_RECORD_TYPE,
+        schema_version=BACKUP_MANIFEST_SCHEMA_VERSION,
+        backup_id=root.name,
+        created_at=FIXED,
+        suite_version="0.1.0",
+        core_version="0.6.0",
+        payload_root=BACKUP_PAYLOAD_ROOT,
+        hash_algorithm=BACKUP_HASH_ALGORITHM,
+        directory_count=2,
+        file_count=2,
+        total_bytes=5,
+        directories=("empty", "nested"),
+        files=files,
+        exclusions=(),
+    )
+    root.mkdir(exist_ok=True)
+    (root / "manifest.json").write_bytes(serialize_workspace_backup_manifest(manifest))
+    return root
+
+
+def _services(workspace: Path, source: str = "saved_config") -> CoreWorkspaceServices:
+    def inspect(explicit_root=None):
+        assert explicit_root is None
+        return SimpleNamespace(root=workspace, source=source)
+
+    def ensure_workspace_root(path, create=True):
+        raise AssertionError("restore must not initialize a workspace")
+
+    def save_workspace_root(path):
+        raise AssertionError("restore must not save workspace selection")
+
+    def clear_saved_workspace_root():
+        raise AssertionError("restore must not clear workspace selection")
+
+    return CoreWorkspaceServices(
+        inspect_workspace_root=inspect,
+        ensure_workspace_root=ensure_workspace_root,
+        save_workspace_root=save_workspace_root,
+        clear_saved_workspace_root=clear_saved_workspace_root,
+    )
+
+
+def _free(value: int):
+    return lambda _path: SimpleNamespace(free=value)
+
+
+def _plan(tmp_path: Path):
+    backup = _backup(tmp_path)
+    workspace = tmp_path / "active"
+    workspace.mkdir()
+    destination = tmp_path / "recovery" / "restored"
+    plan = plan_workspace_restore(
+        backup,
+        destination,
+        services=_services(workspace),
+        disk_usage_reader=_free(10**9),
+    )
+    return backup, workspace, destination, plan
+
+
+def test_restore_publishes_only_verified_payload(tmp_path: Path) -> None:
+    backup, workspace, destination, plan = _plan(tmp_path)
+    backup_before = {
+        p.relative_to(backup).as_posix(): p.read_bytes()
+        for p in backup.rglob("*")
+        if p.is_file()
+    }
+
+    result = restore_workspace_backup(
+        plan,
+        services=_services(workspace),
+        disk_usage_reader=_free(10**9),
+        staging_nonce_factory=lambda: "fixed",
+    )
+
+    assert result.destination_root == destination.resolve()
+    assert (destination / "nested" / "alpha.bin").read_bytes() == b"alpha"
+    assert (destination / "zero").read_bytes() == b""
+    assert (destination / "empty").is_dir()
+    assert not (destination / "manifest.json").exists()
+    assert workspace.exists()
+    assert backup_before == {
+        p.relative_to(backup).as_posix(): p.read_bytes()
+        for p in backup.rglob("*")
+        if p.is_file()
+    }
+
+
+def test_restore_reverifies_backup_before_destination_mutation(tmp_path: Path) -> None:
+    backup, workspace, destination, plan = _plan(tmp_path)
+    (backup / "workspace" / "nested" / "alpha.bin").write_bytes(b"omega")
+
+    with pytest.raises(WorkspaceRestoreDriftError, match="no longer verifies"):
+        restore_workspace_backup(
+            plan,
+            services=_services(workspace),
+            disk_usage_reader=_free(10**9),
+        )
+
+    assert not destination.parent.exists()
+
+
+def test_restore_rechecks_core_resolution_before_mutation(tmp_path: Path) -> None:
+    _backup, _workspace, destination, plan = _plan(tmp_path)
+    changed = tmp_path / "other-active"
+
+    with pytest.raises(WorkspaceRestoreDriftError, match="resolved workspace changed"):
+        restore_workspace_backup(
+            plan,
+            services=_services(changed),
+            disk_usage_reader=_free(10**9),
+        )
+
+    assert not destination.parent.exists()
+
+
+def test_restore_rechecks_free_space_before_staging(tmp_path: Path) -> None:
+    _backup, workspace, destination, plan = _plan(tmp_path)
+    destination.parent.mkdir(parents=True)
+
+    with pytest.raises(WorkspaceRestoreSpaceError, match="Insufficient"):
+        restore_workspace_backup(
+            plan,
+            services=_services(workspace),
+            disk_usage_reader=_free(plan.required_free_bytes - 1),
+        )
+
+    assert not destination.exists()
+    assert tuple(destination.parent.iterdir()) == ()
+
+
+def test_restore_rechecks_free_space_before_creating_missing_parent(
+    tmp_path: Path,
+) -> None:
+    _backup, workspace, destination, plan = _plan(tmp_path)
+    assert not destination.parent.exists()
+
+    with pytest.raises(WorkspaceRestoreSpaceError, match="Insufficient"):
+        restore_workspace_backup(
+            plan,
+            services=_services(workspace),
+            disk_usage_reader=_free(plan.required_free_bytes - 1),
+        )
+
+    assert not destination.parent.exists()
+    assert not destination.exists()
+
+
+def test_restore_preserves_preexisting_staging_collision(tmp_path: Path) -> None:
+    _backup, workspace, destination, plan = _plan(tmp_path)
+    destination.parent.mkdir(parents=True)
+    staging = destination.parent / ".restored.pds-restore.incomplete-fixed"
+    staging.mkdir()
+    sentinel = staging / "sentinel"
+    sentinel.write_text("keep", encoding="utf-8")
+
+    with pytest.raises(WorkspaceRestoreCollisionError, match="staging path"):
+        restore_workspace_backup(
+            plan,
+            services=_services(workspace),
+            disk_usage_reader=_free(10**9),
+            staging_nonce_factory=lambda: "fixed",
+        )
+
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+    assert not destination.exists()
+
+
+def test_restore_detects_backup_drift_after_copy_and_cleans(tmp_path: Path) -> None:
+    backup, workspace, destination, plan = _plan(tmp_path)
+
+    def mutate(payload: Path, _staging: Path) -> None:
+        (payload / "nested" / "alpha.bin").write_bytes(b"omega")
+
+    with pytest.raises(WorkspaceRestoreDriftError, match="changed while"):
+        restore_workspace_backup(
+            plan,
+            services=_services(workspace),
+            disk_usage_reader=_free(10**9),
+            staging_nonce_factory=lambda: "fixed",
+            after_copy_hook=mutate,
+        )
+
+    assert not destination.exists()
+    assert not (
+        destination.parent / ".restored.pds-restore.incomplete-fixed"
+    ).exists()
+    assert (backup / "workspace" / "nested" / "alpha.bin").read_bytes() == b"omega"
+
+
+def test_restore_detects_staged_corruption_and_cleans(tmp_path: Path) -> None:
+    _backup, workspace, destination, plan = _plan(tmp_path)
+
+    def corrupt(_payload: Path, staging: Path) -> None:
+        (staging / "nested" / "alpha.bin").write_bytes(b"omega")
+
+    with pytest.raises(WorkspaceRestoreVerificationError, match="SHA-256"):
+        restore_workspace_backup(
+            plan,
+            services=_services(workspace),
+            disk_usage_reader=_free(10**9),
+            staging_nonce_factory=lambda: "fixed",
+            after_copy_hook=corrupt,
+        )
+
+    assert not destination.exists()
+    assert not (
+        destination.parent / ".restored.pds-restore.incomplete-fixed"
+    ).exists()
+
+
+def test_restore_copy_failure_cleans_owned_staging(tmp_path: Path) -> None:
+    _backup, workspace, destination, plan = _plan(tmp_path)
+
+    def fail(_payload: Path, _staging: Path, expected: BackupFileEntry, _size: int):
+        raise WorkspaceRestoreCopyError(f"synthetic failure: {expected.path}")
+
+    with pytest.raises(WorkspaceRestoreCopyError, match="synthetic"):
+        restore_workspace_backup(
+            plan,
+            services=_services(workspace),
+            disk_usage_reader=_free(10**9),
+            staging_nonce_factory=lambda: "fixed",
+            file_copier=fail,
+        )
+
+    assert not destination.exists()
+    assert not (
+        destination.parent / ".restored.pds-restore.incomplete-fixed"
+    ).exists()
+
+
+def test_restore_publication_collision_preserves_existing_destination(
+    tmp_path: Path,
+) -> None:
+    _backup, workspace, destination, plan = _plan(tmp_path)
+
+    def collide(_staging: Path, final: Path) -> None:
+        final.mkdir()
+        (final / "sentinel").write_text("keep", encoding="utf-8")
+
+    with pytest.raises(WorkspaceRestoreCollisionError, match="already exists"):
+        restore_workspace_backup(
+            plan,
+            services=_services(workspace),
+            disk_usage_reader=_free(10**9),
+            staging_nonce_factory=lambda: "fixed",
+            before_publish_hook=collide,
+        )
+
+    assert (destination / "sentinel").read_text(encoding="utf-8") == "keep"
+    assert not (
+        destination.parent / ".restored.pds-restore.incomplete-fixed"
+    ).exists()
+
+def test_publication_race_does_not_replace_existing_empty_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    staging = tmp_path / ".restore.incomplete-fixed"
+    final = tmp_path / "restored"
+    staging.mkdir()
+    sentinel = staging / "sentinel"
+    sentinel.write_text("staged", encoding="utf-8")
+    final.mkdir()
+
+    monkeypatch.setattr(
+        workspace_restore_module,
+        "_path_entry_exists",
+        lambda _path: False,
+    )
+
+    with pytest.raises(WorkspaceRestoreCollisionError, match="already exists"):
+        workspace_restore_module._publish_staging(staging, final)
+
+    assert final.is_dir()
+    assert tuple(final.iterdir()) == ()
+    assert sentinel.read_text(encoding="utf-8") == "staged"
+
+
+def test_restore_cleanup_failure_reports_remaining_staging(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _backup, workspace, destination, plan = _plan(tmp_path)
+    remaining = (
+        destination.parent
+        / ".restored.pds-restore.incomplete-fixed"
+    )
+
+    def fail_copy(
+        _payload: Path,
+        _staging: Path,
+        expected: BackupFileEntry,
+        _size: int,
+    ) -> BackupFileEntry:
+        raise WorkspaceRestoreCopyError(f"synthetic failure: {expected.path}")
+
+    monkeypatch.setattr(
+        "paper_data_suite.workspace_restore._cleanup_staging",
+        lambda _path: str(remaining),
+    )
+
+    with pytest.raises(
+        WorkspaceRestoreCopyError,
+        match="Incomplete restore staging remains",
+    ):
+        restore_workspace_backup(
+            plan,
+            services=_services(workspace),
+            disk_usage_reader=_free(10**9),
+            staging_nonce_factory=lambda: "fixed",
+            file_copier=fail_copy,
+        )
+

--- a/tests/test_workspace_restore_planning.py
+++ b/tests/test_workspace_restore_planning.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from paper_data_suite.workspace_backup import (
+    BACKUP_HASH_ALGORITHM,
+    BACKUP_MANIFEST_RECORD_TYPE,
+    BACKUP_MANIFEST_SCHEMA_VERSION,
+    BACKUP_PAYLOAD_ROOT,
+    BackupFileEntry,
+    WorkspaceBackupManifest,
+    WorkspaceBackupVerificationError,
+    backup_name,
+    required_backup_free_bytes,
+    serialize_workspace_backup_manifest,
+)
+from paper_data_suite.workspace_backup_verification import (
+    WorkspaceBackupVerificationResult,
+    verify_workspace_backup,
+)
+from paper_data_suite.workspace_restore import (
+    WorkspaceRestoreDestinationError,
+    WorkspaceRestoreSpaceError,
+    plan_workspace_restore,
+)
+from paper_data_suite.workspace_setup import (
+    CoreWorkspaceServices,
+    WorkspaceEnsurer,
+    WorkspaceInspector,
+    WorkspaceResetter,
+    WorkspaceSaver,
+)
+
+FIXED_TIME = datetime(2026, 8, 20, 17, 48, 12, 123456, tzinfo=timezone.utc)
+BACKUP_ID = backup_name(FIXED_TIME)
+
+
+@dataclass
+class FakeStatus:
+    root: Path
+    source: str
+    exists: bool
+    is_dir: bool
+    is_writable: bool
+    config_path: Path
+    default_root: Path
+
+
+class FakeCore:
+    def __init__(self, root: Path, *, exists: bool = True) -> None:
+        self.root = root
+        self.exists = exists
+        self.inspect_calls = 0
+        self.mutation_calls = 0
+
+    def inspect(self, explicit_root: str | Path | None = None) -> FakeStatus:
+        assert explicit_root is None
+        self.inspect_calls += 1
+        return FakeStatus(
+            root=self.root,
+            source="saved_config",
+            exists=self.exists,
+            is_dir=self.root.is_dir() if self.exists else False,
+            is_writable=False,
+            config_path=self.root.parent / "config.json",
+            default_root=self.root.parent / "default",
+        )
+
+    def mutate(self, *_args: object, **_kwargs: object) -> object:
+        self.mutation_calls += 1
+        raise AssertionError("restore planning must not call Core mutation services")
+
+    def services(self) -> CoreWorkspaceServices:
+        return CoreWorkspaceServices(
+            inspect_workspace_root=cast(WorkspaceInspector, self.inspect),
+            ensure_workspace_root=cast(WorkspaceEnsurer, self.mutate),
+            save_workspace_root=cast(WorkspaceSaver, self.mutate),
+            clear_saved_workspace_root=cast(WorkspaceResetter, self.mutate),
+        )
+
+
+def free_space(value: int):  # type: ignore[no-untyped-def]
+    return lambda _path: SimpleNamespace(total=value * 2, used=value, free=value)
+
+
+def make_backup(tmp_path: Path) -> Path:
+    root = tmp_path / BACKUP_ID
+    payload = root / "workspace"
+    (payload / "empty").mkdir(parents=True)
+    (payload / "alpha.bin").write_bytes(b"alpha")
+    digest = hashlib.sha256(b"alpha").hexdigest()
+    manifest = WorkspaceBackupManifest(
+        record_type=BACKUP_MANIFEST_RECORD_TYPE,
+        schema_version=BACKUP_MANIFEST_SCHEMA_VERSION,
+        backup_id=BACKUP_ID,
+        created_at=FIXED_TIME,
+        suite_version="0.1.0",
+        core_version="0.6.0",
+        payload_root=BACKUP_PAYLOAD_ROOT,
+        hash_algorithm=BACKUP_HASH_ALGORITHM,
+        directory_count=1,
+        file_count=1,
+        total_bytes=5,
+        directories=("empty",),
+        files=(BackupFileEntry(path="alpha.bin", size=5, sha256=digest),),
+        exclusions=(),
+    )
+    (root / "manifest.json").write_bytes(serialize_workspace_backup_manifest(manifest))
+    return root
+
+
+def test_restore_plan_fully_verifies_before_core_and_is_read_only(
+    tmp_path: Path,
+) -> None:
+    backup = make_backup(tmp_path / "backups")
+    workspace = tmp_path / "active"
+    workspace.mkdir()
+    destination = tmp_path / "recovery" / "restored"
+    core = FakeCore(workspace)
+    required = required_backup_free_bytes(5)
+    events: list[str] = []
+
+    def verifier(path: str | Path) -> WorkspaceBackupVerificationResult:
+        events.append("verify")
+        return verify_workspace_backup(path)
+
+    def loader() -> CoreWorkspaceServices:
+        events.append("core")
+        return core.services()
+
+    plan = plan_workspace_restore(
+        backup,
+        destination,
+        services_loader=loader,
+        verifier=verifier,
+        disk_usage_reader=free_space(required),
+    )
+
+    assert events == ["verify", "core"]
+    assert core.inspect_calls == 1
+    assert core.mutation_calls == 0
+    assert plan.backup_root == backup.resolve()
+    assert plan.workspace_root == workspace.resolve()
+    assert plan.workspace_source == "saved_config"
+    assert plan.destination_root == destination.resolve()
+    assert plan.destination_parent == destination.parent.resolve()
+    assert plan.destination_anchor == tmp_path.resolve()
+    assert plan.destination_parent_exists is False
+    assert plan.destination_free_bytes == required
+    assert plan.required_free_bytes == required
+    assert not destination.exists()
+    assert (backup / "workspace" / "alpha.bin").read_bytes() == b"alpha"
+
+
+def test_restore_plan_uses_provided_services_without_loader(tmp_path: Path) -> None:
+    backup = make_backup(tmp_path / "backups")
+    workspace = tmp_path / "active"
+    workspace.mkdir()
+    core = FakeCore(workspace)
+
+    def forbidden_loader() -> CoreWorkspaceServices:
+        raise AssertionError("provided services should be used")
+
+    plan = plan_workspace_restore(
+        backup,
+        tmp_path / "restored",
+        services=core.services(),
+        services_loader=forbidden_loader,
+        disk_usage_reader=free_space(10**9),
+    )
+
+    assert plan.workspace_root == workspace.resolve()
+    assert core.mutation_calls == 0
+
+
+@pytest.mark.parametrize("kind", ("empty-dir", "full-dir", "file"))
+def test_restore_plan_refuses_any_existing_destination(
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    backup = make_backup(tmp_path / "backups")
+    workspace = tmp_path / "active"
+    workspace.mkdir()
+    destination = tmp_path / "restored"
+    if kind == "empty-dir":
+        destination.mkdir()
+    elif kind == "full-dir":
+        destination.mkdir()
+        (destination / "sentinel").write_text("keep", encoding="utf-8")
+    else:
+        destination.write_text("keep", encoding="utf-8")
+
+    with pytest.raises(WorkspaceRestoreDestinationError, match="already exists"):
+        plan_workspace_restore(
+            backup,
+            destination,
+            services=FakeCore(workspace).services(),
+            disk_usage_reader=free_space(10**9),
+        )
+
+
+@pytest.mark.parametrize(
+    "destination_factory",
+    (
+        lambda backup, _workspace: backup / "new-workspace",
+        lambda backup, _workspace: backup / "workspace" / "nested",
+        lambda backup, _workspace: _workspace / "alternate",
+    ),
+)
+def test_restore_plan_refuses_destination_inside_protected_tree(
+    tmp_path: Path,
+    destination_factory,  # type: ignore[no-untyped-def]
+) -> None:
+    backup = make_backup(tmp_path / "backups")
+    workspace = tmp_path / "active"
+    workspace.mkdir()
+    destination = destination_factory(backup, workspace)
+
+    with pytest.raises(WorkspaceRestoreDestinationError, match="overlap"):
+        plan_workspace_restore(
+            backup,
+            destination,
+            services=FakeCore(workspace).services(),
+            disk_usage_reader=free_space(10**9),
+        )
+
+
+def test_restore_plan_refuses_resolved_workspace_even_when_missing(
+    tmp_path: Path,
+) -> None:
+    backup = make_backup(tmp_path / "backups")
+    missing_workspace = tmp_path / "missing-active"
+
+    with pytest.raises(WorkspaceRestoreDestinationError, match="resolved workspace"):
+        plan_workspace_restore(
+            backup,
+            missing_workspace,
+            services=FakeCore(missing_workspace, exists=False).services(),
+            disk_usage_reader=free_space(10**9),
+        )
+
+
+def test_restore_plan_refuses_destination_containing_missing_workspace(
+    tmp_path: Path,
+) -> None:
+    backup = make_backup(tmp_path / "backups")
+    destination = tmp_path / "recovery"
+    missing_workspace = destination / "future-active"
+
+    with pytest.raises(WorkspaceRestoreDestinationError, match="resolved workspace"):
+        plan_workspace_restore(
+            backup,
+            destination,
+            services=FakeCore(missing_workspace, exists=False).services(),
+            disk_usage_reader=free_space(10**9),
+        )
+
+
+def test_restore_plan_resolves_destination_alias_before_containment(
+    tmp_path: Path,
+) -> None:
+    backup = make_backup(tmp_path / "backups")
+    workspace = tmp_path / "active"
+    workspace.mkdir()
+    alias = tmp_path / "active-alias"
+    try:
+        alias.symlink_to(workspace, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlink creation unavailable")
+
+    with pytest.raises(WorkspaceRestoreDestinationError, match="resolved workspace"):
+        plan_workspace_restore(
+            backup,
+            alias / "restored",
+            services=FakeCore(workspace).services(),
+            disk_usage_reader=free_space(10**9),
+        )
+
+
+def test_restore_plan_refuses_below_free_space_threshold_and_accepts_exact(
+    tmp_path: Path,
+) -> None:
+    backup = make_backup(tmp_path / "backups")
+    workspace = tmp_path / "active"
+    workspace.mkdir()
+    required = required_backup_free_bytes(5)
+
+    with pytest.raises(WorkspaceRestoreSpaceError, match="Insufficient"):
+        plan_workspace_restore(
+            backup,
+            tmp_path / "restore-low",
+            services=FakeCore(workspace).services(),
+            disk_usage_reader=free_space(required - 1),
+        )
+
+    plan = plan_workspace_restore(
+        backup,
+        tmp_path / "restore-exact",
+        services=FakeCore(workspace).services(),
+        disk_usage_reader=free_space(required),
+    )
+    assert plan.required_free_bytes == required
+    assert plan.destination_free_bytes == required
+
+
+def test_restore_plan_reports_free_space_provider_failure(tmp_path: Path) -> None:
+    backup = make_backup(tmp_path / "backups")
+    workspace = tmp_path / "active"
+    workspace.mkdir()
+
+    def fail(_path: str | Path):  # type: ignore[no-untyped-def]
+        raise OSError("synthetic free-space failure")
+
+    with pytest.raises(WorkspaceRestoreDestinationError, match="free space"):
+        plan_workspace_restore(
+            backup,
+            tmp_path / "restored",
+            services=FakeCore(workspace).services(),
+            disk_usage_reader=fail,
+        )
+
+
+def test_restore_plan_verification_failure_happens_before_core(tmp_path: Path) -> None:
+    bad_backup = tmp_path / "missing-backup"
+    core_loaded = False
+
+    def loader() -> CoreWorkspaceServices:
+        nonlocal core_loaded
+        core_loaded = True
+        raise AssertionError("Core must not load before backup verification")
+
+    with pytest.raises(WorkspaceBackupVerificationError, match="Backup"):
+        plan_workspace_restore(
+            bad_backup,
+            tmp_path / "restored",
+            services_loader=loader,
+            disk_usage_reader=free_space(10**9),
+        )
+
+    assert core_loaded is False
+
+def test_restore_plan_refuses_existing_destination_after_environment_expansion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backup = make_backup(tmp_path / "backups")
+    workspace = tmp_path / "active"
+    workspace.mkdir()
+    destination = tmp_path / "existing-restore"
+    destination.mkdir()
+    monkeypatch.setenv("PDS_RESTORE_TEST_ROOT", str(tmp_path))
+
+    with pytest.raises(WorkspaceRestoreDestinationError, match="already exists"):
+        plan_workspace_restore(
+            backup,
+            Path("$PDS_RESTORE_TEST_ROOT") / "existing-restore",
+            services=FakeCore(workspace).services(),
+            disk_usage_reader=free_space(10**9),
+        )
+
+
+def test_restore_plan_refuses_dangling_destination_symlink(tmp_path: Path) -> None:
+    backup = make_backup(tmp_path / "backups")
+    workspace = tmp_path / "active"
+    workspace.mkdir()
+    destination = tmp_path / "dangling-restore"
+    target = tmp_path / "not-created-target"
+    try:
+        destination.symlink_to(target, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlink creation unavailable")
+
+    with pytest.raises(WorkspaceRestoreDestinationError, match="already exists"):
+        plan_workspace_restore(
+            backup,
+            destination,
+            services=FakeCore(workspace).services(),
+            disk_usage_reader=free_space(10**9),
+        )
+


### PR DESCRIPTION
## Summary

Closes #11.

Adds independent verification and safe restore-to-alternate-location for Paper Data Suite whole-workspace backups created by `pds backup create`.

This completes the recovery workflow established by #10:

```text
backup create
    ->
backup verify
    ->
restore to explicit alternate location
    ->
separate teacher decision
    ->
pds workspace set <restored-location>
```

The implementation preserves the suite-shell boundary that backup and restore are opaque byte-custody operations rather than semantic ownership of Core- or module-owned records.

## What this adds

### Independent backup verification

Adds:

```text
pds backup verify <backup>
python -m paper_data_suite backup verify <backup>
```

Verification:

- accepts only canonical completed backup-v1 roots;
- strictly validates `manifest.json`;
- requires backup-root identity, `backup_id`, and `created_at` to agree;
- verifies the exact directory inventory;
- verifies the exact regular-file inventory;
- preserves empty-directory integrity;
- checks every file size;
- streams every file through SHA-256 verification;
- detects same-size byte corruption;
- detects missing, extra, renamed, or type-changed entries;
- rejects incomplete `.incomplete-*` backups;
- rejects redirecting/special filesystem entries;
- verifies without resolving or mutating the active Core workspace;
- requires no sibling PDS applications;
- reports recorded suite/Core versions as provenance rather than runtime-compatibility guarantees;
- reports the persisted manifest SHA-256; and
- keeps normal output privacy-bounded rather than dumping the complete inventory or per-file hashes.

SHA-256 verification is explicitly documented as integrity evidence, not authentication or a digital signature.

### Restore to an explicit alternate location

Adds:

```text
pds backup restore <backup> --destination <path>
python -m paper_data_suite backup restore <backup> --destination <path>
```

Restore:

- fully verifies the backup before showing the restore preview;
- exactly qualifies the suite-supported Core release;
- uses public Core workspace inspection only to protect the currently resolved workspace;
- never initializes, selects, saves, clears, or otherwise changes Core workspace selection;
- requires an explicit final destination that does not already exist;
- refuses destinations that overlap the backup, backup payload, or Core-resolved workspace;
- protects the Core-resolved workspace even when that path does not yet exist;
- canonicalizes missing destinations through the nearest existing ancestor;
- uses the same conservative free-space rule established by #10;
- requires exact uppercase `RESTORE` interactively;
- supports `--yes` only as a confirmation bypass, not a safety bypass;
- repeats verification, Core inspection, containment, destination, and free-space checks after confirmation;
- creates only clearly incomplete sibling staging state;
- copies regular-file bytes in bounded chunks;
- restores empty directories;
- detects backup drift during restoration;
- independently verifies the staged restore against the manifest;
- publishes only through non-overwriting filesystem semantics;
- never merges into or overwrites an existing destination;
- never copies `manifest.json` into the restored workspace;
- cleans only staging owned by the current attempt on handled failures; and
- explicitly states after success that the restored workspace has not been selected automatically.

The restored workspace contains the contents formerly beneath:

```text
<backup-root>/workspace/
```

directly beneath the requested destination.

## Safety hardening

The final adversarial audit also tightened several edge cases:

- rejects an explicit backup-root symlink/redirect before resolving through it;
- checks restore free space before creating missing destination parent directories;
- uses fail-closed non-replacing final publication semantics rather than relying on Unix `rename()` behavior that can replace an existing empty directory;
- detects final-destination races without overwriting existing state;
- preserves unrelated pre-existing incomplete staging directories; and
- keeps import-time behavior free of workspace resolution, Core qualification, backup enumeration, or filesystem mutation.

## Documentation

Adds:

```text
docs/operations/workspace-restore.md
```

and updates:

- `README.md`;
- `docs/operations/workspace-backup.md`.

The documentation covers:

- completed-backup recognition;
- manifest/inventory/hash verification;
- integrity versus authenticity;
- explicit alternate restore destinations;
- active-workspace and backup protection;
- free-space and staging behavior;
- drift detection;
- non-overwrite publication;
- cleanup/failure semantics;
- privacy boundaries;
- version provenance versus runtime compatibility;
- no semantic migration or repair; and
- the separate later `pds workspace set <destination>` activation boundary.

## Installed-wheel acceptance

Adds:

```text
scripts/smoke_test_workspace_restore_wheel.py
```

The installed-wheel smoke uses an isolated environment/profile with synthetic data and proves:

- console and module invocation surfaces;
- no sibling PDS application dependency;
- backup verification through the installed package;
- exact restored directory/file inventory;
- byte/hash equality with the original synthetic workspace;
- empty, hidden, binary, zero-byte, Unicode, and unknown-module content;
- no restored `manifest.json`;
- unchanged Core workspace selection;
- existing-destination refusal;
- active-workspace destination refusal;
- incomplete-backup refusal;
- tamper detection;
- cancellation without restore creation; and
- source-tree/PYTHONPATH isolation.

The dedicated restore smoke is also wired into CI on supported Ubuntu and Windows validation runs.

## Validation

Final local source validation:

```text
511 passed, 10 skipped
```

Also passed:

```text
python -m ruff check .
python -m mypy
git diff --check
python -m pip check
python .\scripts\validate_compatibility_manifest.py
python -m build
python -m twine check .\dist\*
```

Fresh built-wheel acceptance passed:

```text
check_package.py
smoke_test_wheel.py
smoke_test_workspace_wheel.py
smoke_test_classroom_setup_wheel.py
smoke_test_workspace_backup_wheel.py
smoke_test_workspace_restore_wheel.py
```

## Boundaries preserved

This PR does **not** add:

- in-place restore;
- restore into an existing directory;
- merge or overwrite behavior;
- automatic workspace activation;
- automatic `pds workspace set`;
- semantic record interpretation;
- Core/module migration or repair;
- selective/module-aware restore;
- runtime-compatibility inference from backup provenance;
- encryption;
- authenticated manifests or digital signatures;
- cloud upload/download;
- scheduled backups/restores;
- retention/pruning; or
- a global cross-module snapshot lock.

Restore remains filesystem recovery of verified opaque workspace bytes, with Core remaining the sole workspace-selection authority.