### PR TITLE
feat: add suite settings and recent safe context

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ installable. The shell now provides read-only environment diagnostics through
 `pds doctor`, suite-qualified application inventory through `pds modules`,
 verified out-of-process application launching through `pds launch <component-id>`,
 Core-backed workspace selection/validation through `pds workspace`, guided shared
-classroom setup through `pds setup`, and whole-workspace backup creation,
+classroom setup through `pds setup`, whole-workspace backup creation,
 independent verification, and safe alternate-location restore through
-`pds backup create`, `pds backup verify`, and `pds backup restore`.
+`pds backup create`, `pds backup verify`, and `pds backup restore`, plus a
+privacy-minimized per-user shell settings facility through `pds settings`.
 Additional teacher-facing workflows are added by later v0.1.0 issues.
 
 The package metadata requires Python 3.11 or newer and
@@ -146,6 +147,39 @@ external prerequisite is healthy. Use `pds doctor` for broader environment healt
 The operational contract and installed-wheel acceptance requirements are
 documented in
 [`docs/operations/application-discovery-launching.md`](docs/operations/application-discovery-launching.md).
+
+## Suite settings and recent safe context
+
+Inspect suite-owned shell convenience settings with:
+
+```powershell
+pds settings show
+```
+
+Clear only recent top-level application context or reset all suite settings with:
+
+```powershell
+pds settings clear-recent
+pds settings reset
+```
+
+Schema v1 stores only the settings record/version identity and a bounded five-entry
+MRU list of exact suite-qualified top-level application IDs. It does not store an
+authoritative workspace path, class/assignment/student context, scores, reviews,
+grouping state, Grades, portfolio state, behavior/support state, credentials, or
+other module-owned data. `settings show` re-resolves stored component IDs against
+the current application inventory before presenting availability.
+
+The settings file lives in the normal per-user application configuration area,
+outside canonical Core workspaces. A missing file is normal first-run state and
+read-only import/help/show operations do not create it. Writes use complete
+validated documents and same-directory atomic replacement. `pds settings reset`
+and `pds settings clear-recent` never call Core workspace reset and never alter
+module-owned context.
+
+The storage contract, privacy and ownership boundaries, failure behavior, and
+installed-wheel acceptance are documented in
+[`docs/operations/suite-settings.md`](docs/operations/suite-settings.md).
 
 ## Workspace selection and validation
 
@@ -368,6 +402,10 @@ pds backup verify <backup>
 pds backup restore <backup> --destination <path> [--yes]
 pds modules
 pds launch <component-id>
+pds settings
+pds settings show
+pds settings clear-recent
+pds settings reset
 pds setup
 pds workspace setup
 pds workspace show
@@ -385,6 +423,10 @@ python -m paper_data_suite backup verify <backup>
 python -m paper_data_suite backup restore <backup> --destination <path> [--yes]
 python -m paper_data_suite modules
 python -m paper_data_suite launch <component-id>
+python -m paper_data_suite settings
+python -m paper_data_suite settings show
+python -m paper_data_suite settings clear-recent
+python -m paper_data_suite settings reset
 python -m paper_data_suite setup
 python -m paper_data_suite workspace setup
 python -m paper_data_suite workspace show
@@ -393,9 +435,12 @@ python -m paper_data_suite workspace set <path>
 python -m paper_data_suite workspace reset
 ```
 
-The help/version commands, `doctor`, `modules`, `workspace show`, and `backup`
-help do not create or select a workspace or perform classroom-data mutation.
-`doctor --workspace` is an invocation-scoped inspection override only.
+The help/version commands, `doctor`, `modules`, `workspace show`, `settings show`,
+and `backup` help do not create or select a workspace or perform classroom-data
+mutation. First-run settings import/help/show also do not create a settings file.
+`settings clear-recent` and `settings reset` mutate only the suite-owned per-user
+preference document; they never change Core workspace selection or module-owned
+context. `doctor --workspace` is an invocation-scoped inspection override only.
 `workspace validate` validates an existing candidate without initializing or
 saving it; `workspace setup`, `set`, and `reset` are the explicit workspace
 mutation surfaces. `pds setup` is the explicit shared-classroom mutation surface
@@ -456,12 +501,19 @@ by the manifest in one artifact directory and run:
 python .\scripts\smoke_test_application_wheels.py `
   <suite-wheel> `
   --artifact-dir <directory-containing-declared-wheels>
+
+python .\scripts\smoke_test_settings_wheels.py `
+  <suite-wheel> `
+  --artifact-dir <directory-containing-declared-wheels>
 ```
 
 The full-composition smoke authenticates the declared PDS component wheels before
 installation, resolves ordinary third-party Python dependencies through pip,
 verifies that every qualified application is `available`, and launches then quits
 each current teacher-facing menu through the installed `pds` console boundary.
+The settings smoke uses another isolated profile to prove no-write first-run
+read-only behavior, real installed-launch MRU updates, privacy-minimized serialized
+state, and unchanged Core workspace selection and bytes after clear/reset.
 
 To authenticate all exact component wheels declared by the manifest:
 
@@ -493,6 +545,9 @@ Do not place a real classroom PDS workspace inside this repository.
 - [`docs/operations/application-discovery-launching.md`](docs/operations/application-discovery-launching.md)
   — suite-qualified application inventory, safe launcher resolution, and process
   boundary.
+- [`docs/operations/suite-settings.md`](docs/operations/suite-settings.md)
+  — privacy-minimized per-user shell settings, recent component MRU, and Core/module
+  ownership boundaries.
 - [`docs/operations/workspace-setup.md`](docs/operations/workspace-setup.md)
   — Core-backed workspace selection, validation, guided setup, and reset.
 - [`docs/operations/shared-classroom-setup.md`](docs/operations/shared-classroom-setup.md)

--- a/docs/architecture/suite-shell-boundaries.md
+++ b/docs/architecture/suite-shell-boundaries.md
@@ -772,6 +772,13 @@ Suite settings MUST NOT store:
 
 Workspace selection remains Core-authoritative.
 
+Issue #12 implements this permission as a separate per-user suite preference file
+whose v1 schema is limited to record/version identity plus a bounded recent
+application MRU. The concrete storage, privacy, reset, and failure contract is
+[`../operations/suite-settings.md`](../operations/suite-settings.md). That
+implementation does not amend Core workspace authority or any module ownership in
+this document.
+
 ## 17. Privacy and diagnostics boundary
 
 The shell operates over workspaces that may contain sensitive educational

--- a/docs/operations/application-discovery-launching.md
+++ b/docs/operations/application-discovery-launching.md
@@ -140,6 +140,17 @@ The child process:
   to prevent source-checkout shadowing;
 - retains legitimate environment context such as `PDS_WORKSPACE_ROOT`.
 
+After the verified child process has actually started, `pds launch` may persist
+only that top-level suite component ID in the suite-owned bounded recent-component
+MRU. It does not persist module workflow context, student/class/assignment state,
+or a workspace selection. A child that cannot be started is not recorded; a child
+that starts and later exits nonzero is still a real recent application interaction.
+Settings persistence failure is reported as a bounded warning and does not replace
+the child application's exit outcome.
+
+The storage and privacy contract for that convenience state is documented in
+[`suite-settings.md`](suite-settings.md).
+
 The suite does not add application-specific arguments in this issue. Advanced or
 module-specific command-line operations remain available through each component's
 own direct CLI.
@@ -255,5 +266,7 @@ installed-console `pds modules` output to report every qualified application as
 It prepends foreign same-named commands to `PATH`, invokes the installed `pds`
 launcher directly, feeds the normal `Q` quit action to every current supported
 application menu, requires each launch to return success, and verifies that the
-foreign commands and synthetic workspace are untouched. On Windows the launcher
-under test is the environment's installed `pds.exe`.
+foreign commands and synthetic workspace are untouched. The smoke isolates the
+user-profile/configuration roots as well as the workspace so launch recency writes
+cannot modify a developer's real suite settings. On Windows the launcher under
+test is the environment's installed `pds.exe`.

--- a/docs/operations/suite-settings.md
+++ b/docs/operations/suite-settings.md
@@ -1,0 +1,321 @@
+# Suite settings and recent safe context
+
+Paper Data Suite stores a deliberately small amount of suite-owned convenience
+state so the `pds` shell can remember recent top-level applications across
+invocations. This file is optional user configuration. It is not a second
+workspace, classroom, student, assessment, grading, portfolio, grouping, or
+support-data store.
+
+The ownership boundary is:
+
+```text
+Core
+  authoritative shared workspace and shared state
+
+modules
+  authoritative domain and workflow state
+
+suite settings
+  disposable non-sensitive shell convenience only
+```
+
+Deleting or resetting suite settings may remove convenience, but it must never
+remove or change canonical PDS records.
+
+## Commands
+
+Inspect the bounded shell settings:
+
+```powershell
+pds settings show
+```
+
+Clear only recent top-level application context:
+
+```powershell
+pds settings clear-recent
+```
+
+Replace only the suite settings document with schema-v1 defaults:
+
+```powershell
+pds settings reset
+```
+
+Equivalent module-form commands are available through
+`python -m paper_data_suite`.
+
+`settings show` is read-only. A first-run invocation with no settings file uses
+in-memory defaults and does not create the settings directory or file.
+
+`settings clear-recent` and `settings reset` never call Core's workspace reset
+service. They do not initialize, select, clear, validate, restore, or otherwise
+mutate a workspace. They also do not change module-owned workflow context.
+
+## Storage location
+
+The settings file is outside canonical PDS workspaces and does not depend on the
+current working directory.
+
+The v1 path is:
+
+| Platform | Path |
+| --- | --- |
+| Windows | `%LOCALAPPDATA%\Paper Data Suite\settings.json` |
+| macOS | `~/Library/Application Support/Paper Data Suite/settings.json` |
+| Linux and other XDG-style systems | `${XDG_CONFIG_HOME:-~/.config}/paper-data-suite/settings.json` |
+
+On Windows, if `LOCALAPPDATA` is unavailable, the fallback is
+`~/AppData/Local/Paper Data Suite/settings.json`. On XDG-style systems, a
+relative `XDG_CONFIG_HOME` is not accepted as a configuration root; the shell
+falls back to `~/.config`.
+
+Tests and installed-wheel acceptance isolate these roots so development does not
+read or modify a real user's settings.
+
+## Schema v1
+
+The complete schema-v1 document is intentionally limited to three fields:
+
+```json
+{
+  "record_type": "paper_data_suite_settings",
+  "schema_version": "1",
+  "recent_components": [
+    "quillan",
+    "scoreform"
+  ]
+}
+```
+
+There are no schema-v1 workspace, class, assignment, student, score, review,
+grouping, grade, portfolio, behavior/support, scan, evidence, publication,
+credential, telemetry, or arbitrary plugin fields.
+
+### Persisted fields
+
+| Field | Owner | Purpose | Allowed values | Privacy classification | Default | Stale-value behavior |
+| --- | --- | --- | --- | --- | --- | --- |
+| `record_type` | Suite | Identify this document family | Exact value `paper_data_suite_settings` | Non-sensitive metadata | `paper_data_suite_settings` | Any other value is rejected |
+| `schema_version` | Suite | Select the settings contract | Exact value `1` | Non-sensitive metadata | `1` | Unknown/newer versions fail closed and are not rewritten automatically |
+| `recent_components` | Suite | Bounded MRU of top-level suite applications explicitly launched by the teacher | Zero to five exact `component_id` values from the active suite compatibility declaration that are `launchable_application` components | Non-sensitive navigation metadata | Empty list | Stored identity remains only a hint; `settings show` re-resolves current installed/compatibility status before presenting it |
+
+The list is most-recent-first, contains no duplicates, and has a maximum length
+of five. Re-launching an existing component moves it to the front. No timestamp
+is stored, so the shell does not build a behavioral history beyond ordering.
+
+The settings parser is strict. It rejects malformed JSON, duplicate JSON object
+keys, missing or unknown fields, unsupported schema versions, invalid component
+IDs, duplicate recent entries, and lists beyond the v1 limit. A settings document
+does not become a generic JSON extension point merely because a future field
+might be useful.
+
+## Component identity and current availability
+
+Settings store stable suite component IDs such as `quillan` and `scoreform`.
+They do not store display names, console command strings, Python import paths,
+URLs, executable paths, or shell fragments.
+
+A stored recent component is never launch authority. When recent context is
+presented, the shell resolves it against the current suite application inventory.
+The current compatibility manifest and installed component state still decide
+whether an application is available, not installed, incompatible, or otherwise
+unavailable. Recent context cannot bypass those checks or execute an arbitrary
+command.
+
+Schema validation is against component identities qualified as launchable by the
+active suite release declaration, not against whether the component happens to be
+installed at that moment. This permits a legitimately recorded component to
+remain readable after it is uninstalled. A component identity no longer admitted
+by a future suite settings contract is rejected rather than silently trusted.
+
+## Launch update boundary
+
+The existing `pds launch <component-id>` workflow is the only v1 source of recent
+component updates.
+
+The ordering is:
+
+```text
+resolve exact manifest component
+-> verify it is suite-launchable
+-> build and resolve current application inventory
+-> verify current launch availability
+-> start the verified foreground application process
+-> record that top-level component as recent
+```
+
+A component is not recorded because it appeared in `pds modules`, was inspected
+by `doctor`, participated in backup/restore, or failed availability or launcher
+checks.
+
+The suite records recency only after the verified child application has actually
+started. A process that starts and later exits with a nonzero status is still a
+real top-level application interaction and is therefore recent. A process that
+cannot be started is not recorded.
+
+Settings are optional convenience state. If the application starts but the recent
+setting cannot be saved, the shell reports a bounded warning while preserving the
+application's own exit outcome. A settings failure must not make module-domain data
+look corrupt or make settings persistence a prerequisite for application use.
+
+## Workspace authority
+
+The settings document contains no field equivalent to:
+
+```text
+selected_workspace
+active_workspace
+workspace_root
+current_workspace
+default_workspace
+```
+
+Core remains the sole authority for workspace normalization, resolution,
+initialization, validation, persisted selection, and reset. `pds settings show`
+states that boundary but does not independently resolve or cache a workspace path.
+
+In particular:
+
+```text
+pds settings reset
+    -> suite preference file only
+
+pds workspace reset
+    -> Core-owned saved workspace selection
+```
+
+These commands are independent and are tested as separate dispatch paths.
+
+## Privacy boundary
+
+The settings model has no public surface for retaining classroom or learner-domain
+objects. It must not contain or derive:
+
+```text
+student names or IDs
+rosters or class-level workflow context
+assignments or student responses
+answers, scores, Grades, proficiency, or rubric ratings
+student writing, teacher feedback, or teacher notes
+raw scans, evidence, QR/PDS2 payloads, or route records
+Concord Activity/Session/GroupPlan/Group/GroupMembership state
+grouping signals or planning bands
+Meridian evidence decisions or Grade state
+Vitrine Candidate/Selection/Portfolio state
+Portia behavior/support observations or narratives
+publication contents
+credentials, tokens, passwords, or environment dumps
+```
+
+Settings code does not inspect module storage or filesystem modification times to
+infer what the teacher was working on. The suite may remember that Quillan was a
+recently launched component; Quillan itself owns any class, assignment, submission,
+student, review, or feedback context within Quillan. The same rule applies to every
+other module.
+
+The settings file is ordinary local configuration and is not encrypted. PDS does
+not synchronize, upload, analyze, or send telemetry from it. If an operating system
+or user-controlled storage product synchronizes the configuration directory, that
+is external storage behavior, not a PDS synchronization feature.
+
+## Missing, malformed, and unsupported settings
+
+A missing file is normal first-run state:
+
+```text
+load
+-> schema-v1 defaults in memory
+-> no file or directory creation
+```
+
+Malformed JSON, an invalid v1 document, or an unsupported future schema produces a
+bounded settings error. The shell does not silently discard or rewrite that file.
+The recovery command is:
+
+```powershell
+pds settings reset
+```
+
+Reset stages and atomically publishes a fresh default settings document. It does
+not require reinstalling Core, recreating a workspace, restoring a backup, or
+repairing module records.
+
+## Persistence and filesystem safety
+
+Writes serialize and validate the complete document before touching the canonical
+file. Persistence then uses a temporary file in the same settings directory,
+flushes and `fsync`s the complete UTF-8 bytes, and atomically replaces the
+canonical file with `os.replace` where supported by the platform. JSON formatting
+is deterministic and ends with one newline.
+
+Handled serialization or staging/replacement failures do not intentionally
+truncate a previously valid canonical document. Temporary artifacts are cleaned up
+where safe. On POSIX systems, newly staged settings files are restricted to mode
+`0600` before publication.
+
+The v1 store intentionally uses a simple last-complete-write model; it does not
+claim multi-process transactional merging or locking. Canonical domain integrity
+never depends on this preference file.
+
+The implementation refuses a settings target that is a directory or direct
+symbolic link and refuses a direct symbolic-link settings directory. Temporary
+files are constrained to the selected settings directory. This is a practical
+per-user configuration defense, not a second backup-grade filesystem subsystem.
+
+## Backup and restore
+
+Whole-workspace backup and restore operate on the Core-selected canonical workspace.
+Suite settings live outside that workspace and are therefore not included in the
+workspace backup format.
+
+`pds backup restore` does not update suite recent context and never selects the
+restored workspace. A later explicit `pds workspace set <restored-location>` still
+uses Core as the only workspace-selection authority, and that selection is not
+mirrored into suite settings.
+
+## Import and read-only behavior
+
+Importing `paper_data_suite` or `paper_data_suite.settings` does not resolve a
+workspace, discover sibling modules, create the settings directory, create the
+settings file, or perform network or classroom-data access.
+
+Reading settings is an explicit operation. Current installed-application probing is
+performed only when a CLI presentation such as `pds settings show` needs to label
+stored component IDs with current availability.
+
+## Future boundaries and sequencing
+
+This v1 facility is only the privacy-minimized persistence foundation for top-level
+suite navigation. It does not implement the later v0.2.0 recent-work/continue-task
+workflow in issue #24. That later work must separately define owner-provided work
+references, stale-reference handling, privacy limits, and safe actions rather than
+expanding this file into a cross-module learner or task database.
+
+Issue #12 also does not adopt unreleased Core APIs or change the exact Core row in
+the active suite compatibility manifest. After #12 and the authenticated Core
+v0.6.2 release work are both complete, issue #38 owns qualification of Core v0.6.2
+and adoption of the current shared-service contracts. Combined installed-suite
+acceptance follows that qualification step.
+
+## Validation
+
+Focused tests cover strict schema validation, missing/read-only state, MRU behavior,
+privacy exclusions, atomic replacement, filesystem redirects, import isolation,
+Core/module noninterference, CLI management, current-inventory revalidation, and
+application-launch recency semantics.
+
+The dedicated installed-wheel smoke is:
+
+```powershell
+python .\scripts\smoke_test_settings_wheels.py `
+  <suite-wheel> `
+  --artifact-dir <directory-containing-declared-wheels>
+```
+
+It installs the suite and exact currently qualified PDS composition outside the
+source checkout, isolates the per-user configuration roots, proves import/help/
+first-run show do not create settings, records recent components through real
+installed `pds launch` boundaries, verifies deterministic MRU ordering, and proves
+`clear-recent` and `reset` leave Core workspace selection and canonical workspace
+bytes unchanged.

--- a/paper_data_suite/cli.py
+++ b/paper_data_suite/cli.py
@@ -28,6 +28,12 @@ from paper_data_suite.compatibility import (
     load_release_compatibility_manifest,
 )
 from paper_data_suite.doctor import collect_doctor_diagnostics, render_doctor_report
+from paper_data_suite.settings import SuiteSettingsError, record_recent_component
+from paper_data_suite.settings_cli import (
+    run_settings_clear_recent,
+    run_settings_reset,
+    run_settings_show,
+)
 from paper_data_suite.workspace_backup_cli import (
     run_workspace_backup_create,
     run_workspace_backup_restore,
@@ -117,6 +123,41 @@ def build_parser() -> argparse.ArgumentParser:
     workspace_subparsers.add_parser(
         "reset",
         help="clear only Core's saved workspace preference",
+    )
+    settings = subparsers.add_parser(
+        "settings",
+        help="inspect, clear, or reset suite-owned shell convenience settings",
+        description=(
+            "Inspect or manage privacy-minimized per-user Paper Data Suite shell "
+            "settings. These settings never own Core workspace selection or "
+            "module workflow state."
+        ),
+    )
+    settings.set_defaults(settings_parser=settings)
+    settings_subparsers = settings.add_subparsers(dest="settings_command")
+    settings_subparsers.add_parser(
+        "show",
+        help="show bounded suite settings and current component availability",
+        description=(
+            "Show suite-owned convenience settings without dumping raw JSON or "
+            "treating settings as a workspace authority."
+        ),
+    )
+    settings_subparsers.add_parser(
+        "clear-recent",
+        help="clear only recent top-level suite component context",
+        description=(
+            "Clear only the bounded recent-component list. Core workspace "
+            "selection and module-owned context are not changed."
+        ),
+    )
+    settings_subparsers.add_parser(
+        "reset",
+        help="replace only suite shell settings with safe defaults",
+        description=(
+            "Atomically replace the suite preference document with schema-v1 "
+            "defaults without changing Core workspace selection or module state."
+        ),
     )
     backup = subparsers.add_parser(
         "backup",
@@ -354,6 +395,16 @@ def _run_launch(component_id: str) -> int:
         print(f"Launch failed: {error}", file=sys.stderr)
         return 1
 
+    try:
+        record_recent_component(result.component_id)
+    except SuiteSettingsError as error:
+        message = str(error)[:300] or error.__class__.__name__
+        print(
+            "Warning: application started, but recent component context was not saved.",
+            file=sys.stderr,
+        )
+        print(f"Settings detail: {message}", file=sys.stderr)
+
     if not result.succeeded:
         print(
             f"{result.display_name} exited with status {result.exit_code}.",
@@ -391,6 +442,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             return run_workspace_reset()
         raise AssertionError(
             f"unhandled workspace command: {arguments.workspace_command}"
+        )
+    if arguments.command == "settings":
+        if arguments.settings_command is None:
+            arguments.settings_parser.print_help()
+            return 0
+        if arguments.settings_command == "show":
+            return run_settings_show()
+        if arguments.settings_command == "clear-recent":
+            return run_settings_clear_recent()
+        if arguments.settings_command == "reset":
+            return run_settings_reset()
+        raise AssertionError(
+            f"unhandled settings command: {arguments.settings_command}"
         )
     if arguments.command == "backup":
         if arguments.backup_command is None:

--- a/paper_data_suite/settings.py
+++ b/paper_data_suite/settings.py
@@ -1,0 +1,495 @@
+"""Privacy-minimized suite-owned settings and recent component context."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+import tempfile
+from collections.abc import Collection, Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Final, cast
+
+from paper_data_suite.compatibility import (
+    CompatibilityManifestError,
+    load_release_compatibility_manifest,
+)
+
+_SETTINGS_RECORD_TYPE: Final = "paper_data_suite_settings"
+_SETTINGS_SCHEMA_VERSION: Final = "1"
+_SETTINGS_FILENAME: Final = "settings.json"
+_MAX_RECENT_COMPONENTS: Final = 5
+_MAX_SETTINGS_BYTES: Final = 16 * 1024
+_REQUIRED_FIELDS: Final = frozenset(
+    {"record_type", "schema_version", "recent_components"}
+)
+
+
+class SuiteSettingsError(RuntimeError):
+    """Base class for bounded suite-settings failures."""
+
+
+class SuiteSettingsSchemaError(SuiteSettingsError):
+    """Raised when persisted settings violate the strict v1 schema."""
+
+
+class SuiteSettingsPathError(SuiteSettingsError):
+    """Raised when the settings path is unsafe or unsupported."""
+
+
+class SuiteSettingsReadError(SuiteSettingsError):
+    """Raised when an existing settings document cannot be read safely."""
+
+
+class SuiteSettingsWriteError(SuiteSettingsError):
+    """Raised when settings cannot be persisted atomically."""
+
+
+@dataclass(frozen=True, slots=True)
+class SuiteSettings:
+    """Immutable schema-v1 shell preferences owned by the suite."""
+
+    record_type: str = _SETTINGS_RECORD_TYPE
+    schema_version: str = _SETTINGS_SCHEMA_VERSION
+    recent_components: tuple[str, ...] = ()
+
+
+def default_suite_settings() -> SuiteSettings:
+    """Return the disposable first-run/default suite settings state."""
+    return SuiteSettings()
+
+
+def suite_settings_path(
+    *,
+    platform: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    home: Path | None = None,
+) -> Path:
+    """Resolve one deterministic per-user settings path outside PDS workspaces."""
+    active_platform = (platform or sys.platform).lower()
+    environment = os.environ if environ is None else environ
+    user_home = Path.home() if home is None else home
+
+    if active_platform.startswith(("win32", "cygwin", "msys")):
+        configured = environment.get("LOCALAPPDATA", "").strip()
+        configured_path = Path(configured) if configured else None
+        root = (
+            configured_path
+            if configured_path is not None and configured_path.is_absolute()
+            else user_home / "AppData" / "Local"
+        )
+        return root / "Paper Data Suite" / _SETTINGS_FILENAME
+
+    if active_platform == "darwin":
+        return (
+            user_home
+            / "Library"
+            / "Application Support"
+            / "Paper Data Suite"
+            / _SETTINGS_FILENAME
+        )
+
+    configured = environment.get("XDG_CONFIG_HOME", "").strip()
+    configured_path = Path(configured) if configured else None
+    root = (
+        configured_path
+        if configured_path is not None and configured_path.is_absolute()
+        else user_home / ".config"
+    )
+    return root / "paper-data-suite" / _SETTINGS_FILENAME
+
+
+def _duplicate_rejecting_object(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SuiteSettingsSchemaError(f"duplicate JSON object key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _qualified_launchable_component_ids() -> frozenset[str]:
+    try:
+        manifest = load_release_compatibility_manifest()
+    except (CompatibilityManifestError, OSError) as error:
+        raise SuiteSettingsSchemaError(
+            "suite compatibility data is unavailable for component validation"
+        ) from error
+    return frozenset(
+        component.component_id
+        for component in manifest.components
+        if "launchable_application" in component.capabilities
+    )
+
+
+def _allowed_ids(
+    allowed_component_ids: Collection[str] | None,
+) -> frozenset[str]:
+    if allowed_component_ids is None:
+        return _qualified_launchable_component_ids()
+    return frozenset(allowed_component_ids)
+
+
+def _parse_recent_components(
+    value: object,
+    *,
+    allowed_component_ids: frozenset[str],
+) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise SuiteSettingsSchemaError("recent_components must be an array")
+    if len(value) > _MAX_RECENT_COMPONENTS:
+        raise SuiteSettingsSchemaError(
+            "recent_components cannot contain more than "
+            f"{_MAX_RECENT_COMPONENTS} entries"
+        )
+
+    result: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item:
+            raise SuiteSettingsSchemaError(
+                f"recent_components[{index}] must be a non-empty component ID"
+            )
+        if item not in allowed_component_ids:
+            raise SuiteSettingsSchemaError(
+                f"recent_components[{index}] is not a suite-qualified application ID"
+            )
+        if item in result:
+            raise SuiteSettingsSchemaError(
+                "recent_components cannot contain duplicates"
+            )
+        result.append(item)
+    return tuple(result)
+
+
+def parse_suite_settings(
+    text: str,
+    *,
+    allowed_component_ids: Collection[str] | None = None,
+) -> SuiteSettings:
+    """Parse one strict schema-v1 settings document into an immutable model."""
+    try:
+        raw = json.loads(text, object_pairs_hook=_duplicate_rejecting_object)
+    except SuiteSettingsSchemaError:
+        raise
+    except json.JSONDecodeError as error:
+        raise SuiteSettingsSchemaError(
+            f"invalid settings JSON: {error.msg}"
+        ) from error
+
+    if not isinstance(raw, dict):
+        raise SuiteSettingsSchemaError("settings document must be a JSON object")
+    data = cast(dict[str, object], raw)
+    keys = frozenset(data)
+    missing = sorted(_REQUIRED_FIELDS - keys)
+    unknown = sorted(keys - _REQUIRED_FIELDS)
+    if missing:
+        raise SuiteSettingsSchemaError(
+            f"settings document is missing fields: {', '.join(missing)}"
+        )
+    if unknown:
+        raise SuiteSettingsSchemaError(
+            f"settings document has unknown fields: {', '.join(unknown)}"
+        )
+
+    record_type = data["record_type"]
+    if record_type != _SETTINGS_RECORD_TYPE:
+        raise SuiteSettingsSchemaError(
+            f"record_type must be {_SETTINGS_RECORD_TYPE!r}"
+        )
+    schema_version = data["schema_version"]
+    if not isinstance(schema_version, str):
+        raise SuiteSettingsSchemaError("schema_version must be a string")
+    if schema_version != _SETTINGS_SCHEMA_VERSION:
+        raise SuiteSettingsSchemaError(
+            f"unsupported suite settings schema version: {schema_version!r}"
+        )
+
+    recent_components = _parse_recent_components(
+        data["recent_components"],
+        allowed_component_ids=_allowed_ids(allowed_component_ids),
+    )
+    return SuiteSettings(
+        record_type=_SETTINGS_RECORD_TYPE,
+        schema_version=_SETTINGS_SCHEMA_VERSION,
+        recent_components=recent_components,
+    )
+
+
+def _validated_model(
+    settings: SuiteSettings,
+    *,
+    allowed_component_ids: Collection[str] | None = None,
+) -> SuiteSettings:
+    if settings.record_type != _SETTINGS_RECORD_TYPE:
+        raise SuiteSettingsSchemaError(
+            f"record_type must be {_SETTINGS_RECORD_TYPE!r}"
+        )
+    if settings.schema_version != _SETTINGS_SCHEMA_VERSION:
+        raise SuiteSettingsSchemaError(
+            f"unsupported suite settings schema version: {settings.schema_version!r}"
+        )
+    if not isinstance(settings.recent_components, tuple):
+        raise SuiteSettingsSchemaError("recent_components must be an immutable tuple")
+    recent_components = _parse_recent_components(
+        list(settings.recent_components),
+        allowed_component_ids=_allowed_ids(allowed_component_ids),
+    )
+    return SuiteSettings(recent_components=recent_components)
+
+
+def serialize_suite_settings(
+    settings: SuiteSettings,
+    *,
+    allowed_component_ids: Collection[str] | None = None,
+) -> str:
+    """Serialize validated settings as deterministic UTF-8 JSON text."""
+    validated = _validated_model(
+        settings,
+        allowed_component_ids=allowed_component_ids,
+    )
+    payload = {
+        "record_type": validated.record_type,
+        "schema_version": validated.schema_version,
+        "recent_components": list(validated.recent_components),
+    }
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=False,
+    ) + "\n"
+
+
+def _is_redirect_entry(path: Path) -> bool:
+    """Return whether one existing entry is a link/reparse redirection."""
+    try:
+        observation = path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as error:
+        raise SuiteSettingsPathError(
+            "suite settings filesystem entry could not be inspected safely"
+        ) from error
+    attributes = int(getattr(observation, "st_file_attributes", 0))
+    return stat.S_ISLNK(observation.st_mode) or bool(
+        attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT
+    )
+
+
+def _checked_existing_settings_path(path: Path) -> None:
+    parent = path.parent
+    if _is_redirect_entry(parent):
+        raise SuiteSettingsPathError(
+            "suite settings directory cannot be a symbolic link or reparse point"
+        )
+    if parent.exists() and not parent.is_dir():
+        raise SuiteSettingsPathError("suite settings directory is not a safe directory")
+    if _is_redirect_entry(path):
+        raise SuiteSettingsPathError(
+            "suite settings file cannot be a symbolic link or reparse point"
+        )
+    if not path.exists():
+        return
+    if not path.is_file():
+        raise SuiteSettingsPathError("suite settings target must be an ordinary file")
+
+
+def load_suite_settings(
+    path: Path | None = None,
+    *,
+    allowed_component_ids: Collection[str] | None = None,
+) -> SuiteSettings:
+    """Load settings without creating files; missing is the normal default state."""
+    target = suite_settings_path() if path is None else Path(path)
+    _checked_existing_settings_path(target)
+    if not target.exists():
+        return default_suite_settings()
+
+    try:
+        size = target.stat().st_size
+    except OSError as error:
+        raise SuiteSettingsReadError(
+            "suite settings metadata could not be read"
+        ) from error
+    if size > _MAX_SETTINGS_BYTES:
+        raise SuiteSettingsReadError(
+            "suite settings document exceeds the supported size"
+        )
+
+    try:
+        text = target.read_text(encoding="utf-8")
+    except UnicodeDecodeError as error:
+        raise SuiteSettingsReadError("suite settings must be valid UTF-8") from error
+    except OSError as error:
+        raise SuiteSettingsReadError(
+            "suite settings document could not be read"
+        ) from error
+
+    try:
+        return parse_suite_settings(
+            text,
+            allowed_component_ids=allowed_component_ids,
+        )
+    except SuiteSettingsSchemaError as error:
+        raise SuiteSettingsReadError(str(error)) from error
+
+
+def _ensure_writable_settings_directory(path: Path) -> None:
+    parent = path.parent
+    if _is_redirect_entry(parent):
+        raise SuiteSettingsPathError(
+            "suite settings directory cannot be a symbolic link or reparse point"
+        )
+    if parent.exists():
+        if not parent.is_dir():
+            raise SuiteSettingsPathError(
+                "suite settings directory is not a safe directory"
+            )
+        return
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise SuiteSettingsWriteError(
+            "suite settings directory could not be created"
+        ) from error
+    if _is_redirect_entry(parent) or not parent.is_dir():
+        raise SuiteSettingsPathError("suite settings directory is not a safe directory")
+
+
+def save_suite_settings(
+    settings: SuiteSettings,
+    path: Path | None = None,
+    *,
+    allowed_component_ids: Collection[str] | None = None,
+) -> None:
+    """Persist one complete validated settings document with atomic replacement."""
+    target = suite_settings_path() if path is None else Path(path)
+    try:
+        text = serialize_suite_settings(
+            settings,
+            allowed_component_ids=allowed_component_ids,
+        )
+    except SuiteSettingsSchemaError:
+        raise
+
+    _ensure_writable_settings_directory(target)
+    _checked_existing_settings_path(target)
+
+    temporary_path: Path | None = None
+    descriptor: int | None = None
+    try:
+        descriptor, raw_temporary = tempfile.mkstemp(
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            dir=target.parent,
+        )
+        temporary_path = Path(raw_temporary)
+        if temporary_path.parent != target.parent:
+            raise SuiteSettingsPathError(
+                "suite settings temporary file escaped the settings directory"
+            )
+        if os.name != "nt":
+            temporary_path.chmod(0o600)
+        with os.fdopen(descriptor, "wb") as stream:
+            descriptor = None
+            stream.write(text.encode("utf-8"))
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, target)
+        temporary_path = None
+    except SuiteSettingsError:
+        raise
+    except OSError as error:
+        raise SuiteSettingsWriteError(
+            "suite settings could not be written atomically"
+        ) from error
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def record_recent_component(
+    component_id: str,
+    path: Path | None = None,
+    *,
+    allowed_component_ids: Collection[str] | None = None,
+) -> SuiteSettings:
+    """Move one qualified top-level application ID to the front of the MRU list."""
+    allowed = _allowed_ids(allowed_component_ids)
+    if component_id not in allowed:
+        raise SuiteSettingsSchemaError(
+            "recent component must be a suite-qualified launchable application ID"
+        )
+    current = load_suite_settings(path, allowed_component_ids=allowed)
+    recent = (component_id,) + tuple(
+        item for item in current.recent_components if item != component_id
+    )
+    updated = replace(current, recent_components=recent[:_MAX_RECENT_COMPONENTS])
+    save_suite_settings(updated, path, allowed_component_ids=allowed)
+    return updated
+
+
+def clear_recent_components(
+    path: Path | None = None,
+    *,
+    allowed_component_ids: Collection[str] | None = None,
+) -> SuiteSettings:
+    """Clear only suite-owned recent component convenience state."""
+    allowed = _allowed_ids(allowed_component_ids)
+    current = load_suite_settings(path, allowed_component_ids=allowed)
+    updated = replace(current, recent_components=())
+    save_suite_settings(updated, path, allowed_component_ids=allowed)
+    return updated
+
+
+def reset_suite_settings(
+    path: Path | None = None,
+    *,
+    allowed_component_ids: Collection[str] | None = None,
+) -> SuiteSettings:
+    """Atomically replace only suite settings with the schema-v1 defaults."""
+    settings = default_suite_settings()
+    save_suite_settings(
+        settings,
+        path,
+        allowed_component_ids=allowed_component_ids,
+    )
+    return settings
+
+
+MAX_RECENT_COMPONENTS: Final = _MAX_RECENT_COMPONENTS
+SETTINGS_RECORD_TYPE: Final = _SETTINGS_RECORD_TYPE
+SETTINGS_SCHEMA_VERSION: Final = _SETTINGS_SCHEMA_VERSION
+
+__all__ = (
+    "MAX_RECENT_COMPONENTS",
+    "SETTINGS_RECORD_TYPE",
+    "SETTINGS_SCHEMA_VERSION",
+    "SuiteSettings",
+    "SuiteSettingsError",
+    "SuiteSettingsPathError",
+    "SuiteSettingsReadError",
+    "SuiteSettingsSchemaError",
+    "SuiteSettingsWriteError",
+    "clear_recent_components",
+    "default_suite_settings",
+    "load_suite_settings",
+    "parse_suite_settings",
+    "record_recent_component",
+    "reset_suite_settings",
+    "save_suite_settings",
+    "serialize_suite_settings",
+    "suite_settings_path",
+)

--- a/paper_data_suite/settings_cli.py
+++ b/paper_data_suite/settings_cli.py
@@ -1,0 +1,144 @@
+"""Teacher-facing rendering and deterministic CLI actions for suite settings."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+
+from paper_data_suite.application_launching import resolve_application_launchers
+from paper_data_suite.applications import (
+    ApplicationInventory,
+    ApplicationInventoryError,
+    ApplicationLaunchStatus,
+    collect_application_inventory,
+)
+from paper_data_suite.compatibility import (
+    CompatibilityManifestError,
+    load_release_compatibility_manifest,
+)
+from paper_data_suite.settings import (
+    SuiteSettings,
+    SuiteSettingsError,
+    clear_recent_components,
+    load_suite_settings,
+    reset_suite_settings,
+)
+
+InventoryProvider = Callable[[], ApplicationInventory]
+
+_STATUS_LABELS = {
+    ApplicationLaunchStatus.AVAILABLE: "available",
+    ApplicationLaunchStatus.NOT_INSTALLED: "not installed",
+    ApplicationLaunchStatus.INCOMPATIBLE: "incompatible",
+    ApplicationLaunchStatus.UNAVAILABLE: "unavailable",
+}
+
+
+def current_application_inventory() -> ApplicationInventory:
+    """Revalidate launchable component status against the current suite inventory."""
+    manifest = load_release_compatibility_manifest()
+    inventory = collect_application_inventory(manifest)
+    return resolve_application_launchers(inventory)
+
+
+def render_suite_settings(
+    settings: SuiteSettings,
+    inventory: ApplicationInventory,
+) -> str:
+    """Render bounded safe settings without dumping raw JSON or workspace paths."""
+    lines = ["Paper Data Suite settings", "", "Recent components:"]
+    if not settings.recent_components:
+        lines.append("  None")
+    else:
+        for index, component_id in enumerate(settings.recent_components, start=1):
+            application = inventory.for_component(component_id)
+            if application is None:
+                lines.append(f"  {index}. {component_id} (not in current inventory)")
+                continue
+            status = _STATUS_LABELS[application.status]
+            lines.append(f"  {index}. {application.display_name} ({status})")
+    lines.extend(
+        (
+            "",
+            "Canonical workspace:",
+            "  Managed by PDS Core; no workspace selection is stored here.",
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _settings_read_failure(error: SuiteSettingsError) -> None:
+    detail = str(error)[:300] or error.__class__.__name__
+    print("Paper Data Suite settings could not be read.", file=sys.stderr)
+    print(f"Detail: {detail}", file=sys.stderr)
+    print(
+        "Run `pds settings reset` to replace only the shell preference file.",
+        file=sys.stderr,
+    )
+
+
+def _settings_write_failure(error: SuiteSettingsError) -> None:
+    detail = str(error)[:300] or error.__class__.__name__
+    print("Paper Data Suite settings could not be updated.", file=sys.stderr)
+    print(f"Detail: {detail}", file=sys.stderr)
+    print("No Core workspace or module state was changed.", file=sys.stderr)
+
+
+def run_settings_show(
+    *,
+    inventory_provider: InventoryProvider = current_application_inventory,
+) -> int:
+    """Show bounded suite convenience state and current component availability."""
+    try:
+        settings = load_suite_settings()
+    except SuiteSettingsError as error:
+        _settings_read_failure(error)
+        return 1
+
+    try:
+        inventory = inventory_provider()
+    except (ApplicationInventoryError, CompatibilityManifestError, OSError) as error:
+        message = str(error)[:300] or error.__class__.__name__
+        print(
+            "Paper Data Suite settings loaded, but current application status "
+            f"could not be resolved: {message}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(render_suite_settings(settings, inventory), end="")
+    return 0
+
+
+def run_settings_clear_recent() -> int:
+    """Clear only the suite-owned bounded recent-component list."""
+    try:
+        clear_recent_components()
+    except SuiteSettingsError as error:
+        _settings_write_failure(error)
+        return 1
+    print("Cleared Paper Data Suite recent component context.")
+    print("Core workspace selection and module-owned context were not changed.")
+    return 0
+
+
+def run_settings_reset() -> int:
+    """Replace only suite-owned settings with disposable schema-v1 defaults."""
+    try:
+        reset_suite_settings()
+    except SuiteSettingsError as error:
+        _settings_write_failure(error)
+        return 1
+    print("Reset Paper Data Suite shell settings to defaults.")
+    print("Core workspace selection and module-owned state were not changed.")
+    return 0
+
+
+__all__ = (
+    "InventoryProvider",
+    "current_application_inventory",
+    "render_suite_settings",
+    "run_settings_clear_recent",
+    "run_settings_reset",
+    "run_settings_show",
+)

--- a/scripts/check_package.py
+++ b/scripts/check_package.py
@@ -36,6 +36,8 @@ REQUIRED_PACKAGE_FILES = frozenset(
         "paper_data_suite/compatibility.py",
         "paper_data_suite/component_inspection.py",
         "paper_data_suite/environment_inspection.py",
+        "paper_data_suite/settings.py",
+        "paper_data_suite/settings_cli.py",
         "paper_data_suite/workspace_setup.py",
         "paper_data_suite/workspace_cli.py",
         "paper_data_suite/data/__init__.py",

--- a/scripts/smoke_test_application_wheels.py
+++ b/scripts/smoke_test_application_wheels.py
@@ -290,9 +290,11 @@ def smoke_test(suite_wheel: Path, artifact_dir: Path) -> None:
         environment = temp_root / "venv"
         run_directory = temp_root / "run"
         foreign_bin = temp_root / "foreign-bin"
+        user_home = temp_root / "user"
         missing_workspace = temp_root / "synthetic-missing-workspace"
         run_directory.mkdir()
         foreign_bin.mkdir()
+        user_home.mkdir()
 
         venv.EnvBuilder(with_pip=True).create(environment)
         python = _venv_python(environment)
@@ -326,6 +328,11 @@ def smoke_test(suite_wheel: Path, artifact_dir: Path) -> None:
         )
 
         command_env = dict(install_env)
+        command_env["HOME"] = str(user_home)
+        command_env["USERPROFILE"] = str(user_home)
+        command_env["LOCALAPPDATA"] = str(user_home / "AppData" / "Local")
+        command_env["APPDATA"] = str(user_home / "AppData" / "Roaming")
+        command_env["XDG_CONFIG_HOME"] = str(user_home / ".config")
         command_env["PDS_WORKSPACE_ROOT"] = str(missing_workspace)
 
         foreign_markers: dict[str, Path] = {}

--- a/scripts/smoke_test_settings_wheels.py
+++ b/scripts/smoke_test_settings_wheels.py
@@ -1,0 +1,570 @@
+"""Smoke-test installed suite settings against the exact qualified composition."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import venv
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from paper_data_suite.artifact_verification import (
+    ArtifactVerificationError,
+    verify_artifact_directory,
+)
+from paper_data_suite.compatibility import (
+    CompatibilityManifestError,
+    load_release_compatibility_manifest,
+)
+
+
+class SettingsWheelSmokeError(RuntimeError):
+    """Raised when installed suite-settings acceptance fails."""
+
+
+@dataclass(frozen=True, slots=True)
+class ApplicationExpectation:
+    """One exact launchable application from the active suite manifest."""
+
+    component_id: str
+    display_name: str
+    wheel: str
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    input_text: str | None = None,
+    timeout: float = 180.0,
+    expected_returncode: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            env=dict(env),
+            input=input_text,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise SettingsWheelSmokeError(
+            f"Command could not complete: {' '.join(command)}: {error}"
+        ) from error
+    if result.returncode != expected_returncode:
+        raise SettingsWheelSmokeError(
+            "Command returned an unexpected status "
+            f"({result.returncode}, expected {expected_returncode}): "
+            f"{' '.join(command)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _venv_python(environment: Path) -> Path:
+    if os.name == "nt":
+        return environment / "Scripts" / "python.exe"
+    return environment / "bin" / "python"
+
+
+def _scripts_directory(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> Path:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            "import sysconfig; print(sysconfig.get_path('scripts'))",
+        ],
+        cwd=cwd,
+        env=env,
+    )
+    return Path(result.stdout.strip())
+
+
+def _expectations() -> tuple[ApplicationExpectation, ...]:
+    manifest = load_release_compatibility_manifest()
+    applications = tuple(
+        ApplicationExpectation(
+            component_id=component.component_id,
+            display_name=component.display_name,
+            wheel=component.release.wheel,
+        )
+        for component in manifest.components
+        if "launchable_application" in component.capabilities
+    )
+    if len(applications) < 2:
+        raise SettingsWheelSmokeError(
+            "Settings acceptance requires at least two qualified applications."
+        )
+    return applications
+
+
+def _component_wheels(
+    artifact_dir: Path,
+    applications: Sequence[ApplicationExpectation],
+) -> tuple[Path, tuple[Path, ...]]:
+    manifest = load_release_compatibility_manifest()
+    core_rows = tuple(
+        component
+        for component in manifest.components
+        if component.component_id == "core"
+    )
+    if len(core_rows) != 1:
+        raise SettingsWheelSmokeError(
+            "Compatibility manifest must declare exactly one Core component."
+        )
+    core_wheel = artifact_dir / core_rows[0].release.wheel
+    application_wheels = tuple(
+        artifact_dir / application.wheel for application in applications
+    )
+    missing = tuple(
+        path for path in (core_wheel, *application_wheels) if not path.is_file()
+    )
+    if missing:
+        raise SettingsWheelSmokeError(
+            "Verified component artifact is missing: "
+            + ", ".join(str(path) for path in missing)
+        )
+    return core_wheel, application_wheels
+
+
+def _isolated_command_env(
+    base_env: Mapping[str, str],
+    *,
+    user_home: Path,
+) -> dict[str, str]:
+    env = dict(base_env)
+    for key in tuple(env):
+        if key.upper() in {"PYTHONPATH", "PDS_WORKSPACE_ROOT"}:
+            env.pop(key, None)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONNOUSERSITE"] = "1"
+    env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    env["HOME"] = str(user_home)
+    env["USERPROFILE"] = str(user_home)
+    env["LOCALAPPDATA"] = str(user_home / "AppData" / "Local")
+    env["APPDATA"] = str(user_home / "AppData" / "Roaming")
+    env["XDG_CONFIG_HOME"] = str(user_home / ".config")
+    return env
+
+
+def _assert_installed_suite_location(
+    python: Path,
+    *,
+    environment: Path,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> None:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            (
+                "from pathlib import Path; import paper_data_suite; "
+                "print(Path(paper_data_suite.__file__).resolve())"
+            ),
+        ],
+        cwd=cwd,
+        env=env,
+    )
+    installed = Path(result.stdout.strip()).resolve()
+    try:
+        installed.relative_to(environment.resolve())
+    except ValueError as error:
+        raise SettingsWheelSmokeError(
+            "Smoke test imported paper_data_suite outside the isolated environment: "
+            f"{installed}"
+        ) from error
+
+
+def _settings_path(
+    python: Path,
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+) -> Path:
+    result = _run(
+        [
+            str(python),
+            "-c",
+            (
+                "from paper_data_suite.settings import suite_settings_path; "
+                "print(suite_settings_path())"
+            ),
+        ],
+        cwd=cwd,
+        env=env,
+    )
+    return Path(result.stdout.strip())
+
+
+def _snapshot_tree(root: Path) -> tuple[tuple[str, int, str], ...]:
+    rows: list[tuple[str, int, str]] = []
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise SettingsWheelSmokeError(
+                f"Synthetic workspace unexpectedly contains a symlink: {path}"
+            )
+        if not path.is_file():
+            continue
+        data = path.read_bytes()
+        rows.append(
+            (
+                path.relative_to(root).as_posix(),
+                len(data),
+                hashlib.sha256(data).hexdigest(),
+            )
+        )
+    return tuple(rows)
+
+
+def _read_settings(path: Path) -> dict[str, object]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SettingsWheelSmokeError(
+            "Installed settings document could not be independently read."
+        ) from error
+    if not isinstance(raw, dict):
+        raise SettingsWheelSmokeError("Installed settings document is not an object.")
+    return cast(dict[str, object], raw)
+
+
+def _assert_safe_document(path: Path) -> dict[str, object]:
+    data = _read_settings(path)
+    if set(data) != {"record_type", "schema_version", "recent_components"}:
+        raise SettingsWheelSmokeError(
+            "Installed settings document contains unexpected fields."
+        )
+    if data.get("record_type") != "paper_data_suite_settings":
+        raise SettingsWheelSmokeError("Installed settings record_type is incorrect.")
+    if data.get("schema_version") != "1":
+        raise SettingsWheelSmokeError("Installed settings schema_version is incorrect.")
+    serialized = json.dumps(data, ensure_ascii=False).casefold()
+    forbidden = (
+        "student_id",
+        "answers",
+        "score",
+        "writing",
+        "feedback",
+        "teacher_note",
+        "raw_scan",
+        "grouping_band",
+        "portfolio_candidate",
+        "behavior_narrative",
+        "workspace_root",
+        "selected_workspace",
+        "active_workspace",
+    )
+    leaked = tuple(fragment for fragment in forbidden if fragment in serialized)
+    if leaked:
+        raise SettingsWheelSmokeError(
+            "Installed settings document contains prohibited state: "
+            + ", ".join(leaked)
+        )
+    return data
+
+
+def _assert_clean_directory(path: Path) -> None:
+    contents = tuple(path.iterdir())
+    if contents:
+        raise SettingsWheelSmokeError(
+            "Settings smoke created working-directory artifacts: "
+            + ", ".join(item.name for item in contents)
+        )
+
+
+def smoke_test_settings_wheels(suite_wheel: Path, artifact_dir: Path) -> None:
+    """Exercise settings through installed module and console entry points."""
+    suite_wheel = suite_wheel.resolve()
+    artifact_dir = artifact_dir.resolve()
+    if not suite_wheel.is_file():
+        raise SettingsWheelSmokeError(f"Suite wheel does not exist: {suite_wheel}")
+    if not artifact_dir.is_dir():
+        raise SettingsWheelSmokeError(
+            f"Artifact directory does not exist: {artifact_dir}"
+        )
+
+    try:
+        verify_artifact_directory(artifact_dir)
+        applications = _expectations()
+        core_wheel, application_wheels = _component_wheels(
+            artifact_dir,
+            applications,
+        )
+    except (
+        ArtifactVerificationError,
+        CompatibilityManifestError,
+        OSError,
+    ) as error:
+        raise SettingsWheelSmokeError(
+            f"Qualified component artifact verification failed: {error}"
+        ) from error
+
+    with tempfile.TemporaryDirectory(prefix="pds-settings-smoke-") as temporary:
+        temp_root = Path(temporary)
+        environment = temp_root / "venv"
+        run_directory = temp_root / "run"
+        user_home = temp_root / "user"
+        workspace = temp_root / "workspace"
+        missing_workspace = temp_root / "missing-workspace"
+        run_directory.mkdir()
+        user_home.mkdir()
+
+        venv.EnvBuilder(with_pip=True).create(environment)
+        python = _venv_python(environment)
+        install_env = dict(os.environ)
+        install_env["PYTHONDONTWRITEBYTECODE"] = "1"
+        install_env["PYTHONNOUSERSITE"] = "1"
+        install_env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+        install_env.pop("PYTHONPATH", None)
+        install_env.pop("PIP_NO_INDEX", None)
+
+        _run(
+            [
+                str(python),
+                "-m",
+                "pip",
+                "install",
+                "--no-input",
+                str(core_wheel),
+                str(suite_wheel),
+                *(str(path) for path in application_wheels),
+            ],
+            cwd=run_directory,
+            env=install_env,
+            timeout=300.0,
+        )
+        _run(
+            [str(python), "-m", "pip", "check"],
+            cwd=run_directory,
+            env=install_env,
+        )
+        _assert_clean_directory(run_directory)
+        install_env = _isolated_command_env(
+            install_env,
+            user_home=user_home,
+        )
+        _assert_installed_suite_location(
+            python,
+            environment=environment,
+            cwd=run_directory,
+            env=install_env,
+        )
+
+        scripts = _scripts_directory(
+            python,
+            cwd=run_directory,
+            env=install_env,
+        )
+        launcher = scripts / ("pds.exe" if os.name == "nt" else "pds")
+        if not launcher.is_file():
+            raise SettingsWheelSmokeError(
+                f"Installed pds launcher does not exist: {launcher}"
+            )
+
+        settings_path = _settings_path(
+            python,
+            cwd=run_directory,
+            env=install_env,
+        )
+        if settings_path.exists():
+            raise SettingsWheelSmokeError(
+                "Resolving the installed settings path created the settings file."
+            )
+
+        _run(
+            [str(python), "-c", "import paper_data_suite.settings"],
+            cwd=run_directory,
+            env=install_env,
+        )
+        _run(
+            [str(launcher), "settings", "--help"],
+            cwd=run_directory,
+            env=install_env,
+        )
+        first_show = _run(
+            [str(python), "-m", "paper_data_suite", "settings", "show"],
+            cwd=run_directory,
+            env=install_env,
+        )
+        if "Recent components:\n  None" not in first_show.stdout:
+            raise SettingsWheelSmokeError(
+                "First-run installed settings show did not report empty recency."
+            )
+        if settings_path.exists():
+            raise SettingsWheelSmokeError(
+                "Import/help/read-only first-run settings access created the file."
+            )
+
+        launch_env = dict(install_env)
+        launch_env["PDS_WORKSPACE_ROOT"] = str(missing_workspace)
+        first = applications[0]
+        second = applications[1]
+        _run(
+            [str(launcher), "launch", first.component_id],
+            cwd=run_directory,
+            env=launch_env,
+            input_text="q\n",
+            timeout=60.0,
+        )
+        first_data = _assert_safe_document(settings_path)
+        if first_data.get("recent_components") != [first.component_id]:
+            raise SettingsWheelSmokeError(
+                "First successful installed launch did not record exact component ID."
+            )
+
+        _run(
+            [str(launcher), "launch", second.component_id],
+            cwd=run_directory,
+            env=launch_env,
+            input_text="q\n",
+            timeout=60.0,
+        )
+        second_data = _assert_safe_document(settings_path)
+        if second_data.get("recent_components") != [
+            second.component_id,
+            first.component_id,
+        ]:
+            raise SettingsWheelSmokeError(
+                "Installed settings MRU ordering is not deterministic."
+            )
+
+        shown = _run(
+            [str(launcher), "settings", "show"],
+            cwd=run_directory,
+            env=install_env,
+        )
+        if (
+            first.display_name not in shown.stdout
+            or second.display_name not in shown.stdout
+        ):
+            raise SettingsWheelSmokeError(
+                "Installed settings show did not re-resolve recent applications."
+            )
+        if "Managed by PDS Core" not in shown.stdout:
+            raise SettingsWheelSmokeError(
+                "Installed settings show omitted the Core workspace authority boundary."
+            )
+
+        _run(
+            [str(launcher), "workspace", "set", str(workspace)],
+            cwd=run_directory,
+            env=install_env,
+        )
+        workspace_before = _snapshot_tree(workspace)
+        workspace_show_before = _run(
+            [str(launcher), "workspace", "show"],
+            cwd=run_directory,
+            env=install_env,
+        ).stdout
+
+        _run(
+            [str(launcher), "settings", "clear-recent"],
+            cwd=run_directory,
+            env=install_env,
+        )
+        cleared = _assert_safe_document(settings_path)
+        if cleared.get("recent_components") != []:
+            raise SettingsWheelSmokeError(
+                "Installed clear-recent did not clear only recent context."
+            )
+        if _snapshot_tree(workspace) != workspace_before:
+            raise SettingsWheelSmokeError(
+                "settings clear-recent modified canonical workspace bytes."
+            )
+        if (
+            _run(
+                [str(launcher), "workspace", "show"],
+                cwd=run_directory,
+                env=install_env,
+            ).stdout
+            != workspace_show_before
+        ):
+            raise SettingsWheelSmokeError(
+                "settings clear-recent changed Core workspace selection."
+            )
+
+        _run(
+            [str(python), "-m", "paper_data_suite", "settings", "reset"],
+            cwd=run_directory,
+            env=install_env,
+        )
+        reset = _assert_safe_document(settings_path)
+        if reset.get("recent_components") != []:
+            raise SettingsWheelSmokeError(
+                "Installed settings reset did not restore schema-v1 defaults."
+            )
+        if _snapshot_tree(workspace) != workspace_before:
+            raise SettingsWheelSmokeError(
+                "settings reset modified canonical workspace bytes."
+            )
+        if (
+            _run(
+                [str(launcher), "workspace", "show"],
+                cwd=run_directory,
+                env=install_env,
+            ).stdout
+            != workspace_show_before
+        ):
+            raise SettingsWheelSmokeError(
+                "settings reset changed Core workspace selection."
+            )
+
+        try:
+            settings_path.relative_to(workspace)
+        except ValueError:
+            pass
+        else:
+            raise SettingsWheelSmokeError(
+                "Suite settings were stored inside the canonical workspace."
+            )
+        _assert_clean_directory(run_directory)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the installed settings smoke-test parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Install the built suite wheel with the exact verified qualified "
+            "composition and exercise privacy-minimized suite settings."
+        )
+    )
+    parser.add_argument("suite_wheel", type=Path)
+    parser.add_argument(
+        "--artifact-dir",
+        required=True,
+        type=Path,
+        help="verified directory containing exact qualified Core/application wheels",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run installed suite-settings acceptance."""
+    arguments = build_parser().parse_args(argv)
+    try:
+        smoke_test_settings_wheels(arguments.suite_wheel, arguments.artifact_dir)
+    except SettingsWheelSmokeError as error:
+        print(f"Settings wheel smoke test failed: {error}", file=sys.stderr)
+        return 1
+    print("Settings wheel smoke test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_application_cli.py
+++ b/tests/test_application_cli.py
@@ -50,6 +50,13 @@ def _console_script_path() -> Path:
     return Path(sysconfig.get_path("scripts")) / script_name
 
 
+@pytest.fixture(autouse=True)
+def _isolate_suite_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    import paper_data_suite.cli as cli
+
+    monkeypatch.setattr(cli, "record_recent_component", lambda component_id: None)
+
+
 def test_render_application_inventory_is_teacher_facing_and_bounded() -> None:
     inventory = ApplicationInventory(
         (

--- a/tests/test_package_compatibility.py
+++ b/tests/test_package_compatibility.py
@@ -28,6 +28,8 @@ _PACKAGE_FILES = (
     "paper_data_suite/compatibility.py",
     "paper_data_suite/component_inspection.py",
     "paper_data_suite/environment_inspection.py",
+    "paper_data_suite/settings.py",
+    "paper_data_suite/settings_cli.py",
     "paper_data_suite/workspace_setup.py",
     "paper_data_suite/workspace_cli.py",
     "paper_data_suite/data/__init__.py",
@@ -203,6 +205,25 @@ def test_package_validator_requires_workspace_cli_runtime_module(
         wheel,
         omitted_package_file="paper_data_suite/workspace_cli.py",
     )
+
+    with pytest.raises(
+        PackageValidationError,
+        match="missing required package files",
+    ):
+        validate_wheel(wheel)
+
+@pytest.mark.parametrize(
+    "omitted_package_file",
+    [
+        "paper_data_suite/settings.py",
+        "paper_data_suite/settings_cli.py",
+    ],
+)
+def test_package_validator_requires_settings_runtime_modules(
+    tmp_path: Path, omitted_package_file: str
+) -> None:
+    wheel = tmp_path / "paper_data_suite-0.1.0.dev0-py3-none-any.whl"
+    _build_wheel(wheel, omitted_package_file=omitted_package_file)
 
     with pytest.raises(
         PackageValidationError,

--- a/tests/test_suite_settings_issue12.py
+++ b/tests/test_suite_settings_issue12.py
@@ -1,0 +1,851 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from paper_data_suite.application_launching import (
+    ApplicationLaunchExecutionError,
+    ApplicationLaunchResult,
+)
+from paper_data_suite.applications import (
+    ApplicationInventory,
+    ApplicationLaunchStatus,
+    ApplicationObservation,
+)
+from paper_data_suite.cli import main
+from paper_data_suite.settings import (
+    MAX_RECENT_COMPONENTS,
+    SuiteSettings,
+    SuiteSettingsPathError,
+    SuiteSettingsReadError,
+    SuiteSettingsSchemaError,
+    SuiteSettingsWriteError,
+    clear_recent_components,
+    default_suite_settings,
+    load_suite_settings,
+    parse_suite_settings,
+    record_recent_component,
+    reset_suite_settings,
+    save_suite_settings,
+    serialize_suite_settings,
+    suite_settings_path,
+)
+from paper_data_suite.settings_cli import render_suite_settings
+
+_ALLOWED = ("concord", "meridian", "quillan", "scoreform", "vitrine", "portia")
+
+
+def _settings_path(tmp_path: Path) -> Path:
+    return tmp_path / "config" / "settings.json"
+
+
+def _document(recent: tuple[str, ...] = ()) -> str:
+    return json.dumps(
+        {
+            "record_type": "paper_data_suite_settings",
+            "schema_version": "1",
+            "recent_components": list(recent),
+        }
+    )
+
+
+def _application(
+    component_id: str,
+    *,
+    status: ApplicationLaunchStatus = ApplicationLaunchStatus.AVAILABLE,
+) -> ApplicationObservation:
+    return ApplicationObservation(
+        component_id=component_id,
+        display_name=component_id.title(),
+        purpose=f"Teacher purpose for {component_id}.",
+        distribution=component_id,
+        qualified_version="1.0.0",
+        installed_version=(
+            "1.0.0"
+            if status is not ApplicationLaunchStatus.NOT_INSTALLED
+            else None
+        ),
+        console_script_name=component_id,
+        console_script_target=f"{component_id}.cli:main",
+        status=status,
+        reason="synthetic status",
+        launcher_path=(
+            Path(f"/synthetic/{component_id}")
+            if status is ApplicationLaunchStatus.AVAILABLE
+            else None
+        ),
+    )
+
+
+def test_valid_v1_settings_parse_to_immutable_model() -> None:
+    parsed = parse_suite_settings(
+        _document(("quillan", "scoreform")),
+        allowed_component_ids=_ALLOWED,
+    )
+
+    assert parsed == SuiteSettings(recent_components=("quillan", "scoreform"))
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        ("[]", "JSON object"),
+        (
+            json.dumps(
+                {
+                    "record_type": "wrong",
+                    "schema_version": "1",
+                    "recent_components": [],
+                }
+            ),
+            "record_type",
+        ),
+        (
+            json.dumps(
+                {
+                    "record_type": "paper_data_suite_settings",
+                    "schema_version": "2",
+                    "recent_components": [],
+                }
+            ),
+            "unsupported",
+        ),
+        (
+            json.dumps(
+                {
+                    "record_type": "paper_data_suite_settings",
+                    "schema_version": "1",
+                    "recent_components": [],
+                    "future": True,
+                }
+            ),
+            "unknown fields",
+        ),
+        (
+            json.dumps(
+                {
+                    "record_type": "paper_data_suite_settings",
+                    "schema_version": "1",
+                }
+            ),
+            "missing fields",
+        ),
+    ],
+)
+def test_schema_is_strict(payload: str, message: str) -> None:
+    with pytest.raises(SuiteSettingsSchemaError, match=message):
+        parse_suite_settings(payload, allowed_component_ids=_ALLOWED)
+
+
+def test_duplicate_json_keys_are_rejected() -> None:
+    text = (
+        '{"record_type":"paper_data_suite_settings",'
+        '"schema_version":"1","schema_version":"1","recent_components":[]}'
+    )
+    with pytest.raises(SuiteSettingsSchemaError, match="duplicate JSON object key"):
+        parse_suite_settings(text, allowed_component_ids=_ALLOWED)
+
+
+def test_unknown_component_id_is_rejected() -> None:
+    with pytest.raises(
+        SuiteSettingsSchemaError,
+        match="suite-qualified application ID",
+    ):
+        parse_suite_settings(
+            _document(("student-123",)),
+            allowed_component_ids=_ALLOWED,
+        )
+
+
+def test_duplicate_recent_components_are_rejected_on_parse() -> None:
+    with pytest.raises(SuiteSettingsSchemaError, match="duplicates"):
+        parse_suite_settings(
+            _document(("quillan", "quillan")),
+            allowed_component_ids=_ALLOWED,
+        )
+
+
+def test_recent_component_document_is_bounded() -> None:
+    recent = tuple(f"app{index}" for index in range(MAX_RECENT_COMPONENTS + 1))
+    with pytest.raises(SuiteSettingsSchemaError, match="cannot contain more than"):
+        parse_suite_settings(
+            _document(recent),
+            allowed_component_ids=recent,
+        )
+
+
+def test_serialization_is_deterministic_utf8_json_with_stable_newline() -> None:
+    settings = SuiteSettings(recent_components=("quillan", "scoreform"))
+    first = serialize_suite_settings(settings, allowed_component_ids=_ALLOWED)
+    second = serialize_suite_settings(settings, allowed_component_ids=_ALLOWED)
+
+    assert first == second
+    assert first.endswith("\n")
+    assert not first.endswith("\n\n")
+    assert first.encode("utf-8").decode("utf-8") == first
+    assert list(json.loads(first)) == [
+        "record_type",
+        "schema_version",
+        "recent_components",
+    ]
+
+
+def test_missing_settings_file_returns_defaults_without_creating_parent(
+    tmp_path: Path,
+) -> None:
+    path = _settings_path(tmp_path)
+
+    assert (
+        load_suite_settings(path, allowed_component_ids=_ALLOWED)
+        == default_suite_settings()
+    )
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+def test_platform_settings_locations_are_deterministic_and_workspace_independent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.chdir(tmp_path)
+
+    windows = suite_settings_path(
+        platform="win32",
+        environ={"LOCALAPPDATA": str(tmp_path / "local")},
+        home=home,
+    )
+    linux = suite_settings_path(
+        platform="linux",
+        environ={"XDG_CONFIG_HOME": str(tmp_path / "xdg")},
+        home=home,
+    )
+    macos = suite_settings_path(platform="darwin", environ={}, home=home)
+
+    assert windows == tmp_path / "local" / "Paper Data Suite" / "settings.json"
+    assert linux == tmp_path / "xdg" / "paper-data-suite" / "settings.json"
+    assert macos == (
+        home / "Library" / "Application Support" / "Paper Data Suite" / "settings.json"
+    )
+    assert "workspace" not in windows.parts
+    assert "workspace" not in linux.parts
+    assert "workspace" not in macos.parts
+
+
+def test_windows_relative_local_app_data_falls_back_to_home(tmp_path: Path) -> None:
+    path = suite_settings_path(
+        platform="win32",
+        environ={"LOCALAPPDATA": "relative-local"},
+        home=tmp_path / "home",
+    )
+    assert path == (
+        tmp_path
+        / "home"
+        / "AppData"
+        / "Local"
+        / "Paper Data Suite"
+        / "settings.json"
+    )
+
+
+def test_linux_relative_xdg_config_home_falls_back_to_home(tmp_path: Path) -> None:
+    path = suite_settings_path(
+        platform="linux",
+        environ={"XDG_CONFIG_HOME": "relative-config"},
+        home=tmp_path / "home",
+    )
+    assert path == tmp_path / "home" / ".config" / "paper-data-suite" / "settings.json"
+
+
+def test_record_recent_component_is_mru_deduplicated_and_bounded(
+    tmp_path: Path,
+) -> None:
+    path = _settings_path(tmp_path)
+    allowed = tuple(f"app{index}" for index in range(7))
+
+    for component_id in allowed[:6]:
+        record_recent_component(
+            component_id,
+            path,
+            allowed_component_ids=allowed,
+        )
+    updated = record_recent_component(
+        "app3",
+        path,
+        allowed_component_ids=allowed,
+    )
+
+    assert updated.recent_components == ("app3", "app5", "app4", "app2", "app1")
+    assert len(updated.recent_components) == MAX_RECENT_COMPONENTS
+    assert len(set(updated.recent_components)) == len(updated.recent_components)
+
+
+def test_clear_recent_only_clears_recent_context(tmp_path: Path) -> None:
+    path = _settings_path(tmp_path)
+    save_suite_settings(
+        SuiteSettings(recent_components=("quillan", "scoreform")),
+        path,
+        allowed_component_ids=_ALLOWED,
+    )
+
+    cleared = clear_recent_components(path, allowed_component_ids=_ALLOWED)
+
+    assert cleared == default_suite_settings()
+    assert (
+        load_suite_settings(path, allowed_component_ids=_ALLOWED)
+        == default_suite_settings()
+    )
+
+
+def test_reset_replaces_malformed_settings_without_reading_it(tmp_path: Path) -> None:
+    path = _settings_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("{broken", encoding="utf-8")
+
+    reset_suite_settings(path, allowed_component_ids=_ALLOWED)
+
+    assert (
+        load_suite_settings(path, allowed_component_ids=_ALLOWED)
+        == default_suite_settings()
+    )
+
+
+def test_malformed_settings_fail_with_bounded_read_error(tmp_path: Path) -> None:
+    path = _settings_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("{broken", encoding="utf-8")
+
+    with pytest.raises(SuiteSettingsReadError, match="invalid settings JSON"):
+        load_suite_settings(path, allowed_component_ids=_ALLOWED)
+
+
+def test_settings_target_directory_is_rejected(tmp_path: Path) -> None:
+    path = _settings_path(tmp_path)
+    path.mkdir(parents=True)
+
+    with pytest.raises(SuiteSettingsPathError, match="ordinary file"):
+        load_suite_settings(path, allowed_component_ids=_ALLOWED)
+
+
+def test_settings_target_symlink_is_rejected(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text(_document(), encoding="utf-8")
+    path = _settings_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    try:
+        path.symlink_to(target)
+    except (OSError, NotImplementedError) as error:
+        pytest.skip(f"symlink creation unavailable: {error}")
+
+    with pytest.raises(SuiteSettingsPathError, match="symbolic link"):
+        load_suite_settings(path, allowed_component_ids=_ALLOWED)
+
+
+def test_dangling_settings_symlink_is_rejected(tmp_path: Path) -> None:
+    path = _settings_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    try:
+        path.symlink_to(tmp_path / "missing.json")
+    except (OSError, NotImplementedError) as error:
+        pytest.skip(f"symlink creation unavailable: {error}")
+
+    with pytest.raises(SuiteSettingsPathError, match="symbolic link"):
+        load_suite_settings(path, allowed_component_ids=_ALLOWED)
+
+
+def test_settings_parent_symlink_is_rejected(tmp_path: Path) -> None:
+    real_parent = tmp_path / "real-config"
+    real_parent.mkdir()
+    linked_parent = tmp_path / "linked-config"
+    try:
+        linked_parent.symlink_to(real_parent, target_is_directory=True)
+    except (OSError, NotImplementedError) as error:
+        pytest.skip(f"symlink creation unavailable: {error}")
+
+    with pytest.raises(SuiteSettingsPathError, match="symbolic link"):
+        save_suite_settings(
+            default_suite_settings(),
+            linked_parent / "settings.json",
+            allowed_component_ids=_ALLOWED,
+        )
+
+
+def test_replacement_failure_preserves_previous_valid_document(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.settings as settings_module
+
+    path = _settings_path(tmp_path)
+    save_suite_settings(
+        SuiteSettings(recent_components=("quillan",)),
+        path,
+        allowed_component_ids=_ALLOWED,
+    )
+    before = path.read_bytes()
+
+    def fail_replace(source: object, destination: object) -> None:
+        del source, destination
+        raise OSError("synthetic replace failure")
+
+    monkeypatch.setattr(settings_module.os, "replace", fail_replace)
+    with pytest.raises(SuiteSettingsWriteError, match="atomically"):
+        save_suite_settings(
+            SuiteSettings(recent_components=("scoreform",)),
+            path,
+            allowed_component_ids=_ALLOWED,
+        )
+
+    assert path.read_bytes() == before
+    assert tuple(path.parent.glob(".settings.json.*.tmp")) == ()
+
+
+
+
+def test_temporary_creation_failure_preserves_previous_valid_document(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.settings as settings_module
+
+    path = _settings_path(tmp_path)
+    save_suite_settings(
+        SuiteSettings(recent_components=("quillan",)),
+        path,
+        allowed_component_ids=_ALLOWED,
+    )
+    before = path.read_bytes()
+
+    def fail_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:
+        del args, kwargs
+        raise OSError("synthetic temporary creation failure")
+
+    monkeypatch.setattr(settings_module.tempfile, "mkstemp", fail_mkstemp)
+    with pytest.raises(SuiteSettingsWriteError, match="atomically"):
+        save_suite_settings(
+            SuiteSettings(recent_components=("scoreform",)),
+            path,
+            allowed_component_ids=_ALLOWED,
+        )
+
+    assert path.read_bytes() == before
+
+def test_serialization_failure_preserves_previous_valid_document(
+    tmp_path: Path,
+) -> None:
+    path = _settings_path(tmp_path)
+    save_suite_settings(
+        SuiteSettings(recent_components=("quillan",)),
+        path,
+        allowed_component_ids=_ALLOWED,
+    )
+    before = path.read_bytes()
+
+    with pytest.raises(SuiteSettingsSchemaError):
+        save_suite_settings(
+            SuiteSettings(recent_components=("student-123",)),
+            path,
+            allowed_component_ids=_ALLOWED,
+        )
+
+    assert path.read_bytes() == before
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode semantics only")
+def test_successful_settings_write_uses_private_posix_file_mode(tmp_path: Path) -> None:
+    path = _settings_path(tmp_path)
+
+    save_suite_settings(
+        SuiteSettings(recent_components=("quillan",)),
+        path,
+        allowed_component_ids=_ALLOWED,
+    )
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_temporary_file_is_created_only_inside_settings_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.settings as settings_module
+
+    path = _settings_path(tmp_path)
+    observed: list[Path] = []
+    original = settings_module.tempfile.mkstemp
+
+    def observe_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:
+        directory = Path(str(kwargs["dir"]))
+        observed.append(directory)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(settings_module.tempfile, "mkstemp", observe_mkstemp)
+    save_suite_settings(
+        SuiteSettings(recent_components=("quillan",)),
+        path,
+        allowed_component_ids=_ALLOWED,
+    )
+
+    assert observed == [path.parent]
+
+
+def test_settings_model_has_no_surface_for_domain_or_student_state() -> None:
+    with pytest.raises(TypeError):
+        SuiteSettings(  # type: ignore[call-arg]
+            recent_components=("quillan",),
+            student_id="student-001",
+            score=99,
+            feedback="synthetic private feedback",
+        )
+
+    attempted = json.dumps(
+        {
+            "record_type": "paper_data_suite_settings",
+            "schema_version": "1",
+            "recent_components": ["quillan"],
+            "student_id": "student-001",
+            "answers": ["A"],
+            "score": 99,
+            "writing": "synthetic student writing",
+            "teacher_note": "synthetic note",
+            "raw_scan": "scan-001.png",
+            "grouping_band": 4,
+            "portfolio_candidate": "candidate-001",
+            "behavior_narrative": "synthetic behavior narrative",
+        }
+    )
+    with pytest.raises(SuiteSettingsSchemaError, match="unknown fields"):
+        parse_suite_settings(attempted, allowed_component_ids=_ALLOWED)
+
+
+def _workspace_snapshot(root: Path) -> tuple[tuple[str, bytes], ...]:
+    return tuple(
+        sorted(
+            (
+                path.relative_to(root).as_posix(),
+                path.read_bytes(),
+            )
+            for path in root.rglob("*")
+            if path.is_file()
+        )
+    )
+
+
+def test_settings_operations_do_not_touch_synthetic_domain_state(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    sentinels = {
+        "core/roster.json": b"synthetic roster",
+        "scoreform/work.json": b"synthetic answers",
+        "quillan/review.json": b"synthetic writing review",
+        "concord/group-plan.json": b"synthetic grouping",
+        "meridian/grades.json": b"synthetic grades",
+        "vitrine/portfolio.json": b"synthetic portfolio",
+        "portia/event.json": b"synthetic support event",
+    }
+    for relative, content in sentinels.items():
+        path = workspace / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+    before = _workspace_snapshot(workspace)
+    settings_path = tmp_path / "outside-workspace" / "settings.json"
+
+    record_recent_component(
+        "quillan",
+        settings_path,
+        allowed_component_ids=_ALLOWED,
+    )
+    clear_recent_components(settings_path, allowed_component_ids=_ALLOWED)
+    reset_suite_settings(settings_path, allowed_component_ids=_ALLOWED)
+
+    assert _workspace_snapshot(workspace) == before
+    assert settings_path.is_file()
+
+
+def test_importing_settings_does_not_create_user_configuration(tmp_path: Path) -> None:
+    user_home = tmp_path / "user"
+    local = user_home / "AppData" / "Local"
+    xdg = user_home / ".config"
+    env = dict(os.environ)
+    env.update(
+        {
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "HOME": str(user_home),
+            "USERPROFILE": str(user_home),
+            "LOCALAPPDATA": str(local),
+            "XDG_CONFIG_HOME": str(xdg),
+        }
+    )
+
+    code = """
+import sys
+import paper_data_suite
+import paper_data_suite.settings
+
+for name in ("scoreform", "quillan", "concord", "meridian", "vitrine", "portia"):
+    if name in sys.modules:
+        raise SystemExit(f"unexpected sibling import: {name}")
+""".strip()
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (local / "Paper Data Suite").exists()
+    assert not (xdg / "paper-data-suite").exists()
+
+
+def test_render_settings_revalidates_and_marks_current_availability() -> None:
+    settings = SuiteSettings(recent_components=("quillan", "scoreform", "concord"))
+    inventory = ApplicationInventory(
+        (
+            _application("quillan"),
+            _application("scoreform", status=ApplicationLaunchStatus.NOT_INSTALLED),
+        )
+    )
+
+    output = render_suite_settings(settings, inventory)
+
+    assert "1. Quillan (available)" in output
+    assert "2. Scoreform (not installed)" in output
+    assert "3. concord (not in current inventory)" in output
+    assert "Managed by PDS Core" in output
+    assert "workspace_root" not in output
+    assert "settings.json" not in output
+
+
+def test_settings_help_and_missing_subcommand_are_deterministic(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as raised:
+        main(("settings", "--help"))
+    assert raised.value.code == 0
+    output = capsys.readouterr().out
+    assert "usage: pds settings" in output
+    assert "clear-recent" in output
+    assert "reset" in output
+
+    assert main(("settings",)) == 0
+    assert "usage: pds settings" in capsys.readouterr().out
+
+
+def test_launch_records_recency_after_child_started_and_returned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.cli as cli
+
+    application = _application("quillan")
+    monkeypatch.setattr(
+        cli,
+        "_resolved_inventory",
+        lambda manifest: ApplicationInventory((application,)),
+    )
+    recorded: list[str] = []
+
+    def launch(value: ApplicationObservation) -> ApplicationLaunchResult:
+        assert value.launcher_path is not None
+        return ApplicationLaunchResult(
+            component_id=value.component_id,
+            display_name=value.display_name,
+            launcher_path=value.launcher_path,
+            exit_code=0,
+        )
+
+    monkeypatch.setattr(cli, "launch_application", launch)
+    monkeypatch.setattr(cli, "record_recent_component", recorded.append)
+
+    assert main(("launch", "quillan")) == 0
+    assert recorded == ["quillan"]
+
+
+def test_launch_nonzero_still_records_because_child_did_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.cli as cli
+
+    application = _application("quillan")
+    monkeypatch.setattr(
+        cli,
+        "_resolved_inventory",
+        lambda manifest: ApplicationInventory((application,)),
+    )
+    recorded: list[str] = []
+
+    def launch(value: ApplicationObservation) -> ApplicationLaunchResult:
+        assert value.launcher_path is not None
+        return ApplicationLaunchResult(
+            component_id=value.component_id,
+            display_name=value.display_name,
+            launcher_path=value.launcher_path,
+            exit_code=4,
+        )
+
+    monkeypatch.setattr(cli, "launch_application", launch)
+    monkeypatch.setattr(cli, "record_recent_component", recorded.append)
+
+    assert main(("launch", "quillan")) == 1
+    assert recorded == ["quillan"]
+
+
+def test_launch_start_failure_does_not_record_recency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.cli as cli
+
+    application = _application("quillan")
+    monkeypatch.setattr(
+        cli,
+        "_resolved_inventory",
+        lambda manifest: ApplicationInventory((application,)),
+    )
+    recorded: list[str] = []
+
+    def fail(value: ApplicationObservation) -> ApplicationLaunchResult:
+        del value
+        raise ApplicationLaunchExecutionError("synthetic start failure")
+
+    monkeypatch.setattr(cli, "launch_application", fail)
+    monkeypatch.setattr(cli, "record_recent_component", recorded.append)
+
+    assert main(("launch", "quillan")) == 1
+    assert recorded == []
+
+
+def test_unavailable_launch_does_not_record_recency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.cli as cli
+
+    application = _application(
+        "quillan",
+        status=ApplicationLaunchStatus.NOT_INSTALLED,
+    )
+    monkeypatch.setattr(
+        cli,
+        "_resolved_inventory",
+        lambda manifest: ApplicationInventory((application,)),
+    )
+    recorded: list[str] = []
+    monkeypatch.setattr(cli, "record_recent_component", recorded.append)
+
+    assert main(("launch", "quillan")) == 1
+    assert recorded == []
+
+
+def test_settings_failure_after_launch_is_warning_not_domain_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import paper_data_suite.cli as cli
+
+    application = _application("quillan")
+    monkeypatch.setattr(
+        cli,
+        "_resolved_inventory",
+        lambda manifest: ApplicationInventory((application,)),
+    )
+
+    def launch(value: ApplicationObservation) -> ApplicationLaunchResult:
+        assert value.launcher_path is not None
+        return ApplicationLaunchResult(
+            component_id=value.component_id,
+            display_name=value.display_name,
+            launcher_path=value.launcher_path,
+            exit_code=0,
+        )
+
+    def fail_settings(component_id: str) -> object:
+        del component_id
+        raise SuiteSettingsWriteError("synthetic settings failure")
+
+    monkeypatch.setattr(cli, "launch_application", launch)
+    monkeypatch.setattr(cli, "record_recent_component", fail_settings)
+
+    assert main(("launch", "quillan")) == 0
+    error = capsys.readouterr().err
+    assert "Warning:" in error
+    assert "recent component context was not saved" in error
+    assert "module data" not in error.casefold()
+
+
+def test_settings_reset_dispatch_is_distinct_from_workspace_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.cli as cli
+
+    observed: list[str] = []
+    monkeypatch.setattr(
+        cli,
+        "run_settings_reset",
+        lambda: observed.append("settings") or 0,
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_workspace_reset",
+        lambda: (_ for _ in ()).throw(AssertionError("workspace reset called")),
+    )
+
+    assert main(("settings", "reset")) == 0
+    assert observed == ["settings"]
+
+
+def test_settings_cli_read_failure_is_bounded_and_points_only_to_settings_reset(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import paper_data_suite.settings_cli as settings_cli
+
+    def fail_load() -> SuiteSettings:
+        raise SuiteSettingsReadError("synthetic malformed settings")
+
+    monkeypatch.setattr(settings_cli, "load_suite_settings", fail_load)
+
+    assert settings_cli.run_settings_show() == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "settings could not be read" in captured.err
+    assert "pds settings reset" in captured.err
+    assert "workspace reset" not in captured.err
+
+
+@pytest.mark.parametrize(
+    "subcommand,function_name",
+    [
+        ("show", "run_settings_show"),
+        ("clear-recent", "run_settings_clear_recent"),
+        ("reset", "run_settings_reset"),
+    ],
+)
+def test_settings_subcommands_dispatch_only_to_settings_handlers(
+    subcommand: str,
+    function_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import paper_data_suite.cli as cli
+
+    observed: list[str] = []
+    monkeypatch.setattr(
+        cli,
+        function_name,
+        lambda: observed.append(subcommand) or 0,
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_workspace_reset",
+        lambda: (_ for _ in ()).throw(AssertionError("workspace reset called")),
+    )
+
+    assert main(("settings", subcommand)) == 0
+    assert observed == [subcommand]


### PR DESCRIPTION
## Summary

Closes #12.

Implements a privacy-minimized, suite-owned settings facility for Paper Data Suite and adds bounded recent top-level application context without creating a second source of truth for Core or module-owned state.

The new settings layer is deliberately limited to harmless shell convenience state. Core remains the sole authority for workspace selection and canonical shared state, and module-domain context remains owned by the respective applications.

## What changed

- add versioned suite settings storage with a strict v1 schema;
- store settings outside the Core workspace in the platform-appropriate per-user configuration location;
- add bounded MRU recent-component context:
  - maximum 5 entries;
  - newest first;
  - deterministic deduplication;
  - no timestamps;
  - exact suite component IDs only;
- validate stored component identities against the active suite compatibility model;
- preserve manifest-known components even when currently uninstalled, while reporting current availability separately;
- reject malformed, unsupported, oversized, duplicated, or unexpected settings data;
- add atomic whole-document settings writes with same-directory temporary files;
- add practical symlink/reparse-point protections;
- use private POSIX file permissions where supported;
- ensure missing settings remain a normal first-run state and do not create files during reads/imports;
- add:
  - `pds settings show`
  - `pds settings clear-recent`
  - `pds settings reset`
- keep `pds settings reset` entirely separate from Core's `pds workspace reset`;
- record application recency only after the child application actually starts;
- count a successfully started application as recent even if it later exits nonzero;
- do not record failed-to-start or unavailable applications;
- treat settings-persistence failures after launch as bounded warnings without replacing application exit semantics;
- revalidate displayed recent components against the current application inventory;
- add focused settings, CLI, launch-boundary, privacy, persistence, and workspace-noninterference tests;
- add installed-wheel acceptance covering:
  - isolated user configuration;
  - first-run no-create behavior;
  - real installed application launch recency;
  - exact privacy-minimized schema;
  - clear/reset behavior;
  - Core workspace noninterference;
- update package validation so built wheels must contain the new settings runtime modules;
- isolate existing application-wheel smoke tests from the developer's real user settings;
- document the settings schema, platform paths, ownership boundaries, lifecycle, recovery behavior, and relationship to Core/module state.

## Architectural boundaries

This PR intentionally does **not**:

- store workspace selection in suite settings;
- duplicate Core workspace paths as authoritative state;
- store class, student, assignment, grading, grouping, portfolio, evidence, scan, publication, or other domain state;
- create recent student/class/work-item history;
- cache sibling-module records;
- add arbitrary commands, executable paths, or URLs to recent context;
- change the active suite compatibility manifest;
- qualify Core v0.6.2;
- perform the later combined suite qualification work owned by #38.

The active release compatibility manifest therefore remains on the currently qualified composition, including Core v0.6.0.

## Validation

Source validation:

```text
552 passed, 14 skipped
ruff: passed
mypy: passed
pip check: passed
compatibility manifest validation: passed
git diff --check: passed
```

Packaging and installed acceptance:

```text
python -m build: passed
twine check: passed
built-wheel package validation: passed
exact release-artifact authentication: passed
base installed-wheel smoke: passed
full application installed-wheel smoke: passed
settings installed-wheel smoke: passed
```

The skipped tests are expected platform/tooling cases such as unavailable Windows symlink privileges, POSIX-only permission semantics, and unavailable `pwsh`.